### PR TITLE
Squash some bugs, formatting tweaks

### DIFF
--- a/src/culture/politics.cpp
+++ b/src/culture/politics.cpp
@@ -114,9 +114,10 @@ bool issue_is_selected(sys::state& state, dcon::nation_id nation, dcon::issue_op
 
 bool can_enact_political_reform(sys::state& state, dcon::nation_id nation, dcon::issue_option_id issue_option) {
     auto issue = state.world.issue_option_get_parent_issue(issue_option);
+    auto current = state.world.nation_get_issues(nation, issue.id).id;
     auto allow = state.world.issue_option_get_allow(issue_option);
     if(
-        (!state.world.issue_get_is_next_step_only(issue.id) || issue.id.index() + 1 == issue_option.index() || issue.id.index() - 1 == issue_option.index())
+        (!state.world.issue_get_is_next_step_only(issue.id) || current.index() + 1 == issue_option.index() || current.index() - 1 == issue_option.index())
         &&
         (!allow || trigger::evaluate_trigger(state, allow, trigger::to_generic(nation), trigger::to_generic(nation), 0))
         ) {
@@ -124,7 +125,7 @@ bool can_enact_political_reform(sys::state& state, dcon::nation_id nation, dcon:
         float total = 0.0f;
         for(uint32_t icounter = state.world.ideology_size(); icounter-- > 0;) {
             dcon::ideology_id iid{ dcon::ideology_id::value_base_t(icounter) };
-            auto condition = allow.index() > issue.id.index() ? state.world.ideology_get_add_political_reform(iid) : state.world.ideology_get_remove_political_reform(iid);
+            auto condition = issue_option.index() > current.index() ? state.world.ideology_get_add_political_reform(iid) : state.world.ideology_get_remove_political_reform(iid);
             auto upperhouse_weight = 0.01f * state.world.nation_get_upper_house(nation, iid);
             if(condition && upperhouse_weight > 0.0f)
                 total += upperhouse_weight * trigger::evaluate_additive_modifier(state, condition, trigger::to_generic(nation), trigger::to_generic(nation), 0);
@@ -137,9 +138,10 @@ bool can_enact_political_reform(sys::state& state, dcon::nation_id nation, dcon:
 
 bool can_enact_social_reform(sys::state& state, dcon::nation_id n, dcon::issue_option_id o) {
     auto issue = state.world.issue_option_get_parent_issue(o);
+    auto current = state.world.nation_get_issues(n, issue.id).id;
     auto allow = state.world.issue_option_get_allow(o);
     if(
-        (!state.world.issue_get_is_next_step_only(issue.id) || issue.id.index() + 1 == o.index() || issue.id.index() - 1 == o.index())
+        (!state.world.issue_get_is_next_step_only(issue.id) || current.index() + 1 == o.index() || current.index() - 1 == o.index())
         &&
         (!allow || trigger::evaluate_trigger(state, allow, trigger::to_generic(n), trigger::to_generic(n), 0))
         ) {
@@ -147,7 +149,7 @@ bool can_enact_social_reform(sys::state& state, dcon::nation_id n, dcon::issue_o
         float total = 0.0f;
         for(uint32_t icounter = state.world.ideology_size(); icounter-- > 0;) {
             dcon::ideology_id iid{ dcon::ideology_id::value_base_t(icounter) };
-            auto condition = o.index() > issue.id.index() ? state.world.ideology_get_add_social_reform(iid) : state.world.ideology_get_remove_social_reform(iid);
+            auto condition = o.index() > current.index() ? state.world.ideology_get_add_social_reform(iid) : state.world.ideology_get_remove_social_reform(iid);
             auto upperhouse_weight = 0.01f * state.world.nation_get_upper_house(n, iid);
             if(condition && upperhouse_weight > 0.0f)
                 total += upperhouse_weight * trigger::evaluate_additive_modifier(state, condition, trigger::to_generic(n), trigger::to_generic(n), 0);
@@ -160,12 +162,13 @@ bool can_enact_social_reform(sys::state& state, dcon::nation_id n, dcon::issue_o
 
 bool can_enact_military_reform(sys::state& state, dcon::nation_id n, dcon::reform_option_id o) {
     auto reform = state.world.reform_option_get_parent_reform(o);
+    auto current = state.world.nation_get_reforms(n, reform.id).id;
     auto allow = state.world.reform_option_get_allow(o);
     auto stored_rp = state.world.nation_get_research_points(n);
     if(
-        o.index() > reform.id.index()
+        o.index() > current.index()
         &&
-        (!state.world.reform_get_is_next_step_only(reform.id) || reform.id.index() + 1 == o.index())
+        (!state.world.reform_get_is_next_step_only(reform.id) || current.index() + 1 == o.index())
         &&
         (!allow || trigger::evaluate_trigger(state, allow, trigger::to_generic(n), trigger::to_generic(n), 0))
         ) {
@@ -192,12 +195,13 @@ bool can_enact_military_reform(sys::state& state, dcon::nation_id n, dcon::refor
 
 bool can_enact_economic_reform(sys::state& state, dcon::nation_id n, dcon::reform_option_id o) {
     auto reform = state.world.reform_option_get_parent_reform(o);
+    auto current = state.world.nation_get_reforms(n, reform.id).id;
     auto allow = state.world.reform_option_get_allow(o);
     auto stored_rp = state.world.nation_get_research_points(n);
     if(
-        o.index() > reform.id.index()
+        o.index() > current.index()
         &&
-        (!state.world.reform_get_is_next_step_only(reform.id) || reform.id.index() + 1 == o.index())
+        (!state.world.reform_get_is_next_step_only(reform.id) || current.index() + 1 == o.index())
         &&
         (!allow || trigger::evaluate_trigger(state, allow, trigger::to_generic(n), trigger::to_generic(n), 0))
         ) {

--- a/src/gui/gui_common_elements.hpp
+++ b/src/gui/gui_common_elements.hpp
@@ -841,7 +841,7 @@ class nation_infamy_text : public standard_nation_text {
 public:
 	std::string get_text(sys::state& state) noexcept override {
 		auto fat_id = dcon::fatten(state.world, nation_id);
-		return text::format_float(fat_id.get_infamy(), 3);
+		return text::format_float(fat_id.get_infamy(), 2);
 	}
 };
 
@@ -871,7 +871,7 @@ class nation_daily_research_points_text : public standard_nation_text {
 public:
 	std::string get_text(sys::state& state) noexcept override {
 		auto points = nations::daily_research_points(state, nation_id);
-		return text::format_float(points, 3);
+		return text::format_float(points, 2);
 	}
 };
 
@@ -879,7 +879,7 @@ class nation_research_points_text : public standard_nation_text {
 public:
 	std::string get_text(sys::state& state) noexcept override {
 		auto points = state.world.nation_get_research_points(nation_id);
-		return std::to_string(int32_t(points));
+		return text::format_float(points, 1);
 	}
 };
 
@@ -887,7 +887,7 @@ class nation_suppression_points_text : public standard_nation_text {
 public:
 	std::string get_text(sys::state& state) noexcept override {
 		auto points = nations::suppression_points(state, nation_id);
-		return text::format_float(points, 3);
+		return text::format_float(points, 2);
 	}
 };
 
@@ -904,7 +904,7 @@ class nation_diplomatic_points_text : public standard_nation_text {
 public:
 	std::string get_text(sys::state& state) noexcept override {
 		auto points = nations::diplomatic_points(state, nation_id);
-		return text::format_float(points, 1);
+		return text::format_float(points, 0);
 	}
 };
 
@@ -943,7 +943,7 @@ class nation_leadership_points_text : public standard_nation_text {
 public:
 	std::string get_text(sys::state& state) noexcept override {
 		auto points = nations::leadership_points(state, nation_id);
-		return text::format_float(points, 2);
+		return text::format_float(points, 1);
 	}
 };
 

--- a/src/gui/gui_element_types.cpp
+++ b/src/gui/gui_element_types.cpp
@@ -704,8 +704,10 @@ void piechart<T>::on_update(sys::state& state) noexcept {
 				colors[(j + i) * channels + 1] = uint8_t(color >> 8 & 0xFF);
 				colors[(j + i) * channels + 2] = uint8_t(color >> 16 & 0xFF);
 			}
-			i += slice_count;
-			last_t = t;
+			if(slice_count) {
+				i += slice_count;
+				last_t = t;
+			}
 		}
 		uint32_t last_color = ogl::get_ui_color(state, last_t);
 		for(; i < resolution; i++) {
@@ -735,8 +737,9 @@ void piechart<T>::update_tooltip(sys::state& state, int32_t x, int32_t y, text::
 	auto box = text::open_layout_box(contents, 0);
 
 	text::add_to_layout_box(contents, state, box, fat_t.get_name(), text::substitution_map{});
-	text::add_to_layout_box(contents, state, box, std::string_view(": "), text::text_color::white, text::substitution{});
-	text::add_to_layout_box(contents, state, box, std::string_view(text::format_percentage(percentage, 3)), text::text_color::white, text::substitution{});
+	text::add_to_layout_box(contents, state, box, std::string(":"), text::text_color::white);
+	text::add_space_to_layout_box(contents, state, box);
+	text::add_to_layout_box(contents, state, box, text::format_percentage(percentage, 1), text::text_color::white);
 	text::close_layout_box(contents, box);
 }
 

--- a/src/gui/topbar_subwindows/gui_politics_window.hpp
+++ b/src/gui/topbar_subwindows/gui_politics_window.hpp
@@ -345,8 +345,9 @@ public:
 				auto box = text::open_layout_box(contents);
 				auto election_start_date = politics::next_election_date(state, nation_id);
 				text::add_to_layout_box(contents, state, box, k->second, text::substitution_map{ });
-				text::add_to_layout_box(contents, state, box, std::string_view(": "), text::text_color::black, text::substitution{});
-				text::add_to_layout_box(contents, state, box, std::string_view(text::date_to_string(state, election_start_date)), text::text_color::black, text::substitution{});
+				text::add_to_layout_box(contents, state, box, std::string(":"), text::text_color::black);
+				text::add_space_to_layout_box(contents, state, box);
+				text::add_to_layout_box(contents, state, box, text::date_to_string(state, election_start_date), text::text_color::black);
 				text::close_layout_box(contents, box);
 			}
 		}

--- a/src/text/text.cpp
+++ b/src/text/text.cpp
@@ -637,7 +637,7 @@ namespace text {
 		char buffer[200] = { 0 };
 		double dval = double(num);
 
-		constexpr static double mag[] = { 1.0, 1'000.0, 1'000'000'000.0, 1'000'000'000'000.0, 1'000'000'000'000'000.0, 1'000'000'000'000'000'000.0, 1'000'000'000'000'000'000'000.0 };
+		constexpr static double mag[] = { 1.0, 1'000.0, 1'000'000.0, 1'000'000'000.0, 1'000'000'000'000.0, 1'000'000'000'000'000.0, 1'000'000'000'000'000'000.0 };
 		constexpr static char const* sufx[] = { "%.0f", "%.2fK", "%.2fM", "%.2fB", "%.2fT", "%.2fP", "%.2fZ" };
 
 		for(size_t i = std::extent_v<decltype(mag)>; i-- > 0; ) {


### PR DESCRIPTION
Fixed the following: text::prettify not handling the millions place correctly, reforms not registering as enactable if they are a get-next-only reform type, cultures sneaking into piecharts where they don't belong.