### PR TITLE
Handle partial transparency and masks when probing mouse

### DIFF
--- a/src/gui/gui_element_base.hpp
+++ b/src/gui/gui_element_base.hpp
@@ -72,6 +72,8 @@ protected:
 		return tooltip_behavior::transparent;
 	}
 	virtual void create_tooltip(sys::state& state, int32_t x, int32_t y, element_base& /*tooltip_window*/) noexcept { }
+private:
+	uint8_t get_pixel_opacity(sys::state& state, int32_t x, int32_t y, dcon::texture_id tid);
 public:
 
 	// these commands are meaningful only if the element has children


### PR DESCRIPTION
If transparencecheck=yes, mouse only counts as over the element if the primary texture's alpha is not 0 at that pixel. Otherwise, if the gfx object has a mask texture, mouse only counts as over the element if the mask alpha at that pixel is not 0.