### PR TITLE
Add stripes to map

### DIFF
--- a/assets/shaders/map_political_close_f.glsl
+++ b/assets/shaders/map_political_close_f.glsl
@@ -6,8 +6,9 @@ layout (binding = 0) uniform sampler2D provinces_texture_sampler;
 layout (binding = 1) uniform sampler2D terrain_texture_sampler;
 layout (binding = 3) uniform sampler2DArray terrainsheet_texture_sampler;
 layout (binding = 6) uniform sampler2D colormap_terrain;
-layout (binding = 8) uniform sampler2D province_color;
+layout (binding = 8) uniform sampler2DArray province_color;
 layout (binding = 10) uniform sampler2D province_highlight;
+layout (binding = 11) uniform sampler2D stripes_texture;
 
 // location 0 : offset
 // location 1 : zoom
@@ -54,7 +55,14 @@ void main() {
  	terrain.rgb = vec3(grey);
 
 	vec2 prov_id = texture(provinces_texture_sampler, tex_coord).xy;
-	vec3 political = clamp(texture(province_color, prov_id) + texture(province_highlight, prov_id), 0.0, 1.0).rgb;
+
+	vec4 prov_color = texture(province_color, vec3(prov_id, 0.));
+	vec4 stripe_color   = texture(province_color, vec3(prov_id, 1.));
+
+	vec2 stripe_coord = tex_coord * vec2(512., 512. * map_size.y / map_size.x);
+
+	float stripeFactor = texture(stripes_texture, stripe_coord).a;
+	vec3 political = clamp(mix(prov_color, stripe_color, stripeFactor) + texture(province_highlight, prov_id), 0.0, 1.0).rgb;
 	political = political - 0.7;
 
 	frag_color.rgb = mix(terrain.rgb, political, 0.3);

--- a/assets/shaders/map_political_far_f.glsl
+++ b/assets/shaders/map_political_far_f.glsl
@@ -4,9 +4,10 @@ in vec2 tex_coord;
 layout (location = 0) out vec4 frag_color;
 layout (binding = 0) uniform sampler2D provinces_texture_sampler;
 layout (binding = 7) uniform sampler2D overlay;
-layout (binding = 8) uniform sampler2D province_color;
+layout (binding = 8) uniform sampler2DArray province_color;
 layout (binding = 9) uniform sampler2D colormap_political;
 layout (binding = 10) uniform sampler2D province_highlight;
+layout (binding = 11) uniform sampler2D stripes_texture;
 
 // location 0 : offset
 // location 1 : zoom
@@ -15,7 +16,14 @@ layout (location = 3) uniform vec2 map_size;
 
 void main() {
 	vec2 prov_id = texture(provinces_texture_sampler, tex_coord).xy;
-	vec3 political = clamp(texture(province_color, prov_id) + texture(province_highlight, prov_id), 0.0, 1.0).rgb;
+
+	vec4 prov_color = texture(province_color, vec3(prov_id, 0.));
+	vec4 stripe_color = texture(province_color, vec3(prov_id, 1.));
+
+	vec2 stripe_coord = tex_coord * vec2(512., 512. * map_size.y / map_size.x);
+
+	float stripeFactor = texture(stripes_texture, stripe_coord).a;
+	vec3 political = clamp(mix(prov_color, stripe_color, stripeFactor) + texture(province_highlight, prov_id), 0.0, 1.0).rgb;
 	political = political - 0.7;
 
 	vec4 OverlayColor = texture(overlay, tex_coord * vec2(11., 11.*map_size.y/map_size.x));

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -84,6 +84,7 @@ private:
 	GLuint province_color = 0;
 	GLuint border_texture = 0;
 	GLuint province_highlight = 0;
+	GLuint stripes_texture = 0;
 
 	// Shaders
 	GLuint terrain_shader = 0;
@@ -118,6 +119,6 @@ private:
 
 	void load_shaders(simple_fs::directory& root);
 	void create_meshes();
-	void gen_prov_color_texture(GLuint texture_handle, std::vector<uint32_t> const& prov_color);
+	void gen_prov_color_texture(GLuint texture_handle, std::vector<uint32_t> const& prov_color, uint8_t layers = 1);
 };
 }

--- a/src/map/map_modes.hpp
+++ b/src/map/map_modes.hpp
@@ -29,6 +29,8 @@ enum class mode : uint8_t {
 	naval = 0x16
 };
 
+const uint8_t PROV_COLOR_LAYERS = 2;
+
 void set_map_mode(sys::state& state, mode mode);
 void update_map_mode(sys::state& state);
 }


### PR DESCRIPTION
The main change is that the province color texture was changed to a Texture Array of 2 textures, the province color and the stripes color.

In gen_prov_color_texture (map.cpp) the prov_color vector was kept, but it contains the colors for both textures, First for province color and then stripe colors.

I'm not quite sure if using a texture array of only 2 textures is better or worse in terms of performance (compared to 2 separated textures).

Initially I thought that with 4 iterations of the stripe texture you could fill the image. I wanted to do 4 color textures to make the map coloring more generic, one for each stripe. But this doesn't work, because the stripes don't have the same size.

For now I modified the culture map to use the stripes, but I'll also need to modify the other map modes