### PR TITLE
Deconflicting Clang and non-Clang cmake preset displayNames, and set …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ if(WIN32)
 			$<$<CONFIG:Debug>: 			/DEBUG:FULL >
 			$<$<NOT:$<CONFIG:Debug>>: 	/OPT:REF /OPT:ICF /LTCG>)
 	else()
+	set_target_properties(Alice PROPERTIES RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_CURRENT_BINARY_DIR})
 		target_compile_options(Alice PRIVATE
 										/bigobj /wd4100 /wd4189 /wd4065 /GR- /W4 /permissive- /Zc:preprocessor /WX /arch:AVX2 /GF /w34388 /w34389 /Z7
 			$<$<CONFIG:Debug>:			/RTC1 /EHsc /MTd /Od>

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -54,7 +54,7 @@
     },
     {
       "name": "x64-debug-win-clang",
-      "displayName": "x64 Debug",
+      "displayName": "x64 Debug (Clang)",
       "inherits": "windows-clang-base",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug"
@@ -70,7 +70,7 @@
     },
     {
       "name": "x64-release-win-clang",
-      "displayName": "x64 Release",
+      "displayName": "x64 Release (Clang)",
       "inherits": "windows-clang-base",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release"


### PR DESCRIPTION
…Alice executable location to current binary directory

Neither of these changes are important, but I wanted to get my feet wet with how contributing to Open Source projects works. The set_target_properties change was necessary to fix my build issues, but I'm suspicious why this is necessary for me but (apparently) nobody else. This could potentially help other VSCode users if nobody else has tried to build with VSCode yet. Not sure if there is any automated testing that can verify my change is ok.