### PR TITLE
Add progress bars

### DIFF
--- a/src/gui/gui_common_elements.hpp
+++ b/src/gui/gui_common_elements.hpp
@@ -77,6 +77,37 @@ public:
 	}
 };
 
+class standard_province_progress_bar : public progress_bar {
+protected:
+	dcon::province_id prov_id{};
+
+public:
+	virtual float get_progress(sys::state& state) noexcept {
+		return 0.f;
+	}
+
+	void on_update(sys::state& state) noexcept override {
+		progress = get_progress(state);
+	}
+
+	message_result set(sys::state& state, Cyto::Any& payload) noexcept override {
+		if(payload.holds_type<dcon::province_id>()) {
+			prov_id = any_cast<dcon::province_id>(payload);
+			on_update(state);
+			return message_result::consumed;
+		} else {
+			return message_result::unseen;
+		}
+	}
+};
+
+class province_liferating_progress_bar : public standard_province_progress_bar {
+public:
+	float get_progress(sys::state& state) noexcept override {
+		return state.world.province_get_life_rating(prov_id) / 35.f;
+	}
+};
+
 class standard_province_icon : public opaque_element_base {
 protected:
 	dcon::province_id prov_id{};
@@ -98,6 +129,14 @@ public:
 		} else {
 			return message_result::unseen;
 		}
+	}
+};
+
+class province_rgo_employment_progress_icon : public standard_province_icon {
+public:
+	int32_t get_icon_frame(sys::state& state) noexcept override {
+		auto employment_ratio = state.world.province_get_rgo_employment(prov_id);
+		return int32_t(10.f * employment_ratio);
 	}
 };
 
@@ -291,13 +330,7 @@ public:
 class province_rgo_employment_percent_text : public standard_province_text {
 public:
 	std::string get_text(sys::state& state) noexcept override {
-		auto employed = province::rgo_employment(state, province_id);
-		auto max_employed = province::rgo_maximum_employment(state, province_id);
-		if(max_employed > 0.f) {
-			return text::format_percentage(employed / max_employed, 3);
-		} else {
-			return text::format_percentage(0.f, 3);
-		}
+		return text::format_percentage(state.world.province_get_rgo_employment(province_id), 3);
 	}
 };
 
@@ -716,6 +749,37 @@ public:
 		} else {
 			return message_result::unseen;
 		}
+	}
+};
+
+class standard_nation_progress_bar : public progress_bar {
+protected:
+	dcon::nation_id nation_id{};
+
+public:
+	virtual float get_progress(sys::state& state) noexcept {
+		return 0.f;
+	}
+
+	void on_update(sys::state& state) noexcept override {
+		progress = get_progress(state);
+	}
+
+	message_result set(sys::state& state, Cyto::Any& payload) noexcept override {
+		if(payload.holds_type<dcon::nation_id>()) {
+			nation_id = any_cast<dcon::nation_id>(payload);
+			on_update(state);
+			return message_result::consumed;
+		} else {
+			return message_result::unseen;
+		}
+	}
+};
+
+class nation_westernization_progress_bar : public standard_nation_progress_bar {
+public:
+	float get_progress(sys::state& state) noexcept override {
+		return state.world.nation_get_modifier_values(nation_id, sys::national_mod_offsets::civilization_progress_modifier);
 	}
 };
 

--- a/src/gui/gui_element_types.cpp
+++ b/src/gui/gui_element_types.cpp
@@ -220,6 +220,28 @@ void tinted_image_element_base::render(sys::state& state, int32_t x, int32_t y) 
 	}
 }
 
+void progress_bar::render(sys::state& state, int32_t x, int32_t y) noexcept {
+	if(base_data.get_element_type() == element_type::image) {
+		dcon::gfx_object_id gid = base_data.data.image.gfx_object;
+		if(gid) {
+			auto& gfx_def = state.ui_defs.gfx[gid];
+			auto secondary_texture_handle = dcon::texture_id(gfx_def.type_dependent - 1);
+			if(gfx_def.primary_texture_handle) {
+				ogl::render_progress_bar(
+					state,
+					get_color_modification(this == state.ui_state.under_mouse, disabled, interactable),
+					progress,
+					float(x), float(y), float(base_data.size.x), float(base_data.size.y),
+					ogl::get_texture_handle(state, gfx_def.primary_texture_handle, gfx_def.is_partially_transparent()),
+					ogl::get_texture_handle(state, secondary_texture_handle, gfx_def.is_partially_transparent()),
+					base_data.get_rotation(),
+					gfx_def.is_vertically_flipped()
+				);
+			}
+		}
+	}
+}
+
 void tinted_image_element_base::on_update(sys::state& state) noexcept {
 	color = get_tint_color(state);
 }

--- a/src/gui/gui_element_types.hpp
+++ b/src/gui/gui_element_types.hpp
@@ -62,6 +62,12 @@ public:
 	void on_create(sys::state& state) noexcept override;
 };
 
+class progress_bar : public image_element_base {
+public:
+	float progress = 0.f;
+	void render(sys::state& state, int32_t x, int32_t y) noexcept override;
+};
+
 class tinted_image_element_base : public image_element_base {
 private:
 	uint32_t color = 0;

--- a/src/gui/gui_province_window.hpp
+++ b/src/gui/gui_province_window.hpp
@@ -185,6 +185,8 @@ public:
 			return make_element_by_type<state_admin_efficiency_text>(state, id);
 		} else if(name == "owner_presence") {
 			return make_element_by_type<state_aristocrat_presence_text>(state, id);
+		} else if(name == "liferating") {
+			return make_element_by_type<province_liferating_progress_bar>(state, id);
 		} else {
 			return nullptr;
 		}
@@ -417,6 +419,8 @@ public:
 			return make_element_by_type<province_crime_fighting_text>(state, id);
 		} else if(name == "rebel_percent") {
 			return make_element_by_type<province_rebel_percent_text>(state, id);
+		} else if(name == "employment_ratio") {
+			return make_element_by_type<province_rgo_employment_progress_icon>(state, id);
 		} else if(name == "rgo_population") {
 			return make_element_by_type<province_rgo_workers_text>(state, id);
 		} else if(name == "rgo_percent") {

--- a/src/gui/topbar_subwindows/gui_politics_window.hpp
+++ b/src/gui/topbar_subwindows/gui_politics_window.hpp
@@ -412,17 +412,6 @@ public:
 			unciv_reforms_win->set_visible(state, true);
 		}
 	}
-	void hide_vector_elements(sys::state& state, std::vector<element_base*>& elements) {
-		for(auto element : elements) {
-			element->set_visible(state, false);
-		}
-	}
-
-	void show_vector_elements(sys::state& state, std::vector<element_base*>& elements) {
-		for(auto element : elements) {
-			element->set_visible(state, true);
-		}
-	}
 	void hide_sub_windows(sys::state& state) {
 		reforms_win->set_visible(state, false);
 		unciv_reforms_win->set_visible(state, false);

--- a/src/gui/topbar_subwindows/politics_subwindows/gui_unciv_reforms_window.hpp
+++ b/src/gui/topbar_subwindows/politics_subwindows/gui_unciv_reforms_window.hpp
@@ -1,8 +1,21 @@
 #pragma once
 
+#include "gui_common_elements.hpp"
 #include "gui_element_types.hpp"
 
 namespace ui {
+
+class unciv_reforms_westernize_button : public standard_nation_button {
+public:
+	void on_create(sys::state& state) noexcept override {
+		button_element_base::on_create(state);
+		on_update(state);
+	}
+
+	void on_update(sys::state& state) noexcept override {
+		disabled = state.world.nation_get_modifier_values(nation_id, sys::national_mod_offsets::civilization_progress_modifier) < 1.f;
+	}
+};
 
 class unciv_reforms_window : public window_element_base {
 public:
@@ -12,7 +25,13 @@ public:
 	}
 
 	std::unique_ptr<element_base> make_child(sys::state& state, std::string_view name, dcon::gui_def_id id) noexcept override {
-		return nullptr;
+		if(name == "civ_progress") {
+			return make_element_by_type<nation_westernization_progress_bar>(state, id);
+		} else if(name == "westernize_button") {
+			return make_element_by_type<unciv_reforms_westernize_button>(state, id);
+		} else {
+			return nullptr;
+		}
 	}
 };
 


### PR DESCRIPTION
Added the progress_bar base type, implemented progress bars for liferating and westernization. Also implemented the progress bar for rgo employment, which is actually a 10 frame image rather than a typical progress bar.