### PR TITLE
Parser with hashed strings instead of comparison branches

### DIFF
--- a/ParserGenerator/parser_generator.cpp
+++ b/ParserGenerator/parser_generator.cpp
@@ -459,11 +459,13 @@ std::string construct_match_tree_outer(V const& vector, F const& generator_match
 		return tabulate(std::string(no_match) + "\n");
 	
 	// No duplicates
+#ifndef NDEBUG
 	for(auto const& e1 : vector)
 		assert(std::count_if(vector.begin(), vector.end(), [&](auto const& e2) {
 			return e1.key == e2.key;
 		}) == 1);
-	
+#endif
+
 	std::string output;
 	output += tabulate("switch(parsers::token_string_hash(cur.content)) {\n");
 	for(auto const& e : vector) {

--- a/ParserGenerator/parser_generator.cpp
+++ b/ParserGenerator/parser_generator.cpp
@@ -11,6 +11,7 @@
 #include <optional>
 #include <sstream>
 #include <cassert>
+#include <algorithm>
 
 // Objects
 struct value_and_optional {

--- a/src/parsing/parsers.hpp
+++ b/src/parsing/parsers.hpp
@@ -261,4 +261,11 @@ namespace parsers {
 		}
 		return true;
 	}
+
+	uint32_t token_string_hash(std::string_view const s) {
+		uint32_t h = 5381;
+		for(auto it = s.begin(); it != s.end(); it++)
+			h = ((h << 5) + h) + uint8_t(*it | 0x20);
+		return h;
+	}
 }


### PR DESCRIPTION
Hashed strings using compiler assisted perfect hashing with the switch branches, reminder that the compiler will OFTEN perform perfect hashing on switch statments OR generate expressions to make it possible