### PR TITLE
Colonial Power / Tilde to close console.

### DIFF
--- a/src/gui/gui_common_elements.hpp
+++ b/src/gui/gui_common_elements.hpp
@@ -528,6 +528,15 @@ public:
 	}
 };
 
+class nation_colonial_power_text : public standard_nation_text {
+public:
+	std::string get_text(sys::state& state) noexcept override {
+		auto fcp = std::to_string(nations::free_colonial_points(state, nation_id));
+		auto mcp = std::to_string(nations::max_colonial_points(state, nation_id));
+		return fcp + "/" + mcp;
+	}
+};
+
 class nation_budget_funds_text : public standard_nation_text {
 public:
 	std::string get_text(sys::state& state) noexcept override {

--- a/src/gui/gui_console.cpp
+++ b/src/gui/gui_console.cpp
@@ -3,60 +3,39 @@
 #include "nations.hpp"
 
 enum class Command {
-	NoMessage,
-	Reload,
-	Abort,
-	ClearLog,
-	FPS,
-	SetTag,
-	Unknown
+	NoMessage, Reload, Abort, ClearLog, FPS, SetTag, Help, Unknown
 };
-
+std::vector<std::string> possibleCommands{ "reload", "abort", "clr_log", "fps", "tag", "help" };
 
 void set_active_tag(sys::state& state, std::string_view tag) noexcept {
-    state.world.for_each_national_identity([&](dcon::national_identity_id id) {
-        std::string curr = nations::int_to_tag(state.world.national_identity_get_identifying_int(id));
-        if(curr == tag) {
-            dcon::national_identity_fat_id fat_id = dcon::fatten(state.world, id);
-            auto nat_id = fat_id.get_nation_from_identity_holder().id;
-            state.local_player_nation = nat_id;
-        }
-    });
+	state.world.for_each_national_identity([&](dcon::national_identity_id id) {
+		std::string curr = nations::int_to_tag(state.world.national_identity_get_identifying_int(id));
+		if(curr == tag) {
+			dcon::national_identity_fat_id fat_id = dcon::fatten(state.world, id);
+			state.local_player_nation = fat_id.get_nation_from_identity_holder().id;
+		}
+	});
 }
 
 Command parse_command(std::string_view s) noexcept {
-	if(s.empty()) {
-		return Command::NoMessage;
-	} else if(s == "reload") {
-		return Command::Reload;
-	} else if(s == "abort") {
-		return Command::Abort;
-	} else if(s == "clr_log") {
-		return Command::ClearLog;
-	} else if(s == "fps") {
-		return Command::FPS;
-	} else if(s.starts_with("tag ") && s.size() == 7) {
-		return Command::SetTag;
-	} else {
-		return Command::Unknown;
-	}
+	if(s.empty()) return Command::NoMessage;
+	if(s == "reload") return Command::Reload;
+	if(s == "abort") return Command::Abort;
+	if(s == "clr_log") return Command::ClearLog;
+	if(s == "fps") return Command::FPS;
+	if(s.starts_with("tag ") && s.size() == 7) return Command::SetTag;
+	if(s == "help") return Command::Help;
+	return Command::Unknown;
 }
 
 void log_to_console(sys::state& state, ui::element_base* parent, std::string_view s) noexcept {
 	Cyto::Any output = std::string(s);
 	parent->impl_get(state, output);
 }
-void clear_console(sys::state& state, ui::element_base* parent) noexcept {
-	// TODO: Implement this. Idk how to remove all children at once.
-}
-
 
 void ui::console_edit::edit_box_enter(sys::state& state, std::string_view s) noexcept {
 	Command command = parse_command(s);
-	if(command == Command::NoMessage) {
-		return;
-	}
-
+	if(command == Command::NoMessage) return;
 	log_to_console(state, parent, s);
 
 	switch(command) {
@@ -69,42 +48,38 @@ void ui::console_edit::edit_box_enter(sys::state& state, std::string_view s) noe
 			std::abort();
 			break;
 		case Command::ClearLog:
-			clear_console(state, parent);
+			static_cast<console_window*>(parent)->clear_list(state);
 			break;
 		case Command::FPS:
 			if(!state.ui_state.fps_counter) {
 				auto fps_counter = make_element_by_type<fps_counter_text_box>(state, "fps_counter");
 				state.ui_state.fps_counter = fps_counter.get();
 				state.ui_state.root->add_child_to_front(std::move(fps_counter));
-			} else if(state.ui_state.fps_counter->is_visible()) {
-				state.ui_state.fps_counter->set_visible(state, false);
 			} else {
-				state.ui_state.fps_counter->set_visible(state, true);
+				state.ui_state.fps_counter->set_visible(state, !state.ui_state.fps_counter->is_visible());
 				state.ui_state.root->move_child_to_front(state.ui_state.fps_counter);
 			}
 			break;
 		case Command::SetTag:
-			// TODO: Verify tag exists. if it doesn't, log error to console using log_to_console.
-			log_to_console(state, parent, std::string("Switching to ")+std::string(s.substr(4)));
+			log_to_console(state, parent, std::string("Switching to ") + std::string(s.substr(4)));
 			set_active_tag(state, s.substr(4));
 			state.game_state_updated.store(true, std::memory_order::release);
 			break;
+		case Command::Help:
+			// TODO: `help {cmd}` should spit out something along the lines of "tag {country tag} - Switch active country". 
+			log_to_console(state, parent, "+-ALICE CONSOLE COMMANDS-+");
+			for(const std::string& cmd : possibleCommands) log_to_console(state, parent, cmd);
+			log_to_console(state, parent, "+-ALICE CONSOLE COMMANDS-+");
+			break;
 		case Command::Unknown:
 			log_to_console(state, parent, "Command not found.");
-			// TODO: Make this red.
 			break;
 	}
-	// Break-line to add space between commands
-	log_to_console(state, parent, "");
+	log_to_console(state, parent, ""); // space after command
 }
 
 void ui::console_window::show_toggle(sys::state& state) {
 	assert(state.ui_state.console_window);
-	if(state.ui_state.console_window->is_visible()) {
-		state.ui_state.console_window->set_visible(state, false);
-		// TODO: Remove focus on console once toggled off--not sure how to do this yet.
-    } else {
-        state.ui_state.console_window->set_visible(state, true);
-        state.ui_state.root->move_child_to_front(state.ui_state.console_window);
-    }
+	state.ui_state.console_window->set_visible(state, !state.ui_state.console_window->is_visible());
+	if(state.ui_state.console_window->is_visible()) state.ui_state.root->move_child_to_front(state.ui_state.console_window);
 }

--- a/src/gui/gui_console.cpp
+++ b/src/gui/gui_console.cpp
@@ -2,6 +2,17 @@
 #include "gui_fps_counter.hpp"
 #include "nations.hpp"
 
+enum class Command {
+	NoMessage,
+	Reload,
+	Abort,
+	ClearLog,
+	FPS,
+	SetTag,
+	Unknown
+};
+
+
 void set_active_tag(sys::state& state, std::string_view tag) noexcept {
     state.world.for_each_national_identity([&](dcon::national_identity_id id) {
         std::string curr = nations::int_to_tag(state.world.national_identity_get_identifying_int(id));
@@ -13,28 +24,78 @@ void set_active_tag(sys::state& state, std::string_view tag) noexcept {
     });
 }
 
+Command parse_command(std::string_view s) noexcept {
+	if(s.empty()) {
+		return Command::NoMessage;
+	} else if(s == "reload") {
+		return Command::Reload;
+	} else if(s == "abort") {
+		return Command::Abort;
+	} else if(s == "clr_log") {
+		return Command::ClearLog;
+	} else if(s == "fps") {
+		return Command::FPS;
+	} else if(s.starts_with("tag ") && s.size() == 7) {
+		return Command::SetTag;
+	} else {
+		return Command::Unknown;
+	}
+}
+
+void log_to_console(sys::state& state, ui::element_base* parent, std::string_view s) noexcept {
+	Cyto::Any output = std::string(s);
+	parent->impl_get(state, output);
+}
+void clear_console(sys::state& state, ui::element_base* parent) noexcept {
+	// TODO: Implement this. Idk how to remove all children at once.
+}
+
+
 void ui::console_edit::edit_box_enter(sys::state& state, std::string_view s) noexcept {
-    if(s == "reload") {
-        state.map_display.load_map(state);
-    } else if(s == "abort") {
-        std::abort();
-    } else if(s == "fps") {
-        if(!state.ui_state.fps_counter) {
-			auto window = make_element_by_type<fps_counter_text_box>(state, "fps_counter");
-			state.ui_state.fps_counter = window.get();
-			state.ui_state.root->add_child_to_front(std::move(window));
-		} else if(state.ui_state.fps_counter->is_visible()) {
-			state.ui_state.fps_counter->set_visible(state, false);
-		} else {
-			state.ui_state.fps_counter->set_visible(state, true);
-			state.ui_state.root->move_child_to_front(state.ui_state.fps_counter);
-		}
-    } else if(s.starts_with("tag ") && s.size() == 7) {
-        set_active_tag(state, s.substr(4));
-		state.game_state_updated.store(true, std::memory_order::release);
-    }
-    Cyto::Any output = std::string(s);
-    parent->impl_get(state, output);
+	Command command = parse_command(s);
+	if(command == Command::NoMessage) {
+		return;
+	}
+
+	log_to_console(state, parent, s);
+
+	switch(command) {
+		case Command::Reload:
+			log_to_console(state, parent, "Reloading...");
+			state.map_display.load_map(state);
+			break;
+		case Command::Abort:
+			log_to_console(state, parent, "Aborting...");
+			std::abort();
+			break;
+		case Command::ClearLog:
+			clear_console(state, parent);
+			break;
+		case Command::FPS:
+			if(!state.ui_state.fps_counter) {
+				auto fps_counter = make_element_by_type<fps_counter_text_box>(state, "fps_counter");
+				state.ui_state.fps_counter = fps_counter.get();
+				state.ui_state.root->add_child_to_front(std::move(fps_counter));
+			} else if(state.ui_state.fps_counter->is_visible()) {
+				state.ui_state.fps_counter->set_visible(state, false);
+			} else {
+				state.ui_state.fps_counter->set_visible(state, true);
+				state.ui_state.root->move_child_to_front(state.ui_state.fps_counter);
+			}
+			break;
+		case Command::SetTag:
+			// TODO: Verify tag exists. if it doesn't, log error to console using log_to_console.
+			log_to_console(state, parent, std::string("Switching to ")+std::string(s.substr(4)));
+			set_active_tag(state, s.substr(4));
+			state.game_state_updated.store(true, std::memory_order::release);
+			break;
+		case Command::Unknown:
+			log_to_console(state, parent, "Command not found.");
+			// TODO: Make this red.
+			break;
+	}
+	// Break-line to add space between commands
+	log_to_console(state, parent, "");
 }
 
 void ui::console_window::show_toggle(sys::state& state) {

--- a/src/gui/gui_console.cpp
+++ b/src/gui/gui_console.cpp
@@ -41,6 +41,7 @@ void ui::console_window::show_toggle(sys::state& state) {
 	assert(state.ui_state.console_window);
 	if(state.ui_state.console_window->is_visible()) {
 		state.ui_state.console_window->set_visible(state, false);
+		// TODO: Remove focus on console once toggled off--not sure how to do this yet.
     } else {
         state.ui_state.console_window->set_visible(state, true);
         state.ui_state.root->move_child_to_front(state.ui_state.console_window);

--- a/src/gui/gui_console.hpp
+++ b/src/gui/gui_console.hpp
@@ -10,6 +10,9 @@ public:
 	void edit_box_esc(sys::state& state) noexcept override {
 		state.ui_state.console_window->set_visible(state, false);
 	}
+	void edit_box_backtick(sys::state& state) noexcept override {
+		state.ui_state.console_window->set_visible(state, false);
+	}
 };
 
 class console_list_entry : public listbox_row_element_base<std::string> {

--- a/src/gui/gui_console.hpp
+++ b/src/gui/gui_console.hpp
@@ -78,10 +78,19 @@ public:
 		}
 	}
 
+
+	void clear_list(sys::state& state) noexcept {
+		console_output_list->row_contents.clear();
+		console_output_list->update(state);
+	}
+
 	static void show_toggle(sys::state& state);
 
 	void on_visible(sys::state& state) noexcept override {
 		state.ui_state.edit_target = edit_box;
+	}
+	void on_hide(sys::state& state) noexcept override {
+		state.ui_state.edit_target = nullptr;
 	}
 };
 }

--- a/src/gui/gui_element_types.cpp
+++ b/src/gui/gui_element_types.cpp
@@ -292,11 +292,13 @@ message_result edit_box_element_base::on_lbutton_down(sys::state& state, int32_t
 }
 
 void edit_box_element_base::on_text(sys::state& state, char ch) noexcept {
-	if(ch >= 32) {
-		auto s = std::string(get_text(state)).insert(edit_index, 1, ch);
-		edit_index++;
-		set_text(state, s);
-		edit_box_update(state, s);
+	if(state.ui_state.console_window->is_visible()) {
+		if(ch >= 32) {
+			auto s = std::string(get_text(state)).insert(edit_index, 1, ch);
+			edit_index++;
+			set_text(state, s);
+			edit_box_update(state, s);
+		}
 	}
 }
 
@@ -313,6 +315,9 @@ message_result edit_box_element_base::on_key_down(sys::state& state, sys::virtua
 			break;
 		case sys::virtual_key::ESCAPE:
 			edit_box_esc(state);
+			break;
+		case sys::virtual_key::TILDA:
+			edit_box_backtick(state);
 			break;
 		case sys::virtual_key::LEFT:
 			edit_index = std::max<int32_t>(edit_index - 1, 0);

--- a/src/gui/gui_element_types.hpp
+++ b/src/gui/gui_element_types.hpp
@@ -149,6 +149,7 @@ public:
 	virtual void edit_box_enter(sys::state& state, std::string_view s) noexcept { }
 	virtual void edit_box_update(sys::state& state, std::string_view s) noexcept { }
 	virtual void edit_box_esc(sys::state& state) noexcept { }
+	virtual void edit_box_backtick(sys::state& state) noexcept { }
 	void on_reset_text(sys::state& state) noexcept override;
 	void on_create(sys::state& state) noexcept override;
 

--- a/src/gui/gui_topbar.hpp
+++ b/src/gui/gui_topbar.hpp
@@ -351,6 +351,8 @@ public:
 			return make_element_by_type<nation_military_score_text>(state, id);
 		} else if(name == "country_total") {
 			return make_element_by_type<nation_total_score_text>(state, id);
+		} else if(name == "country_colonial_power") {
+			return make_element_by_type<nation_colonial_power_text>(state, id);
 		} else if(name == "selected_prestige_rank") {
 			return make_element_by_type<nation_prestige_rank_text>(state, id);
 		} else if(name == "selected_industry_rank") {


### PR DESCRIPTION
This also bundles in a fix that prevents typing into console text box when it's closed (and still focused.). Console is now a lot more stable and usable--only thing that needs to be implemented is reestablishing focus on main window once it is closed (add to toggle_console).
Free colonial power always remains at 0, since the function needs implementation. However, if you tag into great powers, you can see their cap.