### PR TITLE
unit_start_experience modifier, print scope types for easier debugging, make national focuses intake modifier stuff

### DIFF
--- a/src/gamestate/dcon_generated.txt
+++ b/src/gamestate/dcon_generated.txt
@@ -3411,7 +3411,7 @@ object {
 	storage_type{ contiguous }
 	size{ 64 }
 	tag{ scenario }
-
+	
 	property{
 		name{ name }
 		type{ text_sequence_id }
@@ -3465,6 +3465,11 @@ object {
 	property{
 		name{ production_focus }
 		type{array{commodity_id}{float}}
+		tag{ scenario }
+	}
+	property{
+		name{ modifier }
+		type{ modifier_id }
 		tag{ scenario }
 	}
 }

--- a/src/gamestate/modifiers.hpp
+++ b/src/gamestate/modifiers.hpp
@@ -184,8 +184,9 @@ constexpr inline dcon::national_modifier_value plurality{121};
 constexpr inline dcon::national_modifier_value colonial_prestige{122};
 constexpr inline dcon::national_modifier_value permanent_prestige{123};
 constexpr inline dcon::national_modifier_value prestige_modifier{124};
+constexpr inline dcon::national_modifier_value unit_start_experience{125};
 
-constexpr inline uint32_t count = 126;
+constexpr inline uint32_t count = 127;
 }
 
 

--- a/src/gamestate/modifiers.hpp
+++ b/src/gamestate/modifiers.hpp
@@ -184,9 +184,8 @@ constexpr inline dcon::national_modifier_value plurality{121};
 constexpr inline dcon::national_modifier_value colonial_prestige{122};
 constexpr inline dcon::national_modifier_value permanent_prestige{123};
 constexpr inline dcon::national_modifier_value prestige_modifier{124};
-constexpr inline dcon::national_modifier_value unit_start_experience{125};
 
-constexpr inline uint32_t count = 127;
+constexpr inline uint32_t count = 126;
 }
 
 

--- a/src/gui/gui_trigger_tooltips.cpp
+++ b/src/gui/gui_trigger_tooltips.cpp
@@ -5947,16 +5947,6 @@ void tf_variable_reform_group_name_province(TRIGGER_DISPLAY_PARAMS) {
 // non-vanilla triggers
 //
 
-void tf_is_primary_culture_nation(TRIGGER_DISPLAY_PARAMS) {
-	auto box = text::open_layout_box(layout, indentation);
-	make_condition(tval, ws, layout, primary_slot, this_slot, from_slot, indentation, show_condition, box);
-	if(this_slot != -1)
-		display_with_comparison(tval[0], text::produce_simple_string(ws, "culture"), text::produce_simple_string(ws, ws.world.culture_get_name(ws.world.nation_get_primary_culture(trigger::to_nation(this_slot)))), ws, layout, box);
-	else
-		display_with_comparison(tval[0], text::produce_simple_string(ws, "culture"), text::produce_simple_string(ws, "this_nation_primary_culture"), ws, layout, box);
-	text::close_layout_box(layout, box);
-}
-
 void tf_variable_pop_type_name_nation(TRIGGER_DISPLAY_PARAMS) {
 	auto box = text::open_layout_box(layout, indentation);
 	make_condition(tval, ws, layout, primary_slot, this_slot, from_slot, indentation, show_condition, box);

--- a/src/gui/gui_trigger_tooltips.cpp
+++ b/src/gui/gui_trigger_tooltips.cpp
@@ -5944,12 +5944,16 @@ void tf_variable_reform_group_name_province(TRIGGER_DISPLAY_PARAMS) {
 	text::close_layout_box(layout, box);
 }
 //
-// non-vanilla
+// non-vanilla triggers
 //
-void tf_is_accepted_culture_nation(TRIGGER_DISPLAY_PARAMS) {
+
+void tf_is_primary_culture_nation(TRIGGER_DISPLAY_PARAMS) {
 	auto box = text::open_layout_box(layout, indentation);
 	make_condition(tval, ws, layout, primary_slot, this_slot, from_slot, indentation, show_condition, box);
-	display_with_comparison(tval[0], text::produce_simple_string(ws, "dominant_culture"), text::produce_simple_string(ws, "an_accepted"), ws, layout, box);
+	if(this_slot != -1)
+		display_with_comparison(tval[0], text::produce_simple_string(ws, "culture"), text::produce_simple_string(ws, ws.world.culture_get_name(ws.world.nation_get_primary_culture(trigger::to_nation(this_slot)))), ws, layout, box);
+	else
+		display_with_comparison(tval[0], text::produce_simple_string(ws, "culture"), text::produce_simple_string(ws, "this_nation_primary_culture"), ws, layout, box);
 	text::close_layout_box(layout, box);
 }
 
@@ -6687,7 +6691,6 @@ constexpr inline void(* trigger_functions[])(TRIGGER_DISPLAY_PARAMS) = {
 		tf_variable_reform_group_name_province, //constexpr inline uint16_t variable_reform_group_name_province = 0x0274;
 		tf_variable_reform_group_name_pop, //constexpr inline uint16_t variable_reform_group_name_pop = 0x0275;
 		// non-vanilla triggers
-		tf_is_accepted_culture_nation, //constexpr inline uint16_t is_accepted_culture_nation = 0x0276;
 
 		//
 		// scopes

--- a/src/gui/gui_trigger_tooltips.cpp
+++ b/src/gui/gui_trigger_tooltips.cpp
@@ -5943,6 +5943,16 @@ void tf_variable_reform_group_name_province(TRIGGER_DISPLAY_PARAMS) {
 	display_with_comparison(tval[0], text::produce_simple_string(ws, ws.world.reform_get_name(trigger::payload(tval[1]).ref_id)), text::produce_simple_string(ws, ws.world.reform_option_get_name(trigger::payload(tval[2]).ropt_id)), ws, layout, box);
 	text::close_layout_box(layout, box);
 }
+//
+// non-vanilla
+//
+void tf_is_accepted_culture_nation(TRIGGER_DISPLAY_PARAMS) {
+	auto box = text::open_layout_box(layout, indentation);
+	make_condition(tval, ws, layout, primary_slot, this_slot, from_slot, indentation, show_condition, box);
+	display_with_comparison(tval[0], text::produce_simple_string(ws, "dominant_culture"), text::produce_simple_string(ws, "an_accepted"), ws, layout, box);
+	text::close_layout_box(layout, box);
+}
+
 void tf_variable_pop_type_name_nation(TRIGGER_DISPLAY_PARAMS) {
 	auto box = text::open_layout_box(layout, indentation);
 	make_condition(tval, ws, layout, primary_slot, this_slot, from_slot, indentation, show_condition, box);
@@ -6676,6 +6686,8 @@ constexpr inline void(* trigger_functions[])(TRIGGER_DISPLAY_PARAMS) = {
 		tf_variable_reform_group_name_state, //constexpr inline uint16_t variable_reform_group_name_state = 0x0273;
 		tf_variable_reform_group_name_province, //constexpr inline uint16_t variable_reform_group_name_province = 0x0274;
 		tf_variable_reform_group_name_pop, //constexpr inline uint16_t variable_reform_group_name_pop = 0x0275;
+		// non-vanilla triggers
+		tf_is_accepted_culture_nation, //constexpr inline uint16_t is_accepted_culture_nation = 0x0276;
 
 		//
 		// scopes

--- a/src/parsing/nations_parsing.cpp
+++ b/src/parsing/nations_parsing.cpp
@@ -755,11 +755,26 @@ dcon::trigger_key make_focus_limit(token_generator& gen, error_handler& err, nat
 }
 void make_focus(std::string_view name, token_generator& gen, error_handler& err, national_focus_context& context) {
 	auto name_id = text::find_or_add_key(context.outer_context.state, name);
+	
 	auto new_focus = context.outer_context.state.world.create_national_focus();
+	context.id = new_focus;
+	auto national_focus = parse_national_focus(gen, err, context);
+
+	// Fill the national-focus part
 	context.outer_context.state.world.national_focus_set_name(new_focus, name_id);
 	context.outer_context.state.world.national_focus_set_type(new_focus, uint8_t(context.type));
-	context.id = new_focus;
-	parse_national_focus(gen, err, context);
+
+	// And the attached modifier with this national focus...
+	auto new_modifier = context.outer_context.state.world.create_modifier();
+	context.outer_context.state.world.modifier_set_icon(new_modifier, uint8_t(national_focus.icon_index));
+	context.outer_context.state.world.modifier_set_name(new_modifier, name_id);
+	context.outer_context.state.world.modifier_set_province_values(new_modifier, national_focus.peek_province_mod());
+	context.outer_context.state.world.modifier_set_national_values(new_modifier, national_focus.peek_national_mod());
+	context.outer_context.map_of_modifiers.insert_or_assign(std::string(name), new_modifier);
+
+	// Attach to focus
+	context.outer_context.state.world.national_focus_set_modifier(new_focus, new_modifier);
+
 }
 void make_focus_group(std::string_view name, token_generator& gen, error_handler& err, scenario_building_context& context) {
 	nations::focus_type t = nations::focus_type::unknown;

--- a/src/parsing/parser_defs.txt
+++ b/src/parsing/parser_defs.txt
@@ -384,6 +384,7 @@ modifier_base
 	seperatism                                value      float            member_fn
 	plurality                                 value      float            member_fn
 	colonial_prestige                         value      float            member_fn
+	unit_start_experience                     value      float            member_fn
 
 int_vector
 	#free          value      int              member_fn
@@ -691,8 +692,7 @@ country_file
 	graphical_culture   value     none                  discard
 	party          extern     make_party                discard
 	unit_names     group      unit_names_collection     member
-	proletarian_dictatorship  group      none           discard
-	fascist_dictatorship      group      none           discard
+	#any           group      color_from_3i             member_fn
 
 pv_party_loyalty
 	ideology          value          text               member_fn

--- a/src/parsing/parser_defs.txt
+++ b/src/parsing/parser_defs.txt
@@ -385,6 +385,8 @@ modifier_base
 	plurality                                 value      float            member_fn
 	colonial_prestige                         value      float            member_fn
 	unit_start_experience                     value      float            member_fn
+	own_provinces                             value      bool             discard
+	outliner_show_as_percent                  value      bool             discard
 
 int_vector
 	#free          value      int              member_fn
@@ -1497,16 +1499,13 @@ issue_option_body
 	on_execute                group        on_execute_body  member_fn
 
 national_focus
+	#base			modifier_base
 	railroads                 value        float            member_fn
-	icon                      value        int              member_fn
-	limit                     extern       make_focus_limit member_fn
-	own_provinces             value        bool             discard
-	has_flashpoint            value        bool             member_fn
 	flashpoint_tension        value        float            member_fn
-	outliner_show_as_percent  value        bool             discard
+	limit                     extern       make_focus_limit member_fn
+	has_flashpoint            value        bool             member_fn
 	ideology                  value        text             member_fn
 	loyalty_value             value        float            member_fn
-	immigrant_attract         value        float            member_fn
 	#any                      value        float            member_fn
 
 focus_group

--- a/src/parsing/parsers_declarations.cpp
+++ b/src/parsing/parsers_declarations.cpp
@@ -2273,6 +2273,15 @@ void country_file::color(color_from_3i cvalue, error_handler& err, int32_t line,
 	context.outer_context.state.world.national_identity_set_color(context.id, cvalue.value);
 }
 
+void country_file::any_group(std::string_view name, color_from_3i, error_handler& err, int32_t line, country_file_context& context) {
+	if(auto it = context.outer_context.map_of_governments.find(std::string(name)); it != context.outer_context.map_of_governments.end()) {
+		// TODO: Do something with country government types stuff
+		// I assume this is used to change colours of countries?
+	} else {
+		err.accumulated_errors += "Invalid government type " + std::string(name) + " (" + err.file_name + " line " + std::to_string(line) + ")\n";
+	}
+}
+
 void generic_event::title(association_type, std::string_view value, error_handler& err, int32_t line, event_building_context& context) {
 	title_ = text::find_or_add_key(context.outer_context.state, value);
 }

--- a/src/parsing/parsers_declarations.cpp
+++ b/src/parsing/parsers_declarations.cpp
@@ -1213,6 +1213,10 @@ void national_focus::any_value(std::string_view label, association_type, float v
 	}
 }
 
+void national_focus::finish(national_focus_context&) {
+	
+}
+
 void main_pop_type_file::promotion_chance(dcon::value_modifier_key value, error_handler& err, int32_t line, scenario_building_context& context) {
 	context.state.culture_definitions.promotion_chance = value;
 }

--- a/src/parsing/parsers_declarations.hpp
+++ b/src/parsing/parsers_declarations.hpp
@@ -707,7 +707,11 @@ namespace parsers {
 		MOD_NAT_FUNCTION(seperatism)
 		MOD_NAT_FUNCTION(plurality)
 		MOD_NAT_FUNCTION(colonial_prestige)
-		MOD_NAT_FUNCTION(unit_start_experience)
+
+		void unit_start_experience(association_type type, float v, error_handler& err, int32_t line, T& context) {
+			land_unit_start_experience(type, v, err, line, context);
+			naval_unit_start_experience(type, v, err, line, context);
+		}
 
 		template<typename T>
 		void finish(T& context) { }

--- a/src/parsing/parsers_declarations.hpp
+++ b/src/parsing/parsers_declarations.hpp
@@ -1693,8 +1693,7 @@ namespace parsers {
 		::nations::focus_type type = ::nations::focus_type::unknown;
 	};
 
-	struct national_focus {
-		void finish(national_focus_context&) { }
+	struct national_focus : public modifier_base {
 		void railroads(association_type, float value, error_handler& err, int32_t line, national_focus_context& context);
 		void icon(association_type, int32_t value, error_handler& err, int32_t line, national_focus_context& context);
 		void limit(dcon::trigger_key value, error_handler& err, int32_t line, national_focus_context& context);
@@ -1704,6 +1703,7 @@ namespace parsers {
 		void loyalty_value(association_type, float value, error_handler& err, int32_t line, national_focus_context& context);
 		void immigrant_attract(association_type, float value, error_handler& err, int32_t line, national_focus_context& context);
 		void any_value(std::string_view label, association_type, float value, error_handler& err, int32_t line, national_focus_context& context);
+		void finish(national_focus_context&);
 	};
 
 	struct focus_group {

--- a/src/parsing/parsers_declarations.hpp
+++ b/src/parsing/parsers_declarations.hpp
@@ -708,6 +708,7 @@ namespace parsers {
 		MOD_NAT_FUNCTION(plurality)
 		MOD_NAT_FUNCTION(colonial_prestige)
 
+		template<typename T>
 		void unit_start_experience(association_type type, float v, error_handler& err, int32_t line, T& context) {
 			land_unit_start_experience(type, v, err, line, context);
 			naval_unit_start_experience(type, v, err, line, context);

--- a/src/parsing/parsers_declarations.hpp
+++ b/src/parsing/parsers_declarations.hpp
@@ -707,6 +707,7 @@ namespace parsers {
 		MOD_NAT_FUNCTION(seperatism)
 		MOD_NAT_FUNCTION(plurality)
 		MOD_NAT_FUNCTION(colonial_prestige)
+		MOD_NAT_FUNCTION(unit_start_experience)
 
 		template<typename T>
 		void finish(T& context) { }
@@ -1321,6 +1322,7 @@ namespace parsers {
 	struct country_file {
 		void color(color_from_3i cvalue, error_handler& err, int32_t line, country_file_context& context);
 		unit_names_collection unit_names;
+		void any_group(std::string_view name, color_from_3i, error_handler& err, int32_t line, country_file_context& context);
 		void finish(country_file_context&) { }
 	};
 

--- a/src/parsing/trigger_parsing.cpp
+++ b/src/parsing/trigger_parsing.cpp
@@ -4,6 +4,23 @@
 #include <algorithm>
 
 namespace parsers {
+std::string to_string(slot_contents v) {
+	switch(v) {
+	case slot_contents::empty:
+		return "empty";
+	case slot_contents::province:
+		return "province";
+	case slot_contents::state:
+		return "state";
+	case slot_contents::pop:
+		return "pop";
+	case slot_contents::nation:
+		return "nation";
+	case slot_contents::rebel:
+		return "rebel";
+	}
+	return "unknown";
+}
 
 void tr_scope_and(token_generator& gen, error_handler& err, trigger_building_context& context) {
 	context.compiled_trigger.push_back(uint16_t(trigger::generic_scope));

--- a/src/parsing/trigger_parsing.cpp
+++ b/src/parsing/trigger_parsing.cpp
@@ -4,24 +4,6 @@
 #include <algorithm>
 
 namespace parsers {
-std::string to_string(slot_contents v) {
-	switch(v) {
-	case slot_contents::empty:
-		return "empty";
-	case slot_contents::province:
-		return "province";
-	case slot_contents::state:
-		return "state";
-	case slot_contents::pop:
-		return "pop";
-	case slot_contents::nation:
-		return "nation";
-	case slot_contents::rebel:
-		return "rebel";
-	}
-	return "unknown";
-}
-
 void tr_scope_and(token_generator& gen, error_handler& err, trigger_building_context& context) {
 	context.compiled_trigger.push_back(uint16_t(trigger::generic_scope));
 	context.compiled_trigger.push_back(uint16_t(1));
@@ -61,7 +43,7 @@ void tr_scope_any_neighbor_province(token_generator& gen, error_handler& err, tr
 		context.compiled_trigger[payload_size_offset] = uint16_t(context.compiled_trigger.size() - payload_size_offset);
 	} else {
 		gen.discard_group();
-		err.accumulated_errors += "any_neighbor_province trigger scope used in an incorrect scope type (" + err.file_name + ")\n";
+		err.accumulated_errors += "any_neighbor_province trigger scope used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ")\n";
 		return;
 	}
 }
@@ -72,7 +54,7 @@ void tr_scope_any_neighbor_country(token_generator& gen, error_handler& err, tri
 		context.compiled_trigger.push_back(uint16_t(trigger::x_neighbor_country_scope_pop | trigger::is_existence_scope));
 	} else {
 		gen.discard_group();
-		err.accumulated_errors += "any_neighbor_country trigger scope used in an incorrect scope type (" + err.file_name + ")\n";
+		err.accumulated_errors += "any_neighbor_country trigger scope used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ")\n";
 		return;
 	}
 	context.compiled_trigger.push_back(uint16_t(1));
@@ -92,7 +74,7 @@ void tr_scope_war_countries(token_generator& gen, error_handler& err, trigger_bu
 		context.compiled_trigger.push_back(uint16_t(trigger::x_war_countries_scope_pop));
 	} else {
 		gen.discard_group();
-		err.accumulated_errors += "war_countries trigger scope used in an incorrect scope type (" + err.file_name + ")\n";
+		err.accumulated_errors += "war_countries trigger scope used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ")\n";
 		return;
 	}
 	context.compiled_trigger.push_back(uint16_t(1));
@@ -124,7 +106,7 @@ void tr_scope_any_owned_province(token_generator& gen, error_handler& err, trigg
 		context.compiled_trigger.push_back(uint16_t(trigger::x_owned_province_scope_state | trigger::is_existence_scope));
 	} else {
 		gen.discard_group();
-		err.accumulated_errors += "any_owned_province trigger scope used in an incorrect scope type (" + err.file_name + ")\n";
+		err.accumulated_errors += "any_owned_province trigger scope used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ")\n";
 		return;
 	}
 	context.compiled_trigger.push_back(uint16_t(1));
@@ -144,7 +126,7 @@ void tr_scope_any_core(token_generator& gen, error_handler& err, trigger_buildin
 		context.compiled_trigger.push_back(uint16_t(trigger::x_core_scope_province | trigger::is_existence_scope));
 	} else {
 		gen.discard_group();
-		err.accumulated_errors += "any_core trigger scope used in an incorrect scope type (" + err.file_name + ")\n";
+		err.accumulated_errors += "any_core trigger scope used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ")\n";
 		return;
 	}
 	context.compiled_trigger.push_back(uint16_t(1));
@@ -164,7 +146,7 @@ void tr_scope_all_core(token_generator& gen, error_handler& err, trigger_buildin
 		context.compiled_trigger.push_back(uint16_t(trigger::x_core_scope_province));
 	} else {
 		gen.discard_group();
-		err.accumulated_errors += "all_core trigger scope used in an incorrect scope type (" + err.file_name + ")\n";
+		err.accumulated_errors += "all_core trigger scope used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ")\n";
 		return;
 	}
 	context.compiled_trigger.push_back(uint16_t(1));
@@ -190,7 +172,7 @@ void tr_scope_any_state(token_generator& gen, error_handler& err, trigger_buildi
 		context.compiled_trigger[payload_size_offset] = uint16_t(context.compiled_trigger.size() - payload_size_offset);
 	} else {
 		gen.discard_group();
-		err.accumulated_errors += "any_state trigger scope used in an incorrect scope type (" + err.file_name + ")\n";
+		err.accumulated_errors += "any_state trigger scope used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ")\n";
 		return;
 	}
 }
@@ -205,7 +187,7 @@ void tr_scope_any_substate(token_generator& gen, error_handler& err, trigger_bui
 		context.compiled_trigger[payload_size_offset] = uint16_t(context.compiled_trigger.size() - payload_size_offset);
 	} else {
 		gen.discard_group();
-		err.accumulated_errors += "any_substate trigger scope used in an incorrect scope type (" + err.file_name + ")\n";
+		err.accumulated_errors += "any_substate trigger scope used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ")\n";
 		return;
 	}
 }
@@ -220,7 +202,7 @@ void tr_scope_any_sphere_member(token_generator& gen, error_handler& err, trigge
 		context.compiled_trigger[payload_size_offset] = uint16_t(context.compiled_trigger.size() - payload_size_offset);
 	} else {
 		gen.discard_group();
-		err.accumulated_errors += "any_sphere_member trigger scope used in an incorrect scope type (" + err.file_name + ")\n";
+		err.accumulated_errors += "any_sphere_member trigger scope used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ")\n";
 		return;
 	}
 }
@@ -233,7 +215,7 @@ void tr_scope_any_pop(token_generator& gen, error_handler& err, trigger_building
 		context.compiled_trigger.push_back(uint16_t(trigger::x_pop_scope_state | trigger::is_existence_scope));
 	} else {
 		gen.discard_group();
-		err.accumulated_errors += "any_pop trigger scope used in an incorrect scope type (" + err.file_name + ")\n";
+		err.accumulated_errors += "any_pop trigger scope used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ")\n";
 		return;
 	}
 	context.compiled_trigger.push_back(uint16_t(1));
@@ -253,7 +235,7 @@ void tr_scope_owner(token_generator& gen, error_handler& err, trigger_building_c
 		context.compiled_trigger.push_back(uint16_t(trigger::owner_scope_state));
 	} else {
 		gen.discard_group();
-		err.accumulated_errors += "owner trigger scope used in an incorrect scope type (" + err.file_name + ")\n";
+		err.accumulated_errors += "owner trigger scope used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ")\n";
 		return;
 	}
 	context.compiled_trigger.push_back(uint16_t(1));
@@ -271,7 +253,7 @@ void tr_scope_controller(token_generator& gen, error_handler& err, trigger_build
 		context.compiled_trigger.push_back(uint16_t(trigger::controller_scope));
 	} else {
 		gen.discard_group();
-		err.accumulated_errors += "controller trigger scope used in an incorrect scope type (" + err.file_name + ")\n";
+		err.accumulated_errors += "controller trigger scope used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ")\n";
 		return;
 	}
 	context.compiled_trigger.push_back(uint16_t(1));
@@ -288,7 +270,7 @@ void tr_scope_location(token_generator& gen, error_handler& err, trigger_buildin
 		context.compiled_trigger.push_back(uint16_t(trigger::location_scope));
 	} else {
 		gen.discard_group();
-		err.accumulated_errors += "location trigger scope used in an incorrect scope type (" + err.file_name + ")\n";
+		err.accumulated_errors += "location trigger scope used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ")\n";
 		return;
 	}
 	context.compiled_trigger.push_back(uint16_t(1));
@@ -311,7 +293,7 @@ void tr_scope_country(token_generator& gen, error_handler& err, trigger_building
 		context.compiled_trigger.push_back(uint16_t(trigger::country_scope_pop));
 	} else {
 		gen.discard_group();
-		err.accumulated_errors += "country trigger scope used in an incorrect scope type (" + err.file_name + ")\n";
+		err.accumulated_errors += "country trigger scope used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ")\n";
 		return;
 	}
 	context.compiled_trigger.push_back(uint16_t(1));
@@ -329,7 +311,7 @@ void tr_capital_scope(token_generator& gen, error_handler& err, trigger_building
 		context.compiled_trigger.push_back(uint16_t(trigger::capital_scope));
 	} else {
 		gen.discard_group();
-		err.accumulated_errors += "capital_scope trigger scope used in an incorrect scope type (" + err.file_name + ")\n";
+		err.accumulated_errors += "capital_scope trigger scope used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ")\n";
 		return;
 	}
 	context.compiled_trigger.push_back(uint16_t(1));
@@ -352,7 +334,7 @@ void tr_scope_this(token_generator& gen, error_handler& err, trigger_building_co
 		context.compiled_trigger.push_back(uint16_t(trigger::this_scope_pop));
 	} else {
 		gen.discard_group();
-		err.accumulated_errors += "'this' trigger scope used in an incorrect scope type (" + err.file_name + ")\n";
+		err.accumulated_errors += "'this' trigger scope used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ")\n";
 		return;
 	}
 	context.compiled_trigger.push_back(uint16_t(1));
@@ -376,7 +358,7 @@ void tr_scope_from(token_generator& gen, error_handler& err, trigger_building_co
 		context.compiled_trigger.push_back(uint16_t(trigger::from_scope_pop));
 	} else {
 		gen.discard_group();
-		err.accumulated_errors += "'from' trigger scope used in an incorrect scope type (" + err.file_name + ")\n";
+		err.accumulated_errors += "'from' trigger scope used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ")\n";
 		return;
 	}
 	context.compiled_trigger.push_back(uint16_t(1));
@@ -400,7 +382,7 @@ void tr_scope_sea_zone(token_generator& gen, error_handler& err, trigger_buildin
 		context.compiled_trigger[payload_size_offset] = uint16_t(context.compiled_trigger.size() - payload_size_offset);
 	} else {
 		gen.discard_group();
-		err.accumulated_errors += "sea_zone trigger scope used in an incorrect scope type (" + err.file_name + ")\n";
+		err.accumulated_errors += "sea_zone trigger scope used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ")\n";
 		return;
 	}
 }
@@ -411,7 +393,7 @@ void tr_scope_cultural_union(token_generator& gen, error_handler& err, trigger_b
 		context.compiled_trigger.push_back(uint16_t(trigger::cultural_union_scope_pop));
 	} else {
 		gen.discard_group();
-		err.accumulated_errors += "cultural_union trigger scope used in an incorrect scope type (" + err.file_name + ")\n";
+		err.accumulated_errors += "cultural_union trigger scope used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ")\n";
 		return;
 	}
 	context.compiled_trigger.push_back(uint16_t(1));
@@ -435,7 +417,7 @@ void tr_scope_overlord(token_generator& gen, error_handler& err, trigger_buildin
 		context.compiled_trigger[payload_size_offset] = uint16_t(context.compiled_trigger.size() - payload_size_offset);
 	} else {
 		gen.discard_group();
-		err.accumulated_errors += "overlord trigger scope used in an incorrect scope type (" + err.file_name + ")\n";
+		err.accumulated_errors += "overlord trigger scope used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ")\n";
 		return;
 	}
 }
@@ -450,7 +432,7 @@ void tr_scope_sphere_owner(token_generator& gen, error_handler& err, trigger_bui
 		context.compiled_trigger[payload_size_offset] = uint16_t(context.compiled_trigger.size() - payload_size_offset);
 	} else {
 		gen.discard_group();
-		err.accumulated_errors += "sphere_owner trigger scope used in an incorrect scope type (" + err.file_name + ")\n";
+		err.accumulated_errors += "sphere_owner trigger scope used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ")\n";
 		return;
 	}
 }
@@ -468,7 +450,7 @@ void tr_scope_independence(token_generator& gen, error_handler& err, trigger_bui
 		context.compiled_trigger[payload_size_offset] = uint16_t(context.compiled_trigger.size() - payload_size_offset);
 	} else {
 		gen.discard_group();
-		err.accumulated_errors += "independence trigger scope used in an incorrect scope type (" + err.file_name + ")\n";
+		err.accumulated_errors += "independence trigger scope used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ")\n";
 		return;
 	}
 }
@@ -485,7 +467,7 @@ void tr_flashpoint_tag_scope(token_generator& gen, error_handler& err, trigger_b
 		context.compiled_trigger[payload_size_offset] = uint16_t(context.compiled_trigger.size() - payload_size_offset);
 	} else {
 		gen.discard_group();
-		err.accumulated_errors += "flashpoint_tag_scope trigger scope used in an incorrect scope type (" + err.file_name + ")\n";
+		err.accumulated_errors += "flashpoint_tag_scope trigger scope used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ")\n";
 		return;
 	}
 }
@@ -508,7 +490,7 @@ void tr_state_scope(token_generator& gen, error_handler& err, trigger_building_c
 		context.compiled_trigger.push_back(uint16_t(trigger::state_scope_pop));
 	} else {
 		gen.discard_group();
-		err.accumulated_errors += "state_scope trigger scope used in an incorrect scope type (" + err.file_name + ")\n";
+		err.accumulated_errors += "state_scope trigger scope used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ")\n";
 		return;
 	}
 	context.compiled_trigger.push_back(uint16_t(1));
@@ -704,7 +686,7 @@ void trigger_body::badboy(association_type a, float value, error_handler& err, i
 	if(context.main_slot == trigger::slot_contents::nation) {
 		context.compiled_trigger.push_back(uint16_t(trigger::badboy | association_to_trigger_code(a)));
 	} else {
-		err.accumulated_errors += "badboy trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+		err.accumulated_errors += "badboy trigger used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ", line " + std::to_string(line) + ")\n";
 		return;
 	}
 	context.add_float_to_payload(value * context.outer_context.state.defines.badboy_limit);
@@ -715,7 +697,7 @@ void trigger_body::ruling_party(association_type a, std::string_view value, erro
 
 		context.compiled_trigger.push_back(uint16_t(trigger::ruling_party | association_to_bool_code(a)));
 	} else {
-		err.accumulated_errors += "ruling_party trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+		err.accumulated_errors += "ruling_party trigger used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ", line " + std::to_string(line) + ")\n";
 		return;
 	}
 	auto name_id = text::find_or_add_key(context.outer_context.state, value);
@@ -726,7 +708,7 @@ void trigger_body::has_leader(association_type a, std::string_view value, error_
 	if(context.main_slot == trigger::slot_contents::nation) {
 		context.compiled_trigger.push_back(uint16_t(trigger::has_leader | association_to_bool_code(a)));
 	} else {
-		err.accumulated_errors += "has_leader trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+		err.accumulated_errors += "has_leader trigger used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + "(" + err.file_name + ", line " + std::to_string(line) + ")\n";
 		return;
 	}
 	auto name_id = context.outer_context.state.add_unit_name(value);

--- a/src/parsing/trigger_parsing.hpp
+++ b/src/parsing/trigger_parsing.hpp
@@ -13,6 +13,24 @@
 
 namespace parsers {
 
+std::string slot_contents_to_string(trigger::slot_contents v) {
+	switch(v) {
+	case trigger::slot_contents::empty:
+		return "empty";
+	case trigger::slot_contents::province:
+		return "province";
+	case trigger::slot_contents::state:
+		return "state";
+	case trigger::slot_contents::pop:
+		return "pop";
+	case trigger::slot_contents::nation:
+		return "nation";
+	case trigger::slot_contents::rebel:
+		return "rebel";
+	}
+	return "unknown";
+}
+
 struct trigger_building_context {
 	scenario_building_context& outer_context;
 	std::vector<uint16_t> compiled_trigger;
@@ -251,7 +269,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::ai | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "ai trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "ai trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -288,7 +306,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::port | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "port trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "port trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -299,7 +317,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::involved_in_crisis_nation | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "involved_in_crisis trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "involved_in_crisis trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -307,7 +325,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation && context.this_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::has_cultural_sphere | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "has_cultural_sphere trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "has_cultural_sphere trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -318,7 +336,7 @@ struct trigger_body {
 		} else if(context.from_slot == trigger::slot_contents::rebel) {
 			context.compiled_trigger.push_back(uint16_t(trigger::social_movement_from_reb | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "social_movement trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "social_movement trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -328,7 +346,7 @@ struct trigger_body {
 		} else if(context.from_slot == trigger::slot_contents::rebel) {
 				context.compiled_trigger.push_back(uint16_t(trigger::political_movement_from_reb | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "political_movement trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "political_movement trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -336,7 +354,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::rich_tax_above_poor | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "rich_tax_above_poor trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "rich_tax_above_poor trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -345,7 +363,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_substate | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_substate trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_substate trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -353,7 +371,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::state) {
 			context.compiled_trigger.push_back(uint16_t(trigger::has_flashpoint | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "has_flashpoint trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "has_flashpoint trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -361,7 +379,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_disarmed | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_disarmed trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_disarmed trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -369,7 +387,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::can_nationalize | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "can_nationalize trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "can_nationalize trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -377,7 +395,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::part_of_sphere | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "part_of_sphere trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "part_of_sphere trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -385,7 +403,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::constructing_cb_discovered | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "constructing_cb_discovered trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "constructing_cb_discovered trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -393,7 +411,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::colonial_nation | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "colonial_nation trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "colonial_nation trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -401,7 +419,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_capital | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_capital trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_capital trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -409,7 +427,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::election | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "election trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "election trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -421,14 +439,14 @@ struct trigger_body {
 			if(context.from_slot == trigger::slot_contents::nation)
 				context.compiled_trigger.push_back(uint16_t(trigger::is_releasable_vassal_from | trigger::no_payload | association_to_bool_code(a)));
 			else {
-				err.accumulated_errors += "is_releasable_vassal trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "is_releasable_vassal trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else {
 			if(context.from_slot == trigger::slot_contents::nation)
 				context.compiled_trigger.push_back(uint16_t(trigger::is_releasable_vassal_other | trigger::no_payload | association_to_bool_code(a, parse_bool(value, line, err))));
 			else {
-				err.accumulated_errors += "is_releasable_vassal trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "is_releasable_vassal trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		}
@@ -439,14 +457,14 @@ struct trigger_body {
 			if(context.from_slot == trigger::slot_contents::nation)
 				context.compiled_trigger.push_back(uint16_t(trigger::someone_can_form_union_tag_from | trigger::no_payload | association_to_bool_code(a)));
 			else {
-				err.accumulated_errors += "someone_can_form_union_tag trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "someone_can_form_union_tag trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else {
 			if(context.from_slot == trigger::slot_contents::nation)
 				context.compiled_trigger.push_back(uint16_t(trigger::someone_can_form_union_tag_other | trigger::no_payload | association_to_bool_code(a, parse_bool(value, line, err))));
 			else {
-				err.accumulated_errors += "someone_can_form_union_tag trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "someone_can_form_union_tag trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		}
@@ -455,7 +473,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_state_capital | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_state_capital trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_state_capital trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -464,7 +482,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::state) {
 			context.compiled_trigger.push_back(uint16_t(trigger::has_factories | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "has_factories trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "has_factories trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -472,7 +490,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::has_empty_adjacent_province | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "has_empty_adjacent_province trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "has_empty_adjacent_province trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -484,7 +502,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::minorities_province | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "minorities trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "minorities trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -494,7 +512,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::culture_has_union_tag_pop | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "culture_has_union_tag trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "culture_has_union_tag trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -504,7 +522,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::state) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_colonial_state | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_colonial trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_colonial trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -516,7 +534,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_greater_power_province | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_greater_power trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_greater_power trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -524,7 +542,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::can_create_vassals | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "can_create_vassals trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "can_create_vassals trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -532,7 +550,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::has_recently_lost_war | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "has_recently_lost_war trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "has_recently_lost_war trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -540,7 +558,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_mobilised | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_mobilised trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_mobilised trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -554,7 +572,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::crime_higher_than_education_pop | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "crime_higher_than_education trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "crime_higher_than_education trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -567,7 +585,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::civilized_pop | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "civilized trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "civilized trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -576,7 +594,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::rank | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "rank trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "rank trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -591,7 +609,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::has_recent_imigration | association_to_le_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "has_recent_imigration trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "has_recent_imigration trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -601,7 +619,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::province_control_days | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "province_control_days trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "province_control_days trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -610,7 +628,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::num_of_substates | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "num_of_substates trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "num_of_substates trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -619,7 +637,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::num_of_vassals_no_substates | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "num_of_vassals_no_substates trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "num_of_vassals_no_substates trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -628,7 +646,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::number_of_states | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "number_of_states trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "number_of_states trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -638,7 +656,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::war_score | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "war_score trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "war_score trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -648,7 +666,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::state) {
 			context.compiled_trigger.push_back(uint16_t(trigger::flashpoint_tension | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "flashpoint_tension trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "flashpoint_tension trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -658,7 +676,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::life_needs | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "life_needs trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "life_needs trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -668,7 +686,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::everyday_needs | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "everyday_needs trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "everyday_needs trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -678,7 +696,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::luxury_needs | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "luxury_needs trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "luxury_needs trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -687,7 +705,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::social_movement_strength | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "social_movement_strength trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "social_movement_strength trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -696,7 +714,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::political_movement_strength | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "political_movement_strength trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "political_movement_strength trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -706,7 +724,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::total_num_of_ports | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "total_num_of_ports trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "total_num_of_ports trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -715,7 +733,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::agree_with_ruling_party | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "agree_with_ruling_party trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "agree_with_ruling_party trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -724,7 +742,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::constructing_cb_progress | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "constructing_cb_progress trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "constructing_cb_progress trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -733,7 +751,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::civilization_progress | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "civilization_progress trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "civilization_progress trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -749,7 +767,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::rich_strata_life_needs_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "rich_strata_life_needs trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "rich_strata_life_needs trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -764,7 +782,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::rich_strata_everyday_needs_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "rich_strata_everyday_needs trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "rich_strata_everyday_needs trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -779,7 +797,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::rich_strata_luxury_needs_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "rich_strata_luxury_needs trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "rich_strata_luxury_needs trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -795,7 +813,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::middle_strata_life_needs_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "middle_strata_life_needs trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "middle_strata_life_needs trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -810,7 +828,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::middle_strata_everyday_needs_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "middle_strata_everyday_needs trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "middle_strata_everyday_needs trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -825,7 +843,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::middle_strata_luxury_needs_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "middle_strata_luxury_needs trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "middle_strata_luxury_needs trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -842,7 +860,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::poor_strata_life_needs_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "poor_strata_life_needs trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "poor_strata_life_needs trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -857,7 +875,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::poor_strata_everyday_needs_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "poor_strata_everyday_needs trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "poor_strata_everyday_needs trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -872,7 +890,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::poor_strata_luxury_needs_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "poor_strata_luxury_needs trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "poor_strata_luxury_needs trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -884,7 +902,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::revanchism_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "revanchism trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "revanchism trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -900,7 +918,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::poor_strata_militancy_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "poor_strata_militancy trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "poor_strata_militancy trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -915,7 +933,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::middle_strata_militancy_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "middle_strata_militancy trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "middle_strata_militancy trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -930,7 +948,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::rich_strata_militancy_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "rich_strata_militancy trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "rich_strata_militancy trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -945,7 +963,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::consciousness_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "consciousness trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "consciousness trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -960,7 +978,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::literacy_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "literacy trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "literacy trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -975,7 +993,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::militancy_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "militancy trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "militancy trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -990,7 +1008,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::military_spending_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "military_spending trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "military_spending trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(uint16_t(value * 100.0f));
@@ -1005,7 +1023,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::administration_spending_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "administration_spending trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "administration_spending trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(uint16_t(value * 100.0f));
@@ -1020,7 +1038,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::education_spending_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "education_spending trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "education_spending trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(uint16_t(value * 100.0f));
@@ -1029,7 +1047,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::national_provinces_occupied | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "national_provinces_occupied trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "national_provinces_occupied trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -1042,7 +1060,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::social_spending_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "social_spending trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "social_spending trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(uint16_t(value * 100.0f));
@@ -1054,11 +1072,11 @@ struct trigger_body {
 			} else if(context.from_slot == trigger::slot_contents::nation) {
 				context.compiled_trigger.push_back(uint16_t(trigger::brigades_compare_from | association_to_trigger_code(a)));
 			} else {
-				err.accumulated_errors += "brigades_compare trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "brigades_compare trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else {
-			err.accumulated_errors += "brigades_compare trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "brigades_compare trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -1067,7 +1085,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::rich_tax | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "rich_tax trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "rich_tax trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(uint16_t(value * 100.0f));
@@ -1076,7 +1094,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::middle_tax | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "middle_tax trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "middle_tax trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(uint16_t(value * 100.0f));
@@ -1085,7 +1103,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::poor_tax | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "poor_tax trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "poor_tax trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(uint16_t(value * 100.0f));
@@ -1094,7 +1112,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::mobilisation_size | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "mobilisation_size trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "mobilisation_size trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -1103,7 +1121,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::province_id | association_to_bool_code(a)));
 		} else {
-			err.accumulated_errors += "province_id trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "province_id trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		if(0 <= value && size_t(value) < context.outer_context.original_id_to_prov_id_map.size()) {
@@ -1119,7 +1137,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::nation) {
 				context.compiled_trigger.push_back(uint16_t(trigger::technology | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "invention trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "invention trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 
@@ -1129,7 +1147,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::nation) {
 				context.compiled_trigger.push_back(uint16_t(trigger::invention | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "invention trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "invention trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 
@@ -1143,7 +1161,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::nation) {
 				context.compiled_trigger.push_back(uint16_t(trigger::big_producer | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "big_producer trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "big_producer trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 
@@ -1165,7 +1183,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "strata trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "strata trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -1176,7 +1194,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::state) {
 			context.compiled_trigger.push_back(uint16_t(trigger::life_rating_state | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "life_rating trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "life_rating trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(int16_t(value)).value);
@@ -1188,7 +1206,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::state) {
 			context.compiled_trigger.push_back(uint16_t(trigger::has_empty_adjacent_state_state | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "has_empty_adjacent_state trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "has_empty_adjacent_state trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -1199,7 +1217,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::state) {
 			context.compiled_trigger.push_back(uint16_t(trigger::state_id_state | association_to_bool_code(a)));
 		} else {
-			err.accumulated_errors += "state_id trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "state_id trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		if(0 <= value && size_t(value) < context.outer_context.original_id_to_prov_id_map.size()) {
@@ -1213,7 +1231,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::cash_reserves | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "cash_reserves trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "cash_reserves trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -1228,7 +1246,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::unemployment_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "unemployment trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "unemployment trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -1244,7 +1262,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_slave_pop | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_slave trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_slave trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -1253,7 +1271,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_independant | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_independant trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_independant trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -1266,7 +1284,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::has_national_minority_province | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "has_national_minority trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "has_national_minority trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -1278,7 +1296,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::government_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "government trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "government trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 
@@ -1293,7 +1311,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::nation) {
 				context.compiled_trigger.push_back(uint16_t(trigger::constructing_cb_type | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "constructing_cb_type trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "constructing_cb_type trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 
@@ -1308,7 +1326,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::nation) {
 				context.compiled_trigger.push_back(uint16_t(trigger::can_build_factory_in_capital_state | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "can_build_factory_in_capital_state trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "can_build_factory_in_capital_state trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 
@@ -1321,7 +1339,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::capital | association_to_bool_code(a)));
 		} else {
-			err.accumulated_errors += "capital trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "capital trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		if(0 <= value && size_t(value) < context.outer_context.original_id_to_prov_id_map.size()) {
@@ -1336,7 +1354,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::nation) {
 				context.compiled_trigger.push_back(uint16_t(trigger::tech_school | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "tech_school trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "tech_school trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 
@@ -1350,7 +1368,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::nation) {
 				context.compiled_trigger.push_back(uint16_t(trigger::primary_culture | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "primary_culture trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "primary_culture trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 
@@ -1364,7 +1382,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::province) {
 				context.compiled_trigger.push_back(uint16_t(trigger::has_crime | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "has_crime trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "has_crime trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 
@@ -1378,7 +1396,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::nation) {
 				context.compiled_trigger.push_back(uint16_t(trigger::accepted_culture | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "accepted_culture trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "accepted_culture trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 
@@ -1396,7 +1414,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::province) {
 				context.compiled_trigger.push_back(uint16_t(trigger::pop_majority_religion_province | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "pop_majority_religion trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "pop_majority_religion trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -1413,7 +1431,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::province) {
 				context.compiled_trigger.push_back(uint16_t(trigger::pop_majority_culture_province | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "pop_majority_culture trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "pop_majority_culture trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -1432,7 +1450,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::pop_majority_issue_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "pop_majority_issue trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "pop_majority_issue trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second.id).value);
@@ -1451,7 +1469,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::pop_majority_ideology_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "pop_majority_ideology trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "pop_majority_ideology trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second.id).value);
@@ -1466,7 +1484,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::province) {
 				context.compiled_trigger.push_back(uint16_t(trigger::trade_goods_in_state_province | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "trade_goods_in_state trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "trade_goods_in_state trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -1487,23 +1505,23 @@ struct trigger_body {
 				} else if(context.main_slot == trigger::slot_contents::pop) {
 					context.compiled_trigger.push_back(uint16_t(trigger::culture_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				} else {
-					err.accumulated_errors += "culture trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "culture trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
-				err.accumulated_errors += "culture = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "culture = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(is_from(value)) {
 			if(context.main_slot == trigger::slot_contents::pop && context.from_slot == trigger::slot_contents::nation)
 				context.compiled_trigger.push_back(uint16_t(trigger::culture_from_nation | trigger::no_payload | association_to_bool_code(a)));
 			else {
-				err.accumulated_errors += "culture = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "culture = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(is_reb(value)) {
 			if(context.from_slot != trigger::slot_contents::rebel) {
-				err.accumulated_errors += "culture = reb trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "culture = reb trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			} else if(context.main_slot == trigger::slot_contents::pop)
 				context.compiled_trigger.push_back(uint16_t(trigger::culture_pop_reb | trigger::no_payload | association_to_bool_code(a)));
@@ -1514,7 +1532,7 @@ struct trigger_body {
 			else if(context.main_slot == trigger::slot_contents::nation)
 				context.compiled_trigger.push_back(uint16_t(trigger::culture_nation_reb | trigger::no_payload | association_to_bool_code(a)));
 			else {
-				err.accumulated_errors += "culture = reb trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "culture = reb trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(auto it = context.outer_context.map_of_culture_names.find(std::string(value)); it != context.outer_context.map_of_culture_names.end()) {
@@ -1527,7 +1545,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::culture_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "culture trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "culture trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -1547,11 +1565,11 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::province)
 					context.compiled_trigger.push_back(uint16_t(trigger::has_pop_culture_province_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "has_pop_culture = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "has_pop_culture = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
-				err.accumulated_errors += "has_pop_culture = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "has_pop_culture = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(auto it = context.outer_context.map_of_culture_names.find(std::string(value)); it != context.outer_context.map_of_culture_names.end()) {
@@ -1564,7 +1582,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::has_pop_culture_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "has_pop_culture trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "has_pop_culture trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -1584,11 +1602,11 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::province)
 					context.compiled_trigger.push_back(uint16_t(trigger::has_pop_religion_province_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "has_pop_religion = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "has_pop_religion = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
-				err.accumulated_errors += "has_pop_religion = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "has_pop_religion = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(auto it = context.outer_context.map_of_religion_names.find(std::string(value)); it != context.outer_context.map_of_religion_names.end()) {
@@ -1601,7 +1619,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::has_pop_religion_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "has_pop_religion trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "has_pop_religion trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -1618,7 +1636,7 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::culture_group_pop_this_nation | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "culture_group = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "culture_group = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(context.this_slot == trigger::slot_contents::state) {
@@ -1627,7 +1645,7 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::culture_group_pop_this_state | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "culture_group = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "culture_group = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(context.this_slot == trigger::slot_contents::province) {
@@ -1636,7 +1654,7 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::culture_group_pop_this_province | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "culture_group = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "culture_group = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(context.this_slot == trigger::slot_contents::pop) {
@@ -1645,11 +1663,11 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::culture_group_pop_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "culture_group = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "culture_group = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
-				err.accumulated_errors += "culture_group = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "culture_group = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(is_from(value)) {
@@ -1659,11 +1677,11 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::culture_group_pop_from_nation | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "culture_group = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "culture_group = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
-				err.accumulated_errors += "culture_group = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "culture_group = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(is_reb(value)) {
@@ -1673,11 +1691,11 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::culture_group_reb_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "culture_group = reb trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "culture_group = reb trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
-				err.accumulated_errors += "culture_group = reb trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "culture_group = reb trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(auto it = context.outer_context.map_of_culture_group_names.find(std::string(value)); it != context.outer_context.map_of_culture_group_names.end()) {
@@ -1686,7 +1704,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::culture_group_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "culture_group trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "culture_group trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -1703,7 +1721,7 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::religion_this_nation | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "religion = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "religion = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(context.this_slot == trigger::slot_contents::state) {
@@ -1712,7 +1730,7 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::religion_this_state | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "religion = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "religion = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(context.this_slot == trigger::slot_contents::province) {
@@ -1721,7 +1739,7 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::religion_this_province | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "religion = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "religion = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(context.this_slot == trigger::slot_contents::pop) {
@@ -1730,11 +1748,11 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::religion_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "religion = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "religion = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
-				err.accumulated_errors += "religion = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "religion = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(is_from(value)) {
@@ -1744,11 +1762,11 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::religion_from_nation | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "religion = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "religion = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
-				err.accumulated_errors += "religion = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "religion = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(is_reb(value)) {
@@ -1758,11 +1776,11 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::religion_reb | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "religion = reb trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "religion = reb trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
-				err.accumulated_errors += "religion = reb trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "religion = reb trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(auto it = context.outer_context.map_of_religion_names.find(std::string(value)); it != context.outer_context.map_of_religion_names.end()) {
@@ -1771,7 +1789,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::religion | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "religion trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "religion trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -1786,7 +1804,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::province) {
 				context.compiled_trigger.push_back(uint16_t(trigger::terrain_province | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "terrain trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "terrain trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second.id).value);
@@ -1799,7 +1817,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::province) {
 				context.compiled_trigger.push_back(uint16_t(trigger::trade_goods | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "trade_goods trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "trade_goods trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -1813,7 +1831,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_secondary_power_pop | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_secondary_power trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_secondary_power trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -1824,7 +1842,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::has_faction_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "has_faction trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "has_faction trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second.id).value);
@@ -1836,7 +1854,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::has_unclaimed_cores | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "has_unclaimed_cores trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "has_unclaimed_cores trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -1846,7 +1864,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::nation)
 				context.compiled_trigger.push_back(uint16_t(trigger::is_cultural_union_bool | trigger::no_payload | association_to_bool_code(a, parse_bool(value, line, err))));
 			else {
-				err.accumulated_errors += "is_cultural_union = bool trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "is_cultural_union = bool trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(is_this(value)) {
@@ -1866,11 +1884,11 @@ struct trigger_body {
 				else if(context.from_slot == trigger::slot_contents::rebel)
 					context.compiled_trigger.push_back(uint16_t(trigger::is_cultural_union_this_rebel | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "is_cultural_union = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "is_cultural_union = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
-				err.accumulated_errors += "is_cultural_union = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "is_cultural_union = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(value.length() == 3) {
@@ -1887,7 +1905,7 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::is_cultural_union_tag_this_nation | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "is_cultural_union = tag trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "is_cultural_union = tag trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 				context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -1906,7 +1924,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::can_build_factory_pop | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "can_build_factory trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "can_build_factory trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -1916,7 +1934,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::war_pop | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "war trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "war trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -1928,7 +1946,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::war_exhaustion_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "war_exhaustion trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "war_exhaustion trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value / 100.0f);
@@ -1937,7 +1955,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::blockade | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "blockade trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "blockade trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -1946,7 +1964,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::owns | association_to_bool_code(a)));
 		} else {
-			err.accumulated_errors += "owns trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "owns trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		if(0 <= value && size_t(value) < context.outer_context.original_id_to_prov_id_map.size()) {
@@ -1960,7 +1978,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::controls | association_to_bool_code(a)));
 		} else {
-			err.accumulated_errors += "controls trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "controls trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		if(0 <= value && size_t(value) < context.outer_context.original_id_to_prov_id_map.size()) {
@@ -1982,21 +2000,21 @@ struct trigger_body {
 			} else if(context.this_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::is_core_this_pop | trigger::no_payload | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "is_core = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "is_core = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(is_from(value) && context.main_slot == trigger::slot_contents::province) {
 			if(context.from_slot == trigger::slot_contents::nation) {
 				context.compiled_trigger.push_back(uint16_t(trigger::is_core_from_nation | trigger::no_payload | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "is_core = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "is_core = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(is_reb(value) && context.main_slot == trigger::slot_contents::province) {
 			if(context.from_slot == trigger::slot_contents::rebel) {
 				context.compiled_trigger.push_back(uint16_t(trigger::is_core_reb | trigger::no_payload | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "is_core = reb trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "is_core = reb trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(is_integer(value.data(), value.data() + value.length())) {
@@ -2010,7 +2028,7 @@ struct trigger_body {
 					context.compiled_trigger.push_back(trigger::payload(dcon::province_id()).value);
 				}
 			} else {
-				err.accumulated_errors += "is_core trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "is_core trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(value.length() == 3 && context.main_slot == trigger::slot_contents::province) {
@@ -2028,7 +2046,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::num_of_revolts | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "num_of_revolts trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "num_of_revolts trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -2037,7 +2055,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::revolt_percentage | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "revolt_percentage trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "revolt_percentage trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -2053,21 +2071,21 @@ struct trigger_body {
 			} else if(context.this_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::num_of_cities_this_pop | trigger::no_payload | association_to_trigger_code(a)));
 			} else {
-				err.accumulated_errors += "num_of_cities = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "num_of_cities = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(is_from(value) && context.main_slot == trigger::slot_contents::nation) {
 			if(context.from_slot == trigger::slot_contents::nation) {
 				context.compiled_trigger.push_back(uint16_t(trigger::num_of_cities_from_nation | trigger::no_payload | association_to_trigger_code(a)));
 			} else {
-				err.accumulated_errors += "num_of_cities = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "num_of_cities = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::num_of_cities_int | association_to_trigger_code(a)));
 			context.compiled_trigger.push_back(trigger::payload(uint16_t(parse_uint(value, line, err))).value);
 		} else {
-			err.accumulated_errors += "num_of_cities trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "num_of_cities trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2075,7 +2093,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::num_of_ports | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "num_of_ports trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "num_of_ports trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -2084,7 +2102,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::num_of_allies | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "num_of_allies trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "num_of_allies trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -2093,7 +2111,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::num_of_vassals | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "num_of_vassals trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "num_of_vassals trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -2110,14 +2128,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::owned_by_this_nation | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "owned_by = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "owned_by = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::owned_by_from_nation | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "owned_by = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "owned_by = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -2132,7 +2150,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "owned_by trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "owned_by trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2142,7 +2160,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::exists_bool | trigger::no_payload | association_to_bool_code(a, parse_bool(value, line, err))));
 			else {
-				err.accumulated_errors += "exists = bool trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "exists = bool trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 			}
 		} else if(value.length() == 3) {
@@ -2166,7 +2184,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::has_country_flag_province | association_to_bool_code(a)));
 		} else {
-			err.accumulated_errors += "has_country_flag trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "has_country_flag trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(context.outer_context.get_national_flag(std::string(value))).value);
@@ -2182,14 +2200,14 @@ struct trigger_body {
 				if(context.this_slot == trigger::slot_contents::nation) {
 					context.compiled_trigger.push_back(uint16_t(trigger::continent_nation_this | trigger::no_payload | association_to_bool_code(a)));
 				} else {
-					err.accumulated_errors += "continent = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "continent = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation) {
 					context.compiled_trigger.push_back(uint16_t(trigger::continent_nation_from | trigger::no_payload | association_to_bool_code(a)));
 				} else {
-					err.accumulated_errors += "continent = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "continent = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(auto it = context.outer_context.map_of_modifiers.find(std::string(value)); it != context.outer_context.map_of_modifiers.end()) {
@@ -2204,14 +2222,14 @@ struct trigger_body {
 				if(context.this_slot == trigger::slot_contents::nation) {
 					context.compiled_trigger.push_back(uint16_t(trigger::continent_state_this | trigger::no_payload | association_to_bool_code(a)));
 				} else {
-					err.accumulated_errors += "continent = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "continent = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation) {
 					context.compiled_trigger.push_back(uint16_t(trigger::continent_state_from | trigger::no_payload | association_to_bool_code(a)));
 				} else {
-					err.accumulated_errors += "continent = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "continent = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(auto it = context.outer_context.map_of_modifiers.find(std::string(value)); it != context.outer_context.map_of_modifiers.end()) {
@@ -2226,14 +2244,14 @@ struct trigger_body {
 				if(context.this_slot == trigger::slot_contents::nation) {
 					context.compiled_trigger.push_back(uint16_t(trigger::continent_province_this | trigger::no_payload | association_to_bool_code(a)));
 				} else {
-					err.accumulated_errors += "continent = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "continent = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation) {
 					context.compiled_trigger.push_back(uint16_t(trigger::continent_province_from | trigger::no_payload | association_to_bool_code(a)));
 				} else {
-					err.accumulated_errors += "continent = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "continent = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(auto it = context.outer_context.map_of_modifiers.find(std::string(value)); it != context.outer_context.map_of_modifiers.end()) {
@@ -2248,14 +2266,14 @@ struct trigger_body {
 				if(context.this_slot == trigger::slot_contents::nation) {
 					context.compiled_trigger.push_back(uint16_t(trigger::continent_pop_this | trigger::no_payload | association_to_bool_code(a)));
 				} else {
-					err.accumulated_errors += "continent = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "continent = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation) {
 					context.compiled_trigger.push_back(uint16_t(trigger::continent_pop_from | trigger::no_payload | association_to_bool_code(a)));
 				} else {
-					err.accumulated_errors += "continent = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "continent = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(auto it = context.outer_context.map_of_modifiers.find(std::string(value)); it != context.outer_context.map_of_modifiers.end()) {
@@ -2266,7 +2284,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "continent trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "continent trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2282,14 +2300,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::casus_belli_this_nation | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "casus_belli = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "casus_belli = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::casus_belli_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "casus_belli = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "casus_belli = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -2304,7 +2322,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "casus_belli trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "casus_belli trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2321,14 +2339,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::military_access_this_nation | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "military_access = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "military_access = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::military_access_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "military_access = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "military_access = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -2343,7 +2361,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "military_access trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "military_access trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2360,14 +2378,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::prestige_this_nation | trigger::no_payload | association_to_trigger_code(a)));
 				else {
-					err.accumulated_errors += "prestige = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "prestige = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::prestige_from | trigger::no_payload | association_to_trigger_code(a)));
 				else {
-					err.accumulated_errors += "prestige = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "prestige = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
@@ -2376,7 +2394,7 @@ struct trigger_body {
 				context.add_float_to_payload(fvalue);
 			}
 		} else {
-			err.accumulated_errors += "prestige trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "prestige trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2409,7 +2427,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "has_building trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "has_building trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2417,7 +2435,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::empty | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "empty trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "empty trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2425,7 +2443,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_blockaded | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_blockaded trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_blockaded trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2437,7 +2455,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::province) {
 				context.compiled_trigger.push_back(uint16_t(trigger::has_country_modifier_province | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "has_country_modifier trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "has_country_modifier trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -2450,7 +2468,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::province) {
 				context.compiled_trigger.push_back(uint16_t(trigger::has_province_modifier | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "has_province_modifier trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "has_province_modifier trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -2467,7 +2485,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::nationalvalue_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "nationalvalue trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "nationalvalue trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -2480,7 +2498,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::province) {
 				context.compiled_trigger.push_back(uint16_t(trigger::region | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "region trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "region trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -2497,7 +2515,7 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::tag_this_nation | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "tag = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "tag = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
@@ -2506,7 +2524,7 @@ struct trigger_body {
 				else if(context.from_slot == trigger::slot_contents::province)
 					context.compiled_trigger.push_back(uint16_t(trigger::tag_from_province | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "tag = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "tag = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -2533,7 +2551,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "tag trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "tag trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2543,14 +2561,14 @@ struct trigger_body {
 				if(context.this_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::neighbour_this | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "neighbour = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "neighbour = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::neighbour_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "neighbour = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "neighbour = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -2565,7 +2583,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "neighbour trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "neighbour trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2581,14 +2599,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::units_in_province_this_pop | trigger::no_payload | association_to_trigger_code(a)));
 				else {
-					err.accumulated_errors += "units_in_province = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "units_in_province = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::units_in_province_from | trigger::no_payload | association_to_trigger_code(a)));
 				else {
-					err.accumulated_errors += "units_in_province = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "units_in_province = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
@@ -2596,7 +2614,7 @@ struct trigger_body {
 				context.compiled_trigger.push_back(trigger::payload(uint16_t(parse_uint(value, line, err))).value);
 			}
 		} else {
-			err.accumulated_errors += "units_in_province trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "units_in_province trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2612,14 +2630,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::war_with_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "war_with = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "war_with = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::war_with_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "war_with = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "war_with = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -2634,7 +2652,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "war_with trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "war_with trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2642,7 +2660,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::unit_in_battle | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "unit_in_battle trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "unit_in_battle trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2650,7 +2668,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::total_amount_of_divisions | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "total_amount_of_divisions trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "total_amount_of_divisions trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -2659,7 +2677,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::money | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "money trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "money trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -2668,7 +2686,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::lost_national | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "lost_national trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "lost_national trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -2677,7 +2695,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_vassal | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_vassal trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_vassal trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2688,7 +2706,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::ruling_party_ideology_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "ruling_party_ideology trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "ruling_party_ideology trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second.id).value);
@@ -2712,7 +2730,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::political_reform_want_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "political_reform_want trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "political_reform_want trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -2723,7 +2741,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::social_reform_want_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "social_reform_want trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "social_reform_want trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -2732,7 +2750,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::total_amount_of_ships | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "total_amount_of_ships trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "total_amount_of_ships trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -2741,7 +2759,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::plurality | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "plurality trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "plurality trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value / 100.0f);
@@ -2750,7 +2768,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::corruption | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "corruption trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "corruption trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -2763,7 +2781,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_state_religion_pop | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_state_religion trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_state_religion trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2779,7 +2797,7 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::is_primary_culture_nation_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "is_primary_culture = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "is_primary_culture = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(context.main_slot == trigger::slot_contents::state) {
@@ -2792,7 +2810,7 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::is_primary_culture_state_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "is_primary_culture = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "is_primary_culture = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(context.main_slot == trigger::slot_contents::province) {
@@ -2805,7 +2823,7 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::is_primary_culture_province_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "is_primary_culture = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "is_primary_culture = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(context.main_slot == trigger::slot_contents::pop) {
@@ -2818,11 +2836,11 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::is_primary_culture_pop_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "is_primary_culture = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "is_primary_culture = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
-				err.accumulated_errors += "is_primary_culture = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "is_primary_culture = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else {
@@ -2834,7 +2852,7 @@ struct trigger_body {
 			else if(context.main_slot == trigger::slot_contents::pop)
 				context.compiled_trigger.push_back(uint16_t(trigger::is_primary_culture_pop | trigger::no_payload | association_to_bool_code(a, v)));
 			else {
-				err.accumulated_errors += "is_primary_culture trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "is_primary_culture trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		}
@@ -2847,7 +2865,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_accepted_culture_pop | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_accepted_culture trigger used in an incorrect scope type " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_accepted_culture trigger used in an incorrect scope type " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2855,7 +2873,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_coastal | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_coastal trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_coastal trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2871,14 +2889,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::in_sphere_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "in_sphere = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "in_sphere = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::in_sphere_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "in_sphere = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "in_sphere = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -2893,7 +2911,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "in_sphere trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "in_sphere trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2908,7 +2926,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::produces_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "produces trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "produces trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -2927,7 +2945,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::has_pop_type_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "has_pop_type trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "has_pop_type trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -2945,7 +2963,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::total_pops_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "total_pops trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "total_pops trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -2958,7 +2976,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::average_militancy_province | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "average_militancy trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "average_militancy trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -2971,7 +2989,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::average_consciousness_province | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "average_consciousness trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "average_consciousness trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -2983,7 +3001,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::is_next_reform_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "is_next_reform trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "is_next_reform trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second.id).value);
@@ -2993,7 +3011,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::is_next_rreform_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "is_next_reform trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "is_next_reform trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second.id).value);
@@ -3005,7 +3023,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::rebel_power_fraction | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "rebel_power_fraction trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "rebel_power_fraction trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -3016,7 +3034,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::recruited_percentage_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "recruited_percentage trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "recruited_percentage trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -3027,7 +3045,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::province && context.this_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::has_culture_core_province_this_pop | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "has_culture_core trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "has_culture_core trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3035,7 +3053,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::nationalism | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "nationalism trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "nationalism trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -3044,7 +3062,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_overseas | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_overseas trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_overseas trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3052,7 +3070,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::controlled_by_rebels | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "controlled_by_rebels trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "controlled_by_rebels trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3068,21 +3086,21 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::controlled_by_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "controlled_by = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "controlled_by = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::controlled_by_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "controlled_by = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "controlled_by = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_reb(value)) {
 				if(context.from_slot == trigger::slot_contents::rebel)
 					context.compiled_trigger.push_back(uint16_t(trigger::controlled_by_reb | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "controlled_by = reb trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "controlled_by = reb trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_fixed_token_ci(value.data(), value.data() + value.length(), "owner")) {
@@ -3099,7 +3117,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "controlled_by trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "controlled_by trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3115,14 +3133,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::truce_with_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "truce_with = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "truce_with = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::truce_with_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "truce_with = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "truce_with = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -3137,7 +3155,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "truce_with trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "truce_with trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3153,14 +3171,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::is_sphere_leader_of_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "is_sphere_leader_of = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "is_sphere_leader_of = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::is_sphere_leader_of_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "is_sphere_leader_of = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "is_sphere_leader_of = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -3175,7 +3193,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "is_sphere_leader_of trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_sphere_leader_of trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3191,14 +3209,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::constructing_cb_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "constructing_cb = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "constructing_cb = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::constructing_cb_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "constructing_cb = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "constructing_cb = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -3213,7 +3231,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "constructing_cb trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "constructing_cb trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3229,14 +3247,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::vassal_of_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "vassal_of = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "vassal_of = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::vassal_of_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "vassal_of = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "vassal_of = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -3251,7 +3269,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "vassal_of trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "vassal_of trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3267,14 +3285,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::substate_of_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "substate_of = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "substate_of = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::substate_of_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "substate_of = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "substate_of = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -3289,7 +3307,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "substate_of trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "substate_of trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3305,14 +3323,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::is_our_vassal_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "is_our_vassal = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "is_our_vassal = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::is_our_vassal_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "is_our_vassal = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "is_our_vassal = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -3327,7 +3345,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "is_our_vassal trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_our_vassal trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3343,7 +3361,7 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::this_culture_union_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "this_culture_union = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "this_culture_union = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_fixed_token_ci(value.data(), value.data() + value.length(), "this_union")) {
@@ -3356,14 +3374,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::this_culture_union_this_union_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "this_culture_union = this_union trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "this_culture_union = this_union trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::this_culture_union_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "this_culture_union = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "this_culture_union = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -3378,7 +3396,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "this_culture_union trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "this_culture_union trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3394,14 +3412,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::alliance_with_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "alliance_with = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "alliance_with = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::alliance_with_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "alliance_with = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "alliance_with = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -3416,7 +3434,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "alliance_with trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "alliance_with trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3432,14 +3450,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::in_default_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "in_default = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "in_default = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::in_default_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "in_default = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "in_default = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -3454,7 +3472,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "in_default trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "in_default trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3470,14 +3488,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::industrial_score_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "industrial_score = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "industrial_score = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::industrial_score_from_nation | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "industrial_score = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "industrial_score = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
@@ -3485,7 +3503,7 @@ struct trigger_body {
 				context.compiled_trigger.push_back(trigger::payload(uint16_t(parse_uint(value, line, err))).value);
 			}
 		} else {
-			err.accumulated_errors += "industrial_score trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "industrial_score trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3501,14 +3519,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::military_score_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "military_score = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "military_score = this trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::military_score_from_nation | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "military_score = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "military_score = from trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
@@ -3516,7 +3534,7 @@ struct trigger_body {
 				context.compiled_trigger.push_back(trigger::payload(uint16_t(parse_uint(value, line, err))).value);
 			}
 		} else {
-			err.accumulated_errors += "military_score trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "military_score trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3526,7 +3544,7 @@ struct trigger_body {
 				if(context.main_slot == trigger::slot_contents::nation) {
 					context.compiled_trigger.push_back(uint16_t(trigger::is_possible_vassal | association_to_bool_code(a)));
 				} else {
-					err.accumulated_errors += "is_possible_vassal trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "is_possible_vassal trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 				context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -3540,7 +3558,7 @@ struct trigger_body {
 
 	void diplomatic_influence(tr_diplomatic_influence const& value, error_handler& err, int32_t line, trigger_building_context& context) {
 		if(context.main_slot != trigger::slot_contents::nation) {
-			err.accumulated_errors += "diplomatic_influence trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "diplomatic_influence trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		} else if(is_from(value.who)) {
 			if(context.from_slot == trigger::slot_contents::nation)
@@ -3548,7 +3566,7 @@ struct trigger_body {
 			else if(context.from_slot == trigger::slot_contents::province)
 				context.compiled_trigger.push_back(uint16_t(trigger::diplomatic_influence_from_province | association_to_trigger_code(value.a)));
 			else {
-				err.accumulated_errors += "diplomatic_influence trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "diplomatic_influence trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(uint16_t(value.value_)).value);
@@ -3558,7 +3576,7 @@ struct trigger_body {
 			else if(context.this_slot == trigger::slot_contents::province)
 				context.compiled_trigger.push_back(uint16_t(trigger::diplomatic_influence_this_province | association_to_trigger_code(value.a)));
 			else {
-				err.accumulated_errors += "diplomatic_influence trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "diplomatic_influence trigger used in an incorrect scope " + slot_contents_to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(uint16_t(value.value_)).value);

--- a/src/parsing/trigger_parsing.hpp
+++ b/src/parsing/trigger_parsing.hpp
@@ -2844,8 +2844,6 @@ struct trigger_body {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_accepted_culture_state | trigger::no_payload | association_to_bool_code(a, value)));
 		} else if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_accepted_culture_province | trigger::no_payload | association_to_bool_code(a, value)));
-		} else if(context.main_slot == trigger::slot_contents::nation) {
-			context.compiled_trigger.push_back(uint16_t(trigger::is_accepted_culture_nation | trigger::no_payload | association_to_bool_code(a, value)));
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_accepted_culture_pop | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {

--- a/src/parsing/trigger_parsing.hpp
+++ b/src/parsing/trigger_parsing.hpp
@@ -13,24 +13,6 @@
 
 namespace parsers {
 
-std::string slot_contents_to_string(trigger::slot_contents v) {
-	switch(v) {
-	case trigger::slot_contents::empty:
-		return "empty";
-	case trigger::slot_contents::province:
-		return "province";
-	case trigger::slot_contents::state:
-		return "state";
-	case trigger::slot_contents::pop:
-		return "pop";
-	case trigger::slot_contents::nation:
-		return "nation";
-	case trigger::slot_contents::rebel:
-		return "rebel";
-	}
-	return "unknown";
-}
-
 struct trigger_building_context {
 	scenario_building_context& outer_context;
 	std::vector<uint16_t> compiled_trigger;
@@ -72,6 +54,24 @@ struct trigger_building_context {
 		compiled_trigger.push_back(pack_int.v.high);
 	}
 };
+
+inline std::string slot_contents_to_string(trigger::slot_contents v) {
+	switch(v) {
+	case trigger::slot_contents::empty:
+		return "empty";
+	case trigger::slot_contents::province:
+		return "province";
+	case trigger::slot_contents::state:
+		return "state";
+	case trigger::slot_contents::pop:
+		return "pop";
+	case trigger::slot_contents::nation:
+		return "nation";
+	case trigger::slot_contents::rebel:
+		return "rebel";
+	}
+	return "unknown";
+}
 
 inline uint16_t association_to_trigger_code(association_type a) {
 	switch(a) {

--- a/src/parsing/trigger_parsing.hpp
+++ b/src/parsing/trigger_parsing.hpp
@@ -251,7 +251,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::ai | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "ai trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "ai trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -288,7 +288,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::port | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "port trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "port trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -299,7 +299,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::involved_in_crisis_nation | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "involved_in_crisis trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "involved_in_crisis trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -307,7 +307,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation && context.this_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::has_cultural_sphere | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "has_cultural_sphere trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "has_cultural_sphere trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -318,7 +318,7 @@ struct trigger_body {
 		} else if(context.from_slot == trigger::slot_contents::rebel) {
 			context.compiled_trigger.push_back(uint16_t(trigger::social_movement_from_reb | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "social_movement trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "social_movement trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -328,7 +328,7 @@ struct trigger_body {
 		} else if(context.from_slot == trigger::slot_contents::rebel) {
 				context.compiled_trigger.push_back(uint16_t(trigger::political_movement_from_reb | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "political_movement trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "political_movement trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -336,7 +336,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::rich_tax_above_poor | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "rich_tax_above_poor trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "rich_tax_above_poor trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -345,7 +345,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_substate | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_substate trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_substate trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -353,7 +353,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::state) {
 			context.compiled_trigger.push_back(uint16_t(trigger::has_flashpoint | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "has_flashpoint trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "has_flashpoint trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -361,7 +361,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_disarmed | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_disarmed trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_disarmed trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -369,7 +369,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::can_nationalize | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "can_nationalize trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "can_nationalize trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -377,7 +377,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::part_of_sphere | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "part_of_sphere trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "part_of_sphere trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -385,7 +385,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::constructing_cb_discovered | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "constructing_cb_discovered trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "constructing_cb_discovered trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -393,7 +393,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::colonial_nation | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "colonial_nation trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "colonial_nation trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -401,7 +401,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_capital | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_capital trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_capital trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -409,7 +409,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::election | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "election trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "election trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -421,14 +421,14 @@ struct trigger_body {
 			if(context.from_slot == trigger::slot_contents::nation)
 				context.compiled_trigger.push_back(uint16_t(trigger::is_releasable_vassal_from | trigger::no_payload | association_to_bool_code(a)));
 			else {
-				err.accumulated_errors += "is_releasable_vassal trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "is_releasable_vassal trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else {
 			if(context.from_slot == trigger::slot_contents::nation)
 				context.compiled_trigger.push_back(uint16_t(trigger::is_releasable_vassal_other | trigger::no_payload | association_to_bool_code(a, parse_bool(value, line, err))));
 			else {
-				err.accumulated_errors += "is_releasable_vassal trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "is_releasable_vassal trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		}
@@ -439,14 +439,14 @@ struct trigger_body {
 			if(context.from_slot == trigger::slot_contents::nation)
 				context.compiled_trigger.push_back(uint16_t(trigger::someone_can_form_union_tag_from | trigger::no_payload | association_to_bool_code(a)));
 			else {
-				err.accumulated_errors += "someone_can_form_union_tag trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "someone_can_form_union_tag trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else {
 			if(context.from_slot == trigger::slot_contents::nation)
 				context.compiled_trigger.push_back(uint16_t(trigger::someone_can_form_union_tag_other | trigger::no_payload | association_to_bool_code(a, parse_bool(value, line, err))));
 			else {
-				err.accumulated_errors += "someone_can_form_union_tag trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "someone_can_form_union_tag trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		}
@@ -455,7 +455,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_state_capital | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_state_capital trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_state_capital trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -464,7 +464,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::state) {
 			context.compiled_trigger.push_back(uint16_t(trigger::has_factories | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "has_factories trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "has_factories trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -472,7 +472,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::has_empty_adjacent_province | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "has_empty_adjacent_province trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "has_empty_adjacent_province trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -484,7 +484,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::minorities_province | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "minorities trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "minorities trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -494,7 +494,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::culture_has_union_tag_pop | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "culture_has_union_tag trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "culture_has_union_tag trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -504,7 +504,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::state) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_colonial_state | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_colonial trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_colonial trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -516,7 +516,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_greater_power_province | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_greater_power trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_greater_power trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -524,7 +524,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::can_create_vassals | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "can_create_vassals trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "can_create_vassals trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -532,7 +532,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::has_recently_lost_war | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "has_recently_lost_war trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "has_recently_lost_war trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -540,7 +540,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_mobilised | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_mobilised trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_mobilised trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -554,7 +554,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::crime_higher_than_education_pop | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "crime_higher_than_education trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "crime_higher_than_education trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -567,7 +567,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::civilized_pop | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "civilized trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "civilized trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -576,7 +576,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::rank | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "rank trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "rank trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -591,7 +591,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::has_recent_imigration | association_to_le_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "has_recent_imigration trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "has_recent_imigration trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -601,7 +601,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::province_control_days | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "province_control_days trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "province_control_days trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -610,7 +610,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::num_of_substates | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "num_of_substates trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "num_of_substates trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -619,7 +619,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::num_of_vassals_no_substates | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "num_of_vassals_no_substates trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "num_of_vassals_no_substates trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -628,7 +628,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::number_of_states | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "number_of_states trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "number_of_states trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -638,7 +638,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::war_score | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "war_score trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "war_score trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -648,7 +648,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::state) {
 			context.compiled_trigger.push_back(uint16_t(trigger::flashpoint_tension | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "flashpoint_tension trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "flashpoint_tension trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -658,7 +658,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::life_needs | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "life_needs trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "life_needs trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -668,7 +668,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::everyday_needs | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "everyday_needs trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "everyday_needs trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -678,7 +678,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::luxury_needs | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "luxury_needs trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "luxury_needs trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -687,7 +687,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::social_movement_strength | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "social_movement_strength trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "social_movement_strength trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -696,7 +696,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::political_movement_strength | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "political_movement_strength trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "political_movement_strength trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -706,7 +706,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::total_num_of_ports | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "total_num_of_ports trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "total_num_of_ports trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -715,7 +715,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::agree_with_ruling_party | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "agree_with_ruling_party trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "agree_with_ruling_party trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -724,7 +724,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::constructing_cb_progress | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "constructing_cb_progress trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "constructing_cb_progress trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -733,7 +733,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::civilization_progress | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "civilization_progress trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "civilization_progress trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -749,7 +749,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::rich_strata_life_needs_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "rich_strata_life_needs trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "rich_strata_life_needs trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -764,7 +764,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::rich_strata_everyday_needs_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "rich_strata_everyday_needs trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "rich_strata_everyday_needs trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -779,7 +779,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::rich_strata_luxury_needs_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "rich_strata_luxury_needs trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "rich_strata_luxury_needs trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -795,7 +795,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::middle_strata_life_needs_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "middle_strata_life_needs trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "middle_strata_life_needs trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -810,7 +810,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::middle_strata_everyday_needs_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "middle_strata_everyday_needs trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "middle_strata_everyday_needs trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -825,7 +825,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::middle_strata_luxury_needs_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "middle_strata_luxury_needs trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "middle_strata_luxury_needs trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -842,7 +842,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::poor_strata_life_needs_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "poor_strata_life_needs trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "poor_strata_life_needs trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -857,7 +857,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::poor_strata_everyday_needs_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "poor_strata_everyday_needs trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "poor_strata_everyday_needs trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -872,7 +872,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::poor_strata_luxury_needs_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "poor_strata_luxury_needs trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "poor_strata_luxury_needs trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -884,7 +884,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::revanchism_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "revanchism trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "revanchism trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -900,7 +900,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::poor_strata_militancy_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "poor_strata_militancy trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "poor_strata_militancy trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -915,7 +915,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::middle_strata_militancy_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "middle_strata_militancy trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "middle_strata_militancy trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -930,7 +930,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::rich_strata_militancy_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "rich_strata_militancy trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "rich_strata_militancy trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -945,7 +945,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::consciousness_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "consciousness trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "consciousness trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -960,7 +960,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::literacy_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "literacy trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "literacy trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -975,7 +975,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::militancy_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "militancy trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "militancy trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -990,7 +990,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::military_spending_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "military_spending trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "military_spending trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(uint16_t(value * 100.0f));
@@ -1005,7 +1005,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::administration_spending_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "administration_spending trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "administration_spending trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(uint16_t(value * 100.0f));
@@ -1020,7 +1020,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::education_spending_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "education_spending trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "education_spending trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(uint16_t(value * 100.0f));
@@ -1029,7 +1029,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::national_provinces_occupied | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "national_provinces_occupied trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "national_provinces_occupied trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -1042,7 +1042,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::social_spending_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "social_spending trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "social_spending trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(uint16_t(value * 100.0f));
@@ -1054,11 +1054,11 @@ struct trigger_body {
 			} else if(context.from_slot == trigger::slot_contents::nation) {
 				context.compiled_trigger.push_back(uint16_t(trigger::brigades_compare_from | association_to_trigger_code(a)));
 			} else {
-				err.accumulated_errors += "brigades_compare trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "brigades_compare trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else {
-			err.accumulated_errors += "brigades_compare trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "brigades_compare trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -1067,7 +1067,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::rich_tax | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "rich_tax trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "rich_tax trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(uint16_t(value * 100.0f));
@@ -1076,7 +1076,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::middle_tax | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "middle_tax trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "middle_tax trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(uint16_t(value * 100.0f));
@@ -1085,7 +1085,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::poor_tax | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "poor_tax trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "poor_tax trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(uint16_t(value * 100.0f));
@@ -1094,7 +1094,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::mobilisation_size | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "mobilisation_size trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "mobilisation_size trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -1103,7 +1103,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::province_id | association_to_bool_code(a)));
 		} else {
-			err.accumulated_errors += "province_id trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "province_id trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		if(0 <= value && size_t(value) < context.outer_context.original_id_to_prov_id_map.size()) {
@@ -1119,7 +1119,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::nation) {
 				context.compiled_trigger.push_back(uint16_t(trigger::technology | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "invention trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "invention trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 
@@ -1129,7 +1129,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::nation) {
 				context.compiled_trigger.push_back(uint16_t(trigger::invention | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "invention trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "invention trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 
@@ -1143,7 +1143,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::nation) {
 				context.compiled_trigger.push_back(uint16_t(trigger::big_producer | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "big_producer trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "big_producer trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 
@@ -1165,7 +1165,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "strata trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "strata trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -1176,7 +1176,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::state) {
 			context.compiled_trigger.push_back(uint16_t(trigger::life_rating_state | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "life_rating trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "life_rating trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(int16_t(value)).value);
@@ -1188,7 +1188,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::state) {
 			context.compiled_trigger.push_back(uint16_t(trigger::has_empty_adjacent_state_state | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "has_empty_adjacent_state trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "has_empty_adjacent_state trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -1199,7 +1199,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::state) {
 			context.compiled_trigger.push_back(uint16_t(trigger::state_id_state | association_to_bool_code(a)));
 		} else {
-			err.accumulated_errors += "state_id trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "state_id trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		if(0 <= value && size_t(value) < context.outer_context.original_id_to_prov_id_map.size()) {
@@ -1213,7 +1213,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::cash_reserves | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "cash_reserves trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "cash_reserves trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -1228,7 +1228,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::unemployment_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "unemployment trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "unemployment trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -1244,7 +1244,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_slave_pop | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_slave trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_slave trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -1253,7 +1253,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_independant | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_independant trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_independant trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -1266,7 +1266,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::has_national_minority_province | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "has_national_minority trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "has_national_minority trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -1278,7 +1278,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::government_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "government trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "government trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 
@@ -1293,7 +1293,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::nation) {
 				context.compiled_trigger.push_back(uint16_t(trigger::constructing_cb_type | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "constructing_cb_type trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "constructing_cb_type trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 
@@ -1308,7 +1308,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::nation) {
 				context.compiled_trigger.push_back(uint16_t(trigger::can_build_factory_in_capital_state | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "can_build_factory_in_capital_state trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "can_build_factory_in_capital_state trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 
@@ -1321,7 +1321,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::capital | association_to_bool_code(a)));
 		} else {
-			err.accumulated_errors += "capital trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "capital trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		if(0 <= value && size_t(value) < context.outer_context.original_id_to_prov_id_map.size()) {
@@ -1336,7 +1336,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::nation) {
 				context.compiled_trigger.push_back(uint16_t(trigger::tech_school | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "tech_school trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "tech_school trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 
@@ -1350,7 +1350,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::nation) {
 				context.compiled_trigger.push_back(uint16_t(trigger::primary_culture | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "primary_culture trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "primary_culture trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 
@@ -1364,7 +1364,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::province) {
 				context.compiled_trigger.push_back(uint16_t(trigger::has_crime | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "has_crime trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "has_crime trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 
@@ -1378,7 +1378,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::nation) {
 				context.compiled_trigger.push_back(uint16_t(trigger::accepted_culture | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "accepted_culture trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "accepted_culture trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 
@@ -1396,7 +1396,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::province) {
 				context.compiled_trigger.push_back(uint16_t(trigger::pop_majority_religion_province | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "pop_majority_religion trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "pop_majority_religion trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -1413,7 +1413,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::province) {
 				context.compiled_trigger.push_back(uint16_t(trigger::pop_majority_culture_province | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "pop_majority_culture trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "pop_majority_culture trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -1432,7 +1432,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::pop_majority_issue_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "pop_majority_issue trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "pop_majority_issue trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second.id).value);
@@ -1451,7 +1451,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::pop_majority_ideology_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "pop_majority_ideology trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "pop_majority_ideology trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second.id).value);
@@ -1466,7 +1466,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::province) {
 				context.compiled_trigger.push_back(uint16_t(trigger::trade_goods_in_state_province | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "trade_goods_in_state trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "trade_goods_in_state trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -1487,23 +1487,23 @@ struct trigger_body {
 				} else if(context.main_slot == trigger::slot_contents::pop) {
 					context.compiled_trigger.push_back(uint16_t(trigger::culture_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				} else {
-					err.accumulated_errors += "culture trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "culture trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
-				err.accumulated_errors += "culture = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "culture = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(is_from(value)) {
 			if(context.main_slot == trigger::slot_contents::pop && context.from_slot == trigger::slot_contents::nation)
 				context.compiled_trigger.push_back(uint16_t(trigger::culture_from_nation | trigger::no_payload | association_to_bool_code(a)));
 			else {
-				err.accumulated_errors += "culture = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "culture = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(is_reb(value)) {
 			if(context.from_slot != trigger::slot_contents::rebel) {
-				err.accumulated_errors += "culture = reb trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "culture = reb trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			} else if(context.main_slot == trigger::slot_contents::pop)
 				context.compiled_trigger.push_back(uint16_t(trigger::culture_pop_reb | trigger::no_payload | association_to_bool_code(a)));
@@ -1514,7 +1514,7 @@ struct trigger_body {
 			else if(context.main_slot == trigger::slot_contents::nation)
 				context.compiled_trigger.push_back(uint16_t(trigger::culture_nation_reb | trigger::no_payload | association_to_bool_code(a)));
 			else {
-				err.accumulated_errors += "culture = reb trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "culture = reb trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(auto it = context.outer_context.map_of_culture_names.find(std::string(value)); it != context.outer_context.map_of_culture_names.end()) {
@@ -1527,7 +1527,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::culture_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "culture trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "culture trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -1547,11 +1547,11 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::province)
 					context.compiled_trigger.push_back(uint16_t(trigger::has_pop_culture_province_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "has_pop_culture = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "has_pop_culture = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
-				err.accumulated_errors += "has_pop_culture = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "has_pop_culture = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(auto it = context.outer_context.map_of_culture_names.find(std::string(value)); it != context.outer_context.map_of_culture_names.end()) {
@@ -1564,7 +1564,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::has_pop_culture_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "has_pop_culture trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "has_pop_culture trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -1584,11 +1584,11 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::province)
 					context.compiled_trigger.push_back(uint16_t(trigger::has_pop_religion_province_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "has_pop_religion = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "has_pop_religion = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
-				err.accumulated_errors += "has_pop_religion = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "has_pop_religion = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(auto it = context.outer_context.map_of_religion_names.find(std::string(value)); it != context.outer_context.map_of_religion_names.end()) {
@@ -1601,7 +1601,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::has_pop_religion_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "has_pop_religion trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "has_pop_religion trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -1618,7 +1618,7 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::culture_group_pop_this_nation | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "culture_group = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "culture_group = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(context.this_slot == trigger::slot_contents::state) {
@@ -1627,7 +1627,7 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::culture_group_pop_this_state | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "culture_group = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "culture_group = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(context.this_slot == trigger::slot_contents::province) {
@@ -1636,7 +1636,7 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::culture_group_pop_this_province | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "culture_group = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "culture_group = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(context.this_slot == trigger::slot_contents::pop) {
@@ -1645,11 +1645,11 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::culture_group_pop_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "culture_group = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "culture_group = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
-				err.accumulated_errors += "culture_group = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "culture_group = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(is_from(value)) {
@@ -1659,11 +1659,11 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::culture_group_pop_from_nation | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "culture_group = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "culture_group = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
-				err.accumulated_errors += "culture_group = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "culture_group = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(is_reb(value)) {
@@ -1673,11 +1673,11 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::culture_group_reb_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "culture_group = reb trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "culture_group = reb trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
-				err.accumulated_errors += "culture_group = reb trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "culture_group = reb trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(auto it = context.outer_context.map_of_culture_group_names.find(std::string(value)); it != context.outer_context.map_of_culture_group_names.end()) {
@@ -1686,7 +1686,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::culture_group_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "culture_group trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "culture_group trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -1703,7 +1703,7 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::religion_this_nation | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "religion = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "religion = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(context.this_slot == trigger::slot_contents::state) {
@@ -1712,7 +1712,7 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::religion_this_state | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "religion = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "religion = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(context.this_slot == trigger::slot_contents::province) {
@@ -1721,7 +1721,7 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::religion_this_province | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "religion = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "religion = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(context.this_slot == trigger::slot_contents::pop) {
@@ -1730,11 +1730,11 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::religion_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "religion = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "religion = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
-				err.accumulated_errors += "religion = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "religion = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(is_from(value)) {
@@ -1744,11 +1744,11 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::religion_from_nation | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "religion = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "religion = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
-				err.accumulated_errors += "religion = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "religion = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(is_reb(value)) {
@@ -1758,11 +1758,11 @@ struct trigger_body {
 				else if(context.main_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::religion_reb | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "religion = reb trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "religion = reb trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
-				err.accumulated_errors += "religion = reb trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "religion = reb trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(auto it = context.outer_context.map_of_religion_names.find(std::string(value)); it != context.outer_context.map_of_religion_names.end()) {
@@ -1771,7 +1771,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::religion | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "religion trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "religion trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -1786,7 +1786,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::province) {
 				context.compiled_trigger.push_back(uint16_t(trigger::terrain_province | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "terrain trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "terrain trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second.id).value);
@@ -1799,7 +1799,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::province) {
 				context.compiled_trigger.push_back(uint16_t(trigger::trade_goods | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "trade_goods trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "trade_goods trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -1813,7 +1813,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_secondary_power_pop | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_secondary_power trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_secondary_power trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -1824,7 +1824,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::has_faction_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "has_faction trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "has_faction trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second.id).value);
@@ -1836,7 +1836,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::has_unclaimed_cores | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "has_unclaimed_cores trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "has_unclaimed_cores trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -1846,7 +1846,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::nation)
 				context.compiled_trigger.push_back(uint16_t(trigger::is_cultural_union_bool | trigger::no_payload | association_to_bool_code(a, parse_bool(value, line, err))));
 			else {
-				err.accumulated_errors += "is_cultural_union = bool trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "is_cultural_union = bool trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(is_this(value)) {
@@ -1866,11 +1866,11 @@ struct trigger_body {
 				else if(context.from_slot == trigger::slot_contents::rebel)
 					context.compiled_trigger.push_back(uint16_t(trigger::is_cultural_union_this_rebel | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "is_cultural_union = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "is_cultural_union = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
-				err.accumulated_errors += "is_cultural_union = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "is_cultural_union = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(value.length() == 3) {
@@ -1887,7 +1887,7 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::is_cultural_union_tag_this_nation | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "is_cultural_union = tag trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "is_cultural_union = tag trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 				context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -1906,7 +1906,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::can_build_factory_pop | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "can_build_factory trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "can_build_factory trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -1916,7 +1916,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::war_pop | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "war trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "war trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -1928,7 +1928,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::war_exhaustion_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "war_exhaustion trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "war_exhaustion trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value / 100.0f);
@@ -1937,7 +1937,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::blockade | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "blockade trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "blockade trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -1946,7 +1946,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::owns | association_to_bool_code(a)));
 		} else {
-			err.accumulated_errors += "owns trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "owns trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		if(0 <= value && size_t(value) < context.outer_context.original_id_to_prov_id_map.size()) {
@@ -1960,7 +1960,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::controls | association_to_bool_code(a)));
 		} else {
-			err.accumulated_errors += "controls trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "controls trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		if(0 <= value && size_t(value) < context.outer_context.original_id_to_prov_id_map.size()) {
@@ -1982,21 +1982,21 @@ struct trigger_body {
 			} else if(context.this_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::is_core_this_pop | trigger::no_payload | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "is_core = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "is_core = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(is_from(value) && context.main_slot == trigger::slot_contents::province) {
 			if(context.from_slot == trigger::slot_contents::nation) {
 				context.compiled_trigger.push_back(uint16_t(trigger::is_core_from_nation | trigger::no_payload | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "is_core = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "is_core = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(is_reb(value) && context.main_slot == trigger::slot_contents::province) {
 			if(context.from_slot == trigger::slot_contents::rebel) {
 				context.compiled_trigger.push_back(uint16_t(trigger::is_core_reb | trigger::no_payload | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "is_core = reb trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "is_core = reb trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(is_integer(value.data(), value.data() + value.length())) {
@@ -2010,7 +2010,7 @@ struct trigger_body {
 					context.compiled_trigger.push_back(trigger::payload(dcon::province_id()).value);
 				}
 			} else {
-				err.accumulated_errors += "is_core trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "is_core trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(value.length() == 3 && context.main_slot == trigger::slot_contents::province) {
@@ -2028,7 +2028,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::num_of_revolts | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "num_of_revolts trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "num_of_revolts trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -2037,7 +2037,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::revolt_percentage | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "revolt_percentage trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "revolt_percentage trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -2053,21 +2053,21 @@ struct trigger_body {
 			} else if(context.this_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::num_of_cities_this_pop | trigger::no_payload | association_to_trigger_code(a)));
 			} else {
-				err.accumulated_errors += "num_of_cities = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "num_of_cities = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(is_from(value) && context.main_slot == trigger::slot_contents::nation) {
 			if(context.from_slot == trigger::slot_contents::nation) {
 				context.compiled_trigger.push_back(uint16_t(trigger::num_of_cities_from_nation | trigger::no_payload | association_to_trigger_code(a)));
 			} else {
-				err.accumulated_errors += "num_of_cities = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "num_of_cities = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::num_of_cities_int | association_to_trigger_code(a)));
 			context.compiled_trigger.push_back(trigger::payload(uint16_t(parse_uint(value, line, err))).value);
 		} else {
-			err.accumulated_errors += "num_of_cities trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "num_of_cities trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2075,7 +2075,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::num_of_ports | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "num_of_ports trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "num_of_ports trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -2084,7 +2084,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::num_of_allies | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "num_of_allies trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "num_of_allies trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -2093,7 +2093,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::num_of_vassals | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "num_of_vassals trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "num_of_vassals trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -2110,14 +2110,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::owned_by_this_nation | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "owned_by = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "owned_by = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::owned_by_from_nation | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "owned_by = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "owned_by = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -2132,7 +2132,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "owned_by trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "owned_by trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2142,7 +2142,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::exists_bool | trigger::no_payload | association_to_bool_code(a, parse_bool(value, line, err))));
 			else {
-				err.accumulated_errors += "exists = bool trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "exists = bool trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 			}
 		} else if(value.length() == 3) {
@@ -2166,7 +2166,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::has_country_flag_province | association_to_bool_code(a)));
 		} else {
-			err.accumulated_errors += "has_country_flag trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "has_country_flag trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(context.outer_context.get_national_flag(std::string(value))).value);
@@ -2182,14 +2182,14 @@ struct trigger_body {
 				if(context.this_slot == trigger::slot_contents::nation) {
 					context.compiled_trigger.push_back(uint16_t(trigger::continent_nation_this | trigger::no_payload | association_to_bool_code(a)));
 				} else {
-					err.accumulated_errors += "continent = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "continent = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation) {
 					context.compiled_trigger.push_back(uint16_t(trigger::continent_nation_from | trigger::no_payload | association_to_bool_code(a)));
 				} else {
-					err.accumulated_errors += "continent = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "continent = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(auto it = context.outer_context.map_of_modifiers.find(std::string(value)); it != context.outer_context.map_of_modifiers.end()) {
@@ -2204,14 +2204,14 @@ struct trigger_body {
 				if(context.this_slot == trigger::slot_contents::nation) {
 					context.compiled_trigger.push_back(uint16_t(trigger::continent_state_this | trigger::no_payload | association_to_bool_code(a)));
 				} else {
-					err.accumulated_errors += "continent = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "continent = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation) {
 					context.compiled_trigger.push_back(uint16_t(trigger::continent_state_from | trigger::no_payload | association_to_bool_code(a)));
 				} else {
-					err.accumulated_errors += "continent = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "continent = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(auto it = context.outer_context.map_of_modifiers.find(std::string(value)); it != context.outer_context.map_of_modifiers.end()) {
@@ -2226,14 +2226,14 @@ struct trigger_body {
 				if(context.this_slot == trigger::slot_contents::nation) {
 					context.compiled_trigger.push_back(uint16_t(trigger::continent_province_this | trigger::no_payload | association_to_bool_code(a)));
 				} else {
-					err.accumulated_errors += "continent = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "continent = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation) {
 					context.compiled_trigger.push_back(uint16_t(trigger::continent_province_from | trigger::no_payload | association_to_bool_code(a)));
 				} else {
-					err.accumulated_errors += "continent = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "continent = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(auto it = context.outer_context.map_of_modifiers.find(std::string(value)); it != context.outer_context.map_of_modifiers.end()) {
@@ -2248,14 +2248,14 @@ struct trigger_body {
 				if(context.this_slot == trigger::slot_contents::nation) {
 					context.compiled_trigger.push_back(uint16_t(trigger::continent_pop_this | trigger::no_payload | association_to_bool_code(a)));
 				} else {
-					err.accumulated_errors += "continent = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "continent = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation) {
 					context.compiled_trigger.push_back(uint16_t(trigger::continent_pop_from | trigger::no_payload | association_to_bool_code(a)));
 				} else {
-					err.accumulated_errors += "continent = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "continent = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(auto it = context.outer_context.map_of_modifiers.find(std::string(value)); it != context.outer_context.map_of_modifiers.end()) {
@@ -2266,7 +2266,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "continent trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "continent trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2282,14 +2282,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::casus_belli_this_nation | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "casus_belli = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "casus_belli = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::casus_belli_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "casus_belli = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "casus_belli = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -2304,7 +2304,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "casus_belli trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "casus_belli trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2321,14 +2321,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::military_access_this_nation | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "military_access = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "military_access = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::military_access_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "military_access = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "military_access = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -2343,7 +2343,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "military_access trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "military_access trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2360,14 +2360,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::prestige_this_nation | trigger::no_payload | association_to_trigger_code(a)));
 				else {
-					err.accumulated_errors += "prestige = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "prestige = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::prestige_from | trigger::no_payload | association_to_trigger_code(a)));
 				else {
-					err.accumulated_errors += "prestige = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "prestige = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
@@ -2376,7 +2376,7 @@ struct trigger_body {
 				context.add_float_to_payload(fvalue);
 			}
 		} else {
-			err.accumulated_errors += "prestige trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "prestige trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2409,7 +2409,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "has_building trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "has_building trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2417,7 +2417,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::empty | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "empty trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "empty trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2425,7 +2425,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_blockaded | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_blockaded trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_blockaded trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2437,7 +2437,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::province) {
 				context.compiled_trigger.push_back(uint16_t(trigger::has_country_modifier_province | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "has_country_modifier trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "has_country_modifier trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -2450,7 +2450,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::province) {
 				context.compiled_trigger.push_back(uint16_t(trigger::has_province_modifier | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "has_province_modifier trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "has_province_modifier trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -2467,7 +2467,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::nationalvalue_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "nationalvalue trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "nationalvalue trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -2480,7 +2480,7 @@ struct trigger_body {
 			if(context.main_slot == trigger::slot_contents::province) {
 				context.compiled_trigger.push_back(uint16_t(trigger::region | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "region trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "region trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -2497,7 +2497,7 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::tag_this_nation | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "tag = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "tag = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
@@ -2506,7 +2506,7 @@ struct trigger_body {
 				else if(context.from_slot == trigger::slot_contents::province)
 					context.compiled_trigger.push_back(uint16_t(trigger::tag_from_province | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "tag = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "tag = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -2533,7 +2533,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "tag trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "tag trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2543,14 +2543,14 @@ struct trigger_body {
 				if(context.this_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::neighbour_this | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "neighbour = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "neighbour = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::neighbour_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "neighbour = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "neighbour = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -2565,7 +2565,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "neighbour trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "neighbour trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2581,14 +2581,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::units_in_province_this_pop | trigger::no_payload | association_to_trigger_code(a)));
 				else {
-					err.accumulated_errors += "units_in_province = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "units_in_province = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::units_in_province_from | trigger::no_payload | association_to_trigger_code(a)));
 				else {
-					err.accumulated_errors += "units_in_province = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "units_in_province = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
@@ -2596,7 +2596,7 @@ struct trigger_body {
 				context.compiled_trigger.push_back(trigger::payload(uint16_t(parse_uint(value, line, err))).value);
 			}
 		} else {
-			err.accumulated_errors += "units_in_province trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "units_in_province trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2612,14 +2612,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::war_with_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "war_with = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "war_with = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::war_with_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "war_with = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "war_with = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -2634,7 +2634,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "war_with trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "war_with trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2642,7 +2642,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::unit_in_battle | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "unit_in_battle trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "unit_in_battle trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2650,7 +2650,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::total_amount_of_divisions | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "total_amount_of_divisions trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "total_amount_of_divisions trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -2659,7 +2659,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::money | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "money trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "money trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -2668,7 +2668,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::lost_national | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "lost_national trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "lost_national trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -2677,7 +2677,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_vassal | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_vassal trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_vassal trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2688,7 +2688,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::ruling_party_ideology_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "ruling_party_ideology trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "ruling_party_ideology trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second.id).value);
@@ -2712,7 +2712,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::political_reform_want_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "political_reform_want trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "political_reform_want trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -2723,7 +2723,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::social_reform_want_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "social_reform_want trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "social_reform_want trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -2732,7 +2732,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::total_amount_of_ships | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "total_amount_of_ships trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "total_amount_of_ships trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -2741,7 +2741,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::plurality | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "plurality trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "plurality trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value / 100.0f);
@@ -2750,7 +2750,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::corruption | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "corruption trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "corruption trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -2763,7 +2763,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_state_religion_pop | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_state_religion trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_state_religion trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2779,7 +2779,7 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::is_primary_culture_nation_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "is_primary_culture = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "is_primary_culture = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(context.main_slot == trigger::slot_contents::state) {
@@ -2792,7 +2792,7 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::is_primary_culture_state_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "is_primary_culture = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "is_primary_culture = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(context.main_slot == trigger::slot_contents::province) {
@@ -2805,7 +2805,7 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::is_primary_culture_province_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "is_primary_culture = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "is_primary_culture = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(context.main_slot == trigger::slot_contents::pop) {
@@ -2818,11 +2818,11 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::is_primary_culture_pop_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "is_primary_culture = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "is_primary_culture = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
-				err.accumulated_errors += "is_primary_culture = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "is_primary_culture = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		} else {
@@ -2834,7 +2834,7 @@ struct trigger_body {
 			else if(context.main_slot == trigger::slot_contents::pop)
 				context.compiled_trigger.push_back(uint16_t(trigger::is_primary_culture_pop | trigger::no_payload | association_to_bool_code(a, v)));
 			else {
-				err.accumulated_errors += "is_primary_culture trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "is_primary_culture trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 		}
@@ -2847,7 +2847,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_accepted_culture_pop | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_accepted_culture trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_accepted_culture trigger used in an incorrect scope type " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2855,7 +2855,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_coastal | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_coastal trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_coastal trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2871,14 +2871,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::in_sphere_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "in_sphere = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "in_sphere = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::in_sphere_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "in_sphere = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "in_sphere = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -2893,7 +2893,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "in_sphere trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "in_sphere trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -2908,7 +2908,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::produces_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "produces trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "produces trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -2927,7 +2927,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::has_pop_type_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "has_pop_type trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "has_pop_type trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -2945,7 +2945,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::total_pops_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "total_pops trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "total_pops trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -2958,7 +2958,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::average_militancy_province | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "average_militancy trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "average_militancy trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -2971,7 +2971,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::average_consciousness_province | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "average_consciousness trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "average_consciousness trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -2983,7 +2983,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::is_next_reform_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "is_next_reform trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "is_next_reform trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second.id).value);
@@ -2993,7 +2993,7 @@ struct trigger_body {
 			} else if(context.main_slot == trigger::slot_contents::pop) {
 				context.compiled_trigger.push_back(uint16_t(trigger::is_next_rreform_pop | association_to_bool_code(a)));
 			} else {
-				err.accumulated_errors += "is_next_reform trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "is_next_reform trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(it->second.id).value);
@@ -3005,7 +3005,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::nation) {
 			context.compiled_trigger.push_back(uint16_t(trigger::rebel_power_fraction | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "rebel_power_fraction trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "rebel_power_fraction trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -3016,7 +3016,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::recruited_percentage_pop | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "recruited_percentage trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "recruited_percentage trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.add_float_to_payload(value);
@@ -3027,7 +3027,7 @@ struct trigger_body {
 		} else if(context.main_slot == trigger::slot_contents::province && context.this_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::has_culture_core_province_this_pop | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "has_culture_core trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "has_culture_core trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3035,7 +3035,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::nationalism | association_to_trigger_code(a)));
 		} else {
-			err.accumulated_errors += "nationalism trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "nationalism trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 		context.compiled_trigger.push_back(trigger::payload(uint16_t(value)).value);
@@ -3044,7 +3044,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_overseas | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "is_overseas trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_overseas trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3052,7 +3052,7 @@ struct trigger_body {
 		if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::controlled_by_rebels | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {
-			err.accumulated_errors += "controlled_by_rebels trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "controlled_by_rebels trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3068,21 +3068,21 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::controlled_by_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "controlled_by = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "controlled_by = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::controlled_by_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "controlled_by = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "controlled_by = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_reb(value)) {
 				if(context.from_slot == trigger::slot_contents::rebel)
 					context.compiled_trigger.push_back(uint16_t(trigger::controlled_by_reb | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "controlled_by = reb trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "controlled_by = reb trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_fixed_token_ci(value.data(), value.data() + value.length(), "owner")) {
@@ -3099,7 +3099,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "controlled_by trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "controlled_by trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3115,14 +3115,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::truce_with_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "truce_with = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "truce_with = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::truce_with_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "truce_with = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "truce_with = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -3137,7 +3137,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "truce_with trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "truce_with trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3153,14 +3153,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::is_sphere_leader_of_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "is_sphere_leader_of = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "is_sphere_leader_of = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::is_sphere_leader_of_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "is_sphere_leader_of = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "is_sphere_leader_of = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -3175,7 +3175,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "is_sphere_leader_of trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_sphere_leader_of trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3191,14 +3191,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::constructing_cb_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "constructing_cb = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "constructing_cb = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::constructing_cb_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "constructing_cb = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "constructing_cb = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -3213,7 +3213,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "constructing_cb trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "constructing_cb trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3229,14 +3229,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::vassal_of_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "vassal_of = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "vassal_of = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::vassal_of_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "vassal_of = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "vassal_of = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -3251,7 +3251,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "vassal_of trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "vassal_of trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3267,14 +3267,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::substate_of_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "substate_of = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "substate_of = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::substate_of_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "substate_of = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "substate_of = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -3289,7 +3289,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "substate_of trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "substate_of trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3305,14 +3305,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::is_our_vassal_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "is_our_vassal = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "is_our_vassal = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::is_our_vassal_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "is_our_vassal = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "is_our_vassal = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -3327,7 +3327,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "is_our_vassal trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "is_our_vassal trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3343,7 +3343,7 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::this_culture_union_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "this_culture_union = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "this_culture_union = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_fixed_token_ci(value.data(), value.data() + value.length(), "this_union")) {
@@ -3356,14 +3356,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::this_culture_union_this_union_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "this_culture_union = this_union trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "this_culture_union = this_union trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::this_culture_union_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "this_culture_union = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "this_culture_union = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -3378,7 +3378,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "this_culture_union trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "this_culture_union trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3394,14 +3394,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::alliance_with_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "alliance_with = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "alliance_with = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::alliance_with_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "alliance_with = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "alliance_with = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -3416,7 +3416,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "alliance_with trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "alliance_with trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3432,14 +3432,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::in_default_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "in_default = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "in_default = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::in_default_from | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "in_default = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "in_default = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(value.length() == 3) {
@@ -3454,7 +3454,7 @@ struct trigger_body {
 				return;
 			}
 		} else {
-			err.accumulated_errors += "in_default trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "in_default trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3470,14 +3470,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::industrial_score_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "industrial_score = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "industrial_score = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::industrial_score_from_nation | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "industrial_score = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "industrial_score = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
@@ -3485,7 +3485,7 @@ struct trigger_body {
 				context.compiled_trigger.push_back(trigger::payload(uint16_t(parse_uint(value, line, err))).value);
 			}
 		} else {
-			err.accumulated_errors += "industrial_score trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "industrial_score trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3501,14 +3501,14 @@ struct trigger_body {
 				else if(context.this_slot == trigger::slot_contents::pop)
 					context.compiled_trigger.push_back(uint16_t(trigger::military_score_this_pop | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "military_score = this trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "military_score = this trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else if(is_from(value)) {
 				if(context.from_slot == trigger::slot_contents::nation)
 					context.compiled_trigger.push_back(uint16_t(trigger::military_score_from_nation | trigger::no_payload | association_to_bool_code(a)));
 				else {
-					err.accumulated_errors += "military_score = from trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "military_score = from trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 			} else {
@@ -3516,7 +3516,7 @@ struct trigger_body {
 				context.compiled_trigger.push_back(trigger::payload(uint16_t(parse_uint(value, line, err))).value);
 			}
 		} else {
-			err.accumulated_errors += "military_score trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "military_score trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		}
 	}
@@ -3526,7 +3526,7 @@ struct trigger_body {
 				if(context.main_slot == trigger::slot_contents::nation) {
 					context.compiled_trigger.push_back(uint16_t(trigger::is_possible_vassal | association_to_bool_code(a)));
 				} else {
-					err.accumulated_errors += "is_possible_vassal trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+					err.accumulated_errors += "is_possible_vassal trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 					return;
 				}
 				context.compiled_trigger.push_back(trigger::payload(it->second).value);
@@ -3540,7 +3540,7 @@ struct trigger_body {
 
 	void diplomatic_influence(tr_diplomatic_influence const& value, error_handler& err, int32_t line, trigger_building_context& context) {
 		if(context.main_slot != trigger::slot_contents::nation) {
-			err.accumulated_errors += "diplomatic_influence trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+			err.accumulated_errors += "diplomatic_influence trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 			return;
 		} else if(is_from(value.who)) {
 			if(context.from_slot == trigger::slot_contents::nation)
@@ -3548,7 +3548,7 @@ struct trigger_body {
 			else if(context.from_slot == trigger::slot_contents::province)
 				context.compiled_trigger.push_back(uint16_t(trigger::diplomatic_influence_from_province | association_to_trigger_code(value.a)));
 			else {
-				err.accumulated_errors += "diplomatic_influence trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "diplomatic_influence trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(uint16_t(value.value_)).value);
@@ -3558,7 +3558,7 @@ struct trigger_body {
 			else if(context.this_slot == trigger::slot_contents::province)
 				context.compiled_trigger.push_back(uint16_t(trigger::diplomatic_influence_this_province | association_to_trigger_code(value.a)));
 			else {
-				err.accumulated_errors += "diplomatic_influence trigger used in an incorrect scope type (" + err.file_name + ", line " + std::to_string(line) + ")\n";
+				err.accumulated_errors += "diplomatic_influence trigger used in an incorrect scope " + trigger::to_string(context.main_slot) + " (" + err.file_name + ", line " + std::to_string(line) + ")\n";
 				return;
 			}
 			context.compiled_trigger.push_back(trigger::payload(uint16_t(value.value_)).value);

--- a/src/parsing/trigger_parsing.hpp
+++ b/src/parsing/trigger_parsing.hpp
@@ -2844,6 +2844,8 @@ struct trigger_body {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_accepted_culture_state | trigger::no_payload | association_to_bool_code(a, value)));
 		} else if(context.main_slot == trigger::slot_contents::province) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_accepted_culture_province | trigger::no_payload | association_to_bool_code(a, value)));
+		} else if(context.main_slot == trigger::slot_contents::nation) {
+			context.compiled_trigger.push_back(uint16_t(trigger::is_accepted_culture_nation | trigger::no_payload | association_to_bool_code(a, value)));
 		} else if(context.main_slot == trigger::slot_contents::pop) {
 			context.compiled_trigger.push_back(uint16_t(trigger::is_accepted_culture_pop | trigger::no_payload | association_to_bool_code(a, value)));
 		} else {

--- a/src/scripting/script_constants.hpp
+++ b/src/scripting/script_constants.hpp
@@ -1420,9 +1420,8 @@ constexpr inline uint16_t variable_reform_group_name_state = 0x0273;
 constexpr inline uint16_t variable_reform_group_name_province = 0x0274;
 constexpr inline uint16_t variable_reform_group_name_pop = 0x0275;
 // non-vanilla triggers
-constexpr inline uint16_t is_accepted_culture_nation = 0x0276;
 
-constexpr inline uint16_t first_scope_code = 0x0277;
+constexpr inline uint16_t first_scope_code = 0x0276;
 
 //technology name -- payload 1
 //ideology name -- 4 variants payload 2
@@ -2129,7 +2128,6 @@ inline constexpr int32_t data_sizes[] = {
 	2, //constexpr inline uint16_t variable_reform_group_name_pop = 0x0275;
 
 	// non-vanilla triggers
-	0, //constexpr inline uint16_t is_accepted_culture_nation = 0x0276;
 };
 
 enum class slot_contents {

--- a/src/scripting/script_constants.hpp
+++ b/src/scripting/script_constants.hpp
@@ -1419,8 +1419,10 @@ constexpr inline uint16_t variable_reform_group_name_nation = 0x0272;
 constexpr inline uint16_t variable_reform_group_name_state = 0x0273;
 constexpr inline uint16_t variable_reform_group_name_province = 0x0274;
 constexpr inline uint16_t variable_reform_group_name_pop = 0x0275;
+// non-vanilla triggers
+constexpr inline uint16_t is_accepted_culture_nation = 0x0276;
 
-constexpr inline uint16_t first_scope_code = 0x0276;
+constexpr inline uint16_t first_scope_code = 0x0277;
 
 //technology name -- payload 1
 //ideology name -- 4 variants payload 2
@@ -2126,6 +2128,8 @@ inline constexpr int32_t data_sizes[] = {
 	2, //constexpr inline uint16_t variable_reform_group_name_province = 0x0274;
 	2, //constexpr inline uint16_t variable_reform_group_name_pop = 0x0275;
 
+	// non-vanilla triggers
+	0, //constexpr inline uint16_t is_accepted_culture_nation = 0x0276;
 };
 
 enum class slot_contents {

--- a/src/scripting/script_constants.hpp
+++ b/src/scripting/script_constants.hpp
@@ -2139,24 +2139,6 @@ enum class slot_contents {
 	rebel = 5
 };
 
-std::string to_string(slot_contents v) {
-	switch(v) {
-	case slot_contents::empty:
-		return "empty";
-	case slot_contents::province:
-		return "province";
-	case slot_contents::state:
-		return "state";
-	case slot_contents::pop:
-		return "pop";
-	case slot_contents::nation:
-		return "nation";
-	case slot_contents::rebel:
-		return "rebel";
-	}
-	return "unknown";
-}
-
 union payload {
 
 	uint16_t value;

--- a/src/scripting/script_constants.hpp
+++ b/src/scripting/script_constants.hpp
@@ -2137,6 +2137,24 @@ enum class slot_contents {
 	rebel = 5
 };
 
+std::string to_string(slot_contents v) {
+	switch(v) {
+	case slot_contents::empty:
+		return "empty";
+	case slot_contents::province:
+		return "province";
+	case slot_contents::state:
+		return "state";
+	case slot_contents::pop:
+		return "pop";
+	case slot_contents::nation:
+		return "nation";
+	case slot_contents::rebel:
+		return "rebel";
+	}
+	return "unknown";
+}
+
 union payload {
 
 	uint16_t value;

--- a/src/scripting/triggers.cpp
+++ b/src/scripting/triggers.cpp
@@ -4615,6 +4615,14 @@ TRIGGER_FUNCTION(tf_variable_reform_group_name_pop) {
 	auto issue = payload(tval[1]).ref_id;;
 	return compare_values_eq(tval[0], ws.world.nation_get_reforms(owner, issue), option);
 }
+//
+// non-vanilla triggers
+//
+TRIGGER_FUNCTION(tf_is_accepted_culture_nation) {
+	// stub: virtually unused
+	auto is_accepted = true;//ws.world.nation_get_accepted_cultures(to_nation(primary_slot), to_cul);
+	return compare_to_true(tval[0], is_accepted);
+}
 TRIGGER_FUNCTION(tf_variable_pop_type_name_nation) {
 	auto total_pop = ws.world.nation_get_demographics(to_nation(primary_slot), demographics::total);
 	auto type = demographics::to_key(ws, payload(tval[1]).popt_id);
@@ -5323,6 +5331,10 @@ struct trigger_container {
 		tf_variable_reform_group_name_state<return_type, primary_type, this_type, from_type>, //constexpr inline uint16_t variable_reform_group_name_state = 0x0273;
 		tf_variable_reform_group_name_province<return_type, primary_type, this_type, from_type>, //constexpr inline uint16_t variable_reform_group_name_province = 0x0274;
 		tf_variable_reform_group_name_pop<return_type, primary_type, this_type, from_type>, //constexpr inline uint16_t variable_reform_group_name_pop = 0x0275;
+		//
+		// non-vanilla triggers
+		//
+		tf_is_accepted_culture_nation<return_type, primary_type, this_type, from_type>, //constexpr inline uint16_t is_accepted_culture_nation = 0x0276;
 
 		//
 		// scopes

--- a/src/scripting/triggers.cpp
+++ b/src/scripting/triggers.cpp
@@ -4618,11 +4618,7 @@ TRIGGER_FUNCTION(tf_variable_reform_group_name_pop) {
 //
 // non-vanilla triggers
 //
-TRIGGER_FUNCTION(tf_is_accepted_culture_nation) {
-	// stub: virtually unused
-	auto is_accepted = true;//ws.world.nation_get_accepted_cultures(to_nation(primary_slot), to_cul);
-	return compare_to_true(tval[0], is_accepted);
-}
+
 TRIGGER_FUNCTION(tf_variable_pop_type_name_nation) {
 	auto total_pop = ws.world.nation_get_demographics(to_nation(primary_slot), demographics::total);
 	auto type = demographics::to_key(ws, payload(tval[1]).popt_id);
@@ -5334,7 +5330,6 @@ struct trigger_container {
 		//
 		// non-vanilla triggers
 		//
-		tf_is_accepted_culture_nation<return_type, primary_type, this_type, from_type>, //constexpr inline uint16_t is_accepted_culture_nation = 0x0276;
 
 		//
 		// scopes

--- a/src/scripting/triggers.cpp
+++ b/src/scripting/triggers.cpp
@@ -4,8 +4,6 @@
 
 namespace trigger {
 
-
-
 #ifdef WIN32
 #define CALLTYPE __vectorcall
 #else


### PR DESCRIPTION
- unit_start_experience modifier
hfm uses it, basically land_unit_start_experience_modifier and naval_unit_start_experience_modifier but with a single statment

- print scopes for easier debugging
self explainatory

- make national focuses intake modifier stuff
removes some overhead and allows the national_focuses to be able to be tooltip'ed by whatever make_modifier_tooltip or whatnot...