### PR TITLE
Add FPS Counter and search window

### DIFF
--- a/assets/alice.gfx
+++ b/assets/alice.gfx
@@ -1,0 +1,6 @@
+spriteTypes = {
+    textSpriteType = {
+		name = "GFX_goto_location_button"
+		texturefile = "gfx\\interface\\save_list_button.dds"
+	}
+}

--- a/assets/alice.gui
+++ b/assets/alice.gui
@@ -471,4 +471,14 @@ guiTypes = {
 			}
 		}
 	}
+
+	guiButtonType = {
+		name = "goto_location_button"
+		quadTextureSprite = "GFX_goto_location_button"
+		position = { x=0 y=0 }
+		size = { x=240, y=24 }
+		orientation = "UPPER_LEFT"
+		buttonText = "GOTO_GOTO"
+		buttonFont = "vic_18_black"
+	}
 }

--- a/src/gamestate/system_state.cpp
+++ b/src/gamestate/system_state.cpp
@@ -9,6 +9,7 @@
 #include "gui_topbar.hpp"
 #include "gui_console.hpp"
 #include "gui_province_window.hpp"
+#include "gui_fps_counter.hpp"
 #include <algorithm>
 #include <thread>
 
@@ -169,6 +170,10 @@ namespace sys {
 		}
 		{
 			auto new_elm = ui::make_element_by_type<ui::topbar_window>(*this, "topbar");
+			ui_state.root->add_child_to_front(std::move(new_elm));
+		}
+		{
+			auto new_elm = ui::make_element_by_type<ui::fps_counter_text_box>(*this, "fps_counter");
 			ui_state.root->add_child_to_front(std::move(new_elm));
 		}
 	}

--- a/src/gamestate/system_state.cpp
+++ b/src/gamestate/system_state.cpp
@@ -9,7 +9,6 @@
 #include "gui_topbar.hpp"
 #include "gui_console.hpp"
 #include "gui_province_window.hpp"
-#include "gui_fps_counter.hpp"
 #include <algorithm>
 #include <thread>
 
@@ -170,10 +169,6 @@ namespace sys {
 		}
 		{
 			auto new_elm = ui::make_element_by_type<ui::topbar_window>(*this, "topbar");
-			ui_state.root->add_child_to_front(std::move(new_elm));
-		}
-		{
-			auto new_elm = ui::make_element_by_type<ui::fps_counter_text_box>(*this, "fps_counter");
 			ui_state.root->add_child_to_front(std::move(new_elm));
 		}
 	}

--- a/src/gui/gui_console.cpp
+++ b/src/gui/gui_console.cpp
@@ -1,4 +1,5 @@
 #include "gui_console.hpp"
+#include "gui_fps_counter.hpp"
 
 void ui::console_edit::edit_box_enter(sys::state& state, std::string_view s) noexcept {
     if(s == "reload") {
@@ -6,7 +7,16 @@ void ui::console_edit::edit_box_enter(sys::state& state, std::string_view s) noe
     } else if(s == "abort") {
         std::abort();
     } else if(s == "fps") {
-        state.ui_state.fps_counter->set_visible(state, !state.ui_state.fps_counter->is_visible());
+        if(!state.ui_state.fps_counter) {
+			auto window = make_element_by_type<fps_counter_text_box>(state, "fps_counter");
+			state.ui_state.fps_counter = window.get();
+			state.ui_state.root->add_child_to_front(std::move(window));
+		} else if(state.ui_state.fps_counter->is_visible()) {
+			state.ui_state.fps_counter->set_visible(state, false);
+		} else {
+			state.ui_state.fps_counter->set_visible(state, true);
+			state.ui_state.root->move_child_to_front(state.ui_state.fps_counter);
+		}
     }
     Cyto::Any output = std::string(s);
     parent->impl_get(state, output);

--- a/src/gui/gui_console.cpp
+++ b/src/gui/gui_console.cpp
@@ -5,6 +5,8 @@ void ui::console_edit::edit_box_enter(sys::state& state, std::string_view s) noe
         state.map_display.load_map(state);
     } else if(s == "abort") {
         std::abort();
+    } else if(s == "fps") {
+        state.ui_state.fps_counter->set_visible(state, !state.ui_state.fps_counter->is_visible());
     }
     Cyto::Any output = std::string(s);
     parent->impl_get(state, output);

--- a/src/gui/gui_element_types.cpp
+++ b/src/gui/gui_element_types.cpp
@@ -720,33 +720,58 @@ message_result listbox_row_element_base<RowConT>::get(sys::state& state, Cyto::A
 	return message_result::unseen;
 }
 
+template<class RowConT>
+message_result listbox_row_button_base<RowConT>::get(sys::state& state, Cyto::Any& payload) noexcept {
+	if(payload.holds_type<wrapped_row_content<RowConT>>()) {
+		content = any_cast<wrapped_row_content<RowConT>>(payload).content;
+		update(state);
+	}
+	return message_result::unseen;
+}
+
+template<class RowConT>
+message_result listbox_row_button_base<RowConT>::on_scroll(sys::state& state, int32_t x, int32_t y, float amount, sys::key_modifiers mods) noexcept {
+	return parent->impl_on_scroll(state, x, y, amount, mods);
+}
+
 template<class RowWinT, class RowConT>
 void listbox_element_base<RowWinT, RowConT>::update(sys::state& state) {
 	if(is_reversed()) {
 		auto i = int32_t(row_contents.size()) - scroll_pos - 1;
 		for(size_t rw_i = row_windows.size() - 1; rw_i > 0; rw_i--) {
-			auto content = i >= 0 ? row_contents[i--] : RowConT{};
-			Cyto::Any payload = wrapped_row_content<RowConT>{ content };
-			row_windows[rw_i]->impl_get(state, payload);
+			if(i >= 0) {
+				Cyto::Any payload = wrapped_row_content<RowConT>{ row_contents[i--] };
+				row_windows[rw_i]->impl_get(state, payload);
+				row_windows[rw_i]->set_visible(state, true);
+			} else {
+				row_windows[rw_i]->set_visible(state, false);
+			}
 		}
 	} else {
 		auto i = size_t(scroll_pos);
 		for(RowWinT* row_window : row_windows) {
-			auto content = i < row_contents.size() ? row_contents[i++] : RowConT{};
-			Cyto::Any payload = wrapped_row_content<RowConT>{ content };
-			row_window->impl_get(state, payload);
+			if(i < row_contents.size()) {
+				Cyto::Any payload = wrapped_row_content<RowConT>{ row_contents[i++] };
+				row_window->impl_get(state, payload);
+				row_window->set_visible(state, true);
+			} else {
+				row_window->set_visible(state, false);
+			}
 		}
 	}
 }
 
 template<class RowWinT, class RowConT>
 message_result listbox_element_base<RowWinT, RowConT>::on_scroll(sys::state& state, int32_t x, int32_t y, float amount, sys::key_modifiers mods) noexcept {
-	if(amount < 0) {
+	auto old_scroll_pos = scroll_pos;
+	if(amount > 0) {
 		scroll_pos = std::max(scroll_pos - 1, 0);
-	} else {
+	} else if(row_contents.size() > row_windows.size()) {
 		scroll_pos = std::min(scroll_pos + 1, int32_t(row_contents.size() - row_windows.size()));
 	}
-	update(state);
+	if(scroll_pos != old_scroll_pos) {
+		update(state);
+	}
 	return message_result::consumed;
 }
 

--- a/src/gui/gui_element_types.hpp
+++ b/src/gui/gui_element_types.hpp
@@ -218,6 +218,17 @@ public:
 	message_result get(sys::state& state, Cyto::Any& payload) noexcept override;
 };
 
+template<class RowConT>
+class listbox_row_button_base : public button_element_base {
+protected:
+	RowConT content{};
+
+public:
+	virtual void update(sys::state& state) noexcept { }
+	message_result get(sys::state& state, Cyto::Any& payload) noexcept override;
+	message_result on_scroll(sys::state& state, int32_t x, int32_t y, float amount, sys::key_modifiers mods) noexcept override;
+};
+
 template<class RowWinT, class RowConT>
 class listbox_element_base : public container_base {
 protected:
@@ -238,6 +249,9 @@ public:
 	message_result on_scroll(sys::state& state, int32_t x, int32_t y, float amount, sys::key_modifiers mods) noexcept override;
 	void on_create(sys::state& state) noexcept override;
 	void render(sys::state& state, int32_t x, int32_t y) noexcept override;
+	message_result test_mouse(sys::state& state, int32_t x, int32_t y) noexcept override {
+		return message_result::consumed;
+	}
 };
 
 template<class TabT>

--- a/src/gui/gui_fps_counter.hpp
+++ b/src/gui/gui_fps_counter.hpp
@@ -1,0 +1,35 @@
+#include "gui_element_types.hpp"
+namespace ui {
+
+class fps_counter_text_box : public simple_text_element_base {
+private:
+    std::chrono::time_point<std::chrono::system_clock> last_render_time{};
+    std::chrono::time_point<std::chrono::system_clock> last_compute_time{};
+
+public:
+    void on_create(sys::state& state) noexcept override {
+        simple_text_element_base::on_create(state);
+        state.ui_state.fps_counter = this;
+        set_text(state, "0");
+        set_visible(state, false);
+    }
+
+    void render(sys::state& state, int32_t x, int32_t y) noexcept override {
+        std::chrono::time_point<std::chrono::system_clock> now = std::chrono::system_clock::now();
+        if(last_render_time == std::chrono::time_point<std::chrono::system_clock>{}) {
+            last_render_time = now;
+        }
+        auto microseconds_since_last_render = std::chrono::duration_cast<std::chrono::microseconds>(now - last_render_time);
+        auto microseconds_since_last_compute = std::chrono::duration_cast<std::chrono::microseconds>(now - last_compute_time);
+        if(microseconds_since_last_render.count() > 0.f && microseconds_since_last_compute.count() > 1e5) {
+            auto frames_per_second = 1.f / float(microseconds_since_last_render.count() / 1e6);
+            set_text(state, std::to_string(int32_t(frames_per_second)));
+            last_compute_time = now;
+        }
+        last_render_time = now;
+
+        simple_text_element_base::render(state, x, y);
+    }
+};
+
+}

--- a/src/gui/gui_fps_counter.hpp
+++ b/src/gui/gui_fps_counter.hpp
@@ -5,8 +5,8 @@ namespace ui {
 
 class fps_counter_text_box : public simple_text_element_base {
 private:
-    std::chrono::time_point<std::chrono::system_clock> last_render_time{};
-    std::chrono::time_point<std::chrono::system_clock> last_compute_time{};
+    std::chrono::time_point<std::chrono::steady_clock> last_render_time{};
+    std::chrono::time_point<std::chrono::steady_clock> last_compute_time{};
 
 public:
     void on_create(sys::state& state) noexcept override {
@@ -15,8 +15,8 @@ public:
     }
 
     void render(sys::state& state, int32_t x, int32_t y) noexcept override {
-        std::chrono::time_point<std::chrono::system_clock> now = std::chrono::system_clock::now();
-        if(last_render_time == std::chrono::time_point<std::chrono::system_clock>{}) {
+        std::chrono::time_point<std::chrono::steady_clock> now = std::chrono::steady_clock::now();
+        if(last_render_time == std::chrono::time_point<std::chrono::steady_clock>{}) {
             last_render_time = now;
         }
         auto microseconds_since_last_render = std::chrono::duration_cast<std::chrono::microseconds>(now - last_render_time);

--- a/src/gui/gui_fps_counter.hpp
+++ b/src/gui/gui_fps_counter.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "gui_element_types.hpp"
 namespace ui {
 
@@ -9,9 +11,7 @@ private:
 public:
     void on_create(sys::state& state) noexcept override {
         simple_text_element_base::on_create(state);
-        state.ui_state.fps_counter = this;
         set_text(state, "0");
-        set_visible(state, false);
     }
 
     void render(sys::state& state, int32_t x, int32_t y) noexcept override {

--- a/src/gui/gui_graphics.cpp
+++ b/src/gui/gui_graphics.cpp
@@ -29,8 +29,17 @@ void load_text_gui_definitions(sys::state& state, parsers::error_handler& err) {
 	auto interfc = open_directory(rt, NATIVE("interface"));
 
 	{
-		auto all_files = list_files(interfc, NATIVE(".gfx"));
+		// first, load in special mod gfx
+		// TODO put this in a better location
+		auto alice_gfx = open_file(rt, NATIVE("assets/alice.gfx"));
+		if(alice_gfx) {
+			auto content = view_contents(*alice_gfx);
+			err.file_name = "assets/alice.gfx";
+			parsers::token_generator gen(content.data, content.data + content.file_size);
+			parsers::parse_gfx_files(gen, err, context);
+		}
 
+		auto all_files = list_files(interfc, NATIVE(".gfx"));
 
 		for(auto& file : all_files) {
 			auto ofile = open_file(file);

--- a/src/gui/gui_graphics.hpp
+++ b/src/gui/gui_graphics.hpp
@@ -356,6 +356,7 @@ namespace ui {
 		element_base* topbar_window = nullptr;
 		element_base* topbar_subwindow = nullptr; // current tab window
 		element_base* province_window = nullptr;
+		element_base* search_window = nullptr;
 
 		state();
 	};

--- a/src/gui/gui_graphics.hpp
+++ b/src/gui/gui_graphics.hpp
@@ -351,6 +351,7 @@ namespace ui {
 
 		// elements we are keeping track of
 		element_base* main_menu = nullptr;
+		element_base* fps_counter = nullptr;
 		element_base* console_window = nullptr; // console window
 		element_base* topbar_window = nullptr;
 		element_base* topbar_subwindow = nullptr; // current tab window

--- a/src/gui/gui_province_window.hpp
+++ b/src/gui/gui_province_window.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "dcon_generated.hpp"
 #include "gui_element_types.hpp"
 #include "province.hpp"

--- a/src/gui/gui_search_window.hpp
+++ b/src/gui/gui_search_window.hpp
@@ -47,13 +47,13 @@ private:
     std::vector<dcon::province_id> search_provinces(sys::state& state, std::string_view search_term) noexcept {
         std::vector<dcon::province_id> results{};
         std::string search_term_lower = std::string(search_term);
-        std::transform(search_term_lower.begin(), search_term_lower.end(), search_term_lower.begin(), ::tolower);
+        std::transform(search_term_lower.begin(), search_term_lower.end(), search_term_lower.begin(), [](unsigned char c){ return std::tolower(c); });
 
         if(!search_term.empty()) {
             state.world.for_each_province([&](dcon::province_id prov_id){
                 dcon::province_fat_id fat_id = dcon::fatten(state.world, prov_id);
                 auto name = text::produce_simple_string(state, fat_id.get_name());
-                std::transform(name.begin(), name.end(), name.begin(), ::tolower);
+                std::transform(name.begin(), name.end(), name.begin(), [](unsigned char c){ return std::tolower(c); });
                 if(name.starts_with(search_term_lower)) {
                     results.push_back(prov_id);
                 }

--- a/src/gui/gui_search_window.hpp
+++ b/src/gui/gui_search_window.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+#include "dcon_generated.hpp"
+#include "gui_element_types.hpp"
+#include "gui_graphics.hpp"
+#include "gui_province_window.hpp"
+#include "province.hpp"
+#include "text.hpp"
+#include <algorithm>
+
+namespace ui {
+
+class province_search_edit : public edit_box_element_base {
+public:
+    void edit_box_update(sys::state& state, std::string_view s) noexcept override {
+        Cyto::Any input = s;
+        parent->impl_get(state, input);
+    }
+};
+
+class province_search_list_item : public listbox_row_button_base<dcon::province_id> {
+public:
+    void button_action(sys::state& state) noexcept override {
+        auto map_prov_id = province::to_map_id(content);
+        state.map_display.set_selected_province(map_prov_id);
+        static_cast<province_view_window*>(state.ui_state.province_window)->set_active_province(state, map_prov_id);
+    }
+
+    void update(sys::state& state) noexcept override {
+        dcon::province_fat_id fat_id = dcon::fatten(state.world, content);
+        auto name = text::produce_simple_string(state, fat_id.get_name());
+        set_button_text(state, name);
+    }
+};
+
+class province_search_list : public listbox_element_base<province_search_list_item, dcon::province_id> {
+protected:
+    std::string_view get_row_element_name() override {
+        return "goto_location_button";
+    }
+};
+
+class province_search_window : public window_element_base {
+private:
+    province_search_list* search_listbox = nullptr;
+
+    std::vector<dcon::province_id> search_provinces(sys::state& state, std::string_view search_term) noexcept {
+        std::vector<dcon::province_id> results{};
+        std::string search_term_lower = std::string(search_term);
+        std::transform(search_term_lower.begin(), search_term_lower.end(), search_term_lower.begin(), ::tolower);
+
+        if(!search_term.empty()) {
+            state.world.for_each_province([&](dcon::province_id prov_id){
+                dcon::province_fat_id fat_id = dcon::fatten(state.world, prov_id);
+                auto name = text::produce_simple_string(state, fat_id.get_name());
+                std::transform(name.begin(), name.end(), name.begin(), ::tolower);
+                if(name.starts_with(search_term_lower)) {
+                    results.push_back(prov_id);
+                }
+            });
+        }
+
+        return results;
+    }
+
+public:
+    void on_create(sys::state& state) noexcept override {
+        window_element_base::on_create(state);
+        move_child_to_front(search_listbox);
+    }
+
+    std::unique_ptr<element_base> make_child(sys::state& state, std::string_view name, dcon::gui_def_id id) noexcept override {
+        if(name == "cancel") {
+            return make_element_by_type<generic_close_button>(state, id);
+        } else if(name == "goto_edit") {
+            return make_element_by_type<province_search_edit>(state, id);
+        } else if(name == "provinces") {
+            auto ptr = make_element_by_type<province_search_list>(state, id);
+            search_listbox = ptr.get();
+            return ptr;
+        } else {
+            return nullptr;
+        }
+    }
+
+    message_result get(sys::state& state, Cyto::Any& payload) noexcept override {
+		if(payload.holds_type<std::string_view>()) {
+			auto search_term = any_cast<std::string_view>(payload);
+			search_listbox->row_contents = search_provinces(state, search_term);
+			search_listbox->update(state);
+			return message_result::consumed;
+		} else {
+			return message_result::unseen;
+		}
+	}
+};
+
+}


### PR DESCRIPTION
The FPS Counter is toggled using the `fps` console command.

For the moment, the search / goto window
only searches provinces. Also, I couldn't find the gui
asset for the button used in the province list, so
I made a custom one. I'm fairly confident the button is not
set up "normally", if it is please correct me.