### PR TITLE
Implement issue options listbox in politics window 

### DIFF
--- a/src/culture/politics.cpp
+++ b/src/culture/politics.cpp
@@ -1,6 +1,7 @@
 
 #include "politics.hpp"
 #include "dcon_generated.hpp"
+#include "demographics.hpp"
 
 namespace politics {
 
@@ -20,6 +21,34 @@ float vote_total(sys::state& state, dcon::nation_id nation) {
 float get_weighted_vote_size(sys::state& state, dcon::nation_id nation, dcon::pop_id pop) {
     // TODO
     return 1.f * state.world.pop_get_size(pop);
+}
+
+float get_popular_support(sys::state& state, dcon::nation_id nation, dcon::issue_option_id issue_option) {
+    auto total = state.world.nation_get_demographics(nation, demographics::total);
+    if(total <= 0.f) {
+        return 0.f;
+    }
+    auto dkey = demographics::to_key(state, issue_option);
+    return state.world.nation_get_demographics(nation, dkey) / total;
+}
+
+float get_voter_support(sys::state& state, dcon::nation_id nation, dcon::issue_option_id issue_option) {
+    auto total = vote_total(state, nation);
+    if(total <= 0.f) {
+        return 0.f;
+    }
+    auto support = 0.f;
+    state.world.for_each_province([&](dcon::province_id province) {
+        if(nation == state.world.province_get_nation_from_province_ownership(province)) {
+            for(auto pop_loc : state.world.province_get_pop_location(province)) {
+                auto pop_id = pop_loc.get_pop();
+                auto vote_size = get_weighted_vote_size(state, nation, pop_id.id);
+                auto dkey = pop_demographics::to_key(state, issue_option);
+                support += state.world.pop_get_demographics(pop_id.id, dkey);
+            }
+        }
+    });
+    return support / total;
 }
 
 bool can_appoint_ruling_party(sys::state& state, dcon::nation_id nation) {

--- a/src/culture/politics.hpp
+++ b/src/culture/politics.hpp
@@ -7,6 +7,9 @@ namespace politics {
 
 float vote_total(sys::state& state, dcon::nation_id nation);
 float get_weighted_vote_size(sys::state& state, dcon::nation_id nation, dcon::pop_id pop);
+float get_popular_support(sys::state& state, dcon::nation_id nation, dcon::issue_option_id issue_option);
+float get_voter_support(sys::state& state, dcon::nation_id nation, dcon::issue_option_id issue_option);
+
 bool can_appoint_ruling_party(sys::state& state, dcon::nation_id nation);
 bool is_election_ongoing(sys::state& state, dcon::nation_id nation);
 bool has_elections(sys::state& state, dcon::nation_id nation);

--- a/src/gui/gui_common_elements.hpp
+++ b/src/gui/gui_common_elements.hpp
@@ -399,6 +399,49 @@ public:
 	}
 };
 
+class standard_nation_issue_option_text : public simple_text_element_base {
+protected:
+	dcon::nation_id nation_id{};
+	dcon::issue_option_id issue_option_id{};
+
+public:
+	virtual std::string get_text(sys::state& state) noexcept {
+		return "";
+	}
+
+	void on_update(sys::state& state) noexcept override {
+		set_text(state, get_text(state));
+	}
+
+	message_result set(sys::state& state, Cyto::Any& payload) noexcept override {
+		if(payload.holds_type<dcon::issue_option_id>()) {
+			issue_option_id = any_cast<dcon::issue_option_id>(payload);
+			on_update(state);
+			return message_result::consumed;
+		} else if(payload.holds_type<dcon::nation_id>()) {
+			nation_id = any_cast<dcon::nation_id>(payload);
+			on_update(state);
+			return message_result::consumed;
+		} else {
+			return message_result::unseen;
+		}
+	}
+};
+
+class issue_option_popular_support : public standard_nation_issue_option_text {
+public:
+	std::string get_text(sys::state& state) noexcept override {
+		return text::format_percentage(politics::get_popular_support(state, nation_id, issue_option_id), 3);
+	}
+};
+
+class issue_option_voter_support : public standard_nation_issue_option_text {
+public:
+	std::string get_text(sys::state& state) noexcept override {
+		return text::format_percentage(politics::get_voter_support(state, nation_id, issue_option_id), 3);
+	}
+};
+
 class standard_nation_multiline_text : public multiline_text_element_base {
 protected:
 	dcon::nation_id nation_id{};

--- a/src/gui/gui_element_types.cpp
+++ b/src/gui/gui_element_types.cpp
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <variant>
 #include <vector>
+#include "color.hpp"
 #include "culture.hpp"
 #include "dcon_generated.hpp"
 #include "demographics.hpp"
@@ -695,8 +696,7 @@ void piechart<T>::on_update(sys::state& state) noexcept {
 		size_t i = 0;
 		for(auto& [index, quant]: distribution) {
 			T t = T(index);
-			auto fat_id = dcon::fatten(state.world, t);
-			uint32_t color = fat_id.get_color();
+			uint32_t color = get_ui_color(state, t);
 			auto slice_count = std::min(size_t(quant * resolution), i + resolution);
 			for(size_t j = 0; j < slice_count; j++) {
 				spread[j + i] = t;
@@ -707,8 +707,7 @@ void piechart<T>::on_update(sys::state& state) noexcept {
 			i += slice_count;
 			last_t = t;
 		}
-		auto last_fat_id = dcon::fatten(state.world, last_t);
-		uint32_t last_color = last_fat_id.get_color();
+		uint32_t last_color = get_ui_color(state, last_t);
 		for(; i < resolution; i++) {
 			spread[i] = last_t;
 			colors[i * channels] = uint8_t(last_color & 0xFF);
@@ -739,6 +738,11 @@ void piechart<T>::update_tooltip(sys::state& state, int32_t x, int32_t y, text::
 	text::add_to_layout_box(contents, state, box, std::string_view(": "), text::text_color::white, text::substitution{});
 	text::add_to_layout_box(contents, state, box, std::string_view(text::format_percentage(percentage, 3)), text::text_color::white, text::substitution{});
 	text::close_layout_box(contents, box);
+}
+
+template<class T>
+uint32_t piechart<T>::get_ui_color(sys::state& state, dcon::issue_option_id id) {
+	return ogl::color_from_hash(uint32_t(id.index()));
 }
 
 template<class SrcT, class DemoT>

--- a/src/gui/gui_element_types.hpp
+++ b/src/gui/gui_element_types.hpp
@@ -389,6 +389,10 @@ public:
 		return dist <= radius ? message_result::consumed : message_result::unseen;
 	}
 	void update_tooltip(sys::state& state, int32_t x, int32_t y, text::columnar_layout& contents) noexcept override;
+	uint32_t get_ui_color(sys::state& state, dcon::issue_option_id id);
+	uint32_t get_ui_color(sys::state& state, T id) {
+		return dcon::fatten(state.world, id).get_color();
+	}
 };
 
 template<class SrcT, class DemoT>

--- a/src/gui/topbar_subwindows/gui_politics_window.hpp
+++ b/src/gui/topbar_subwindows/gui_politics_window.hpp
@@ -14,6 +14,7 @@
 #include "politics.hpp"
 #include "system_state.hpp"
 #include "text.hpp"
+#include <cstdint>
 #include <string_view>
 #include <vector>
 
@@ -24,6 +25,10 @@ enum class politics_window_tab : uint8_t {
 	movements = 0x1,
 	decisions = 0x2,
 	releasables = 0x3
+};
+
+enum class politics_issue_sort_order : uint8_t {
+	name, popular_support, voter_support
 };
 
 class politics_unciv_overlay : public standard_nation_icon {
@@ -345,6 +350,54 @@ public:
 	}
 };
 
+class politics_issue_support_item : public listbox_row_element_base<dcon::issue_option_id> {
+public:
+	std::unique_ptr<element_base> make_child(sys::state& state, std::string_view name, dcon::gui_def_id id) noexcept override {
+		if(name == "issue_name") {
+			return make_element_by_type<generic_name_text<dcon::issue_option_id>>(state, id);
+		} else if(name == "people_perc") {
+			return make_element_by_type<issue_option_popular_support>(state, id);
+		} else if(name == "voters_perc") {
+			return make_element_by_type<issue_option_voter_support>(state, id);
+		} else {
+			return nullptr;
+		}
+	}
+
+	void update(sys::state& state) noexcept override {
+		Cyto::Any issue_option_payload = content;
+		impl_set(state, issue_option_payload);
+	}
+};
+
+class politics_issue_support_listbox : public listbox_element_base<politics_issue_support_item, dcon::issue_option_id> {
+protected:
+	std::string_view get_row_element_name() override {
+        return "issue_option_window";
+    }
+
+public:
+	void on_create(sys::state& state) noexcept override {
+		listbox_element_base<politics_issue_support_item, dcon::issue_option_id>::on_create(state);
+		state.world.for_each_issue_option([&](dcon::issue_option_id io_id) {
+			row_contents.push_back(io_id);
+		});
+		update(state);
+	}
+};
+
+class politics_issue_sort_button : public button_element_base {
+public:
+	politics_issue_sort_order order = politics_issue_sort_order::name;
+
+	void button_action(sys::state& state) noexcept override {
+		if(parent) {
+			Cyto::Any payload = order;
+			parent->impl_get(state, payload);
+		}
+	}
+};
+
 class politics_window : public generic_tabbed_window<politics_window_tab> {
 private:
 	dcon::nation_id nation_id{};
@@ -353,6 +406,7 @@ private:
 	movements_window* movements_win = nullptr;
 	decision_window* decision_win = nullptr;
 	release_nation_window* release_nation_win = nullptr;
+	politics_issue_support_listbox* issues_listbox = nullptr;
 
 public:
 	void on_create(sys::state& state) noexcept override {
@@ -436,6 +490,22 @@ public:
 			return make_element_by_type<politics_upper_house_listbox>(state, id);
 		} else if(name == "unciv_overlay") {
 			return make_element_by_type<politics_unciv_overlay>(state, id);
+		} else if(name == "issue_listbox") {
+			auto ptr = make_element_by_type<politics_issue_support_listbox>(state, id);
+			issues_listbox = ptr.get();
+			return ptr;
+		} else if(name == "sort_by_issue_name") {
+			auto ptr = make_element_by_type<politics_issue_sort_button>(state, id);
+			ptr->order = politics_issue_sort_order::name;
+			return ptr;
+		} else if(name == "sort_by_people") {
+			auto ptr = make_element_by_type<politics_issue_sort_button>(state, id);
+			ptr->order = politics_issue_sort_order::popular_support;
+			return ptr;
+		} else if(name == "sort_by_voters") {
+			auto ptr = make_element_by_type<politics_issue_sort_button>(state, id);
+			ptr->order = politics_issue_sort_order::voter_support;
+			return ptr;
 		} else {
 			return nullptr;
 		}
@@ -487,6 +557,35 @@ public:
 			return message_result::consumed;
 		} else if(payload.holds_type<dcon::nation_id>()) {
 			payload.emplace<dcon::nation_id>(nation_id);
+			return message_result::consumed;
+		} else if(payload.holds_type<politics_issue_sort_order>()) {
+			auto enum_val = any_cast<politics_issue_sort_order>(payload);
+			switch(enum_val) {
+				case politics_issue_sort_order::name:
+					std::sort(issues_listbox->row_contents.begin(), issues_listbox->row_contents.end(), [&](dcon::issue_option_id a, dcon::issue_option_id b) {
+						auto a_name = text::get_name_as_string(state, dcon::fatten(state.world, a));
+						auto b_name = text::get_name_as_string(state, dcon::fatten(state.world, b));
+						return a_name < b_name;
+					});
+					issues_listbox->update(state);
+					break;
+				case politics_issue_sort_order::popular_support:
+					std::sort(issues_listbox->row_contents.begin(), issues_listbox->row_contents.end(), [&](dcon::issue_option_id a, dcon::issue_option_id b) {
+						auto a_support = politics::get_popular_support(state, nation_id, a);
+						auto b_support = politics::get_popular_support(state, nation_id, b);
+						return a_support > b_support;
+					});
+					issues_listbox->update(state);
+					break;
+				case politics_issue_sort_order::voter_support:
+					std::sort(issues_listbox->row_contents.begin(), issues_listbox->row_contents.end(), [&](dcon::issue_option_id a, dcon::issue_option_id b) {
+						auto a_support = politics::get_voter_support(state, nation_id, a);
+						auto b_support = politics::get_voter_support(state, nation_id, b);
+						return a_support > b_support;
+					});
+					issues_listbox->update(state);
+					break;
+			}
 			return message_result::consumed;
 		}
 		return message_result::unseen;

--- a/src/map/map_modes.cpp
+++ b/src/map/map_modes.cpp
@@ -1,5 +1,6 @@
 #include "map_modes.hpp"
 
+#include "color.hpp"
 #include "demographics.hpp"
 #include "system_state.hpp"
 #include "dcon_generated.hpp"
@@ -33,22 +34,6 @@ void set_political(sys::state& state) {
 	state.map_display.set_province_color(prov_color, mode::political);
 }
 
-// borrowed from http://www.burtleburtle.net/bob/hash/doobs.html
-inline constexpr uint32_t scramble(uint32_t color) {
-	uint32_t m1 = 0x1337CAFE;
-	uint32_t m2 = 0xDEADBEEF;
-	m1 -= m2; m1 -= color; m1 ^= (color >> 13);
-	m2 -= color; m2 -= m1; m2 ^= (m1 << 8);
-	color -= m1; color -= m2; color ^= (m2 >> 13);
-	m1 -= m2; m1 -= color; m1 ^= (color >> 12);
-	m2 -= color; m2 -= m1; m2 ^= (m1 << 16);
-	color -= m1; color -= m2; color ^= (m2 >> 5);
-	m1 -= m2; m1 -= color; m1 ^= (color >> 3);
-	m2 -= color; m2 -= m1; m2 ^= (m1 << 10);
-	color -= m1; color -= m2; color ^= (m2 >> 15);
-	return color;
-}
-
 void set_region(sys::state& state) {
 	uint32_t province_size = state.world.province_size() + 1;
 	uint32_t texture_size = province_size + 256 - province_size % 256;
@@ -58,7 +43,7 @@ void set_region(sys::state& state) {
 	state.world.for_each_province([&](dcon::province_id prov_id) {
 		auto fat_id = dcon::fatten(state.world, prov_id);
 		auto id = fat_id.get_abstract_state_membership();
-		uint32_t color = scramble(id.get_state().id.index());
+		uint32_t color = ogl::color_from_hash(id.get_state().id.index());
 		auto i = province::to_map_id(prov_id);
 		prov_color[i] = color;
 		prov_color[i + texture_size] = color;

--- a/src/ogl/color.hpp
+++ b/src/ogl/color.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <cstdint>
+
+namespace ogl {
+
+// borrowed from http://www.burtleburtle.net/bob/hash/doobs.html
+inline constexpr uint32_t color_from_hash(uint32_t color) {
+	uint32_t m1 = 0x1337CAFE;
+	uint32_t m2 = 0xDEADBEEF;
+	m1 -= m2; m1 -= color; m1 ^= (color >> 13);
+	m2 -= color; m2 -= m1; m2 ^= (m1 << 8);
+	color -= m1; color -= m2; color ^= (m2 >> 13);
+	m1 -= m2; m1 -= color; m1 ^= (color >> 12);
+	m2 -= color; m2 -= m1; m2 ^= (m1 << 16);
+	color -= m1; color -= m2; color ^= (m2 >> 5);
+	m1 -= m2; m1 -= color; m1 ^= (color >> 3);
+	m2 -= color; m2 -= m1; m2 ^= (m1 << 10);
+	color -= m1; color -= m2; color ^= (m2 >> 15);
+	return color;
+}
+
+}


### PR DESCRIPTION
This should finish off the left bar of the politics menu.
Note: this listbox is only visible for civilized nations.
Also, set up the pie charts to generate colors for issue options.