### PR TITLE
Add linux cmake build presets for Visual Studio Code 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,8 +6,9 @@ charset = utf-8
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{yml}]
+[*.{yml,json}]
 indent_style = space
+indent_size = 2
 
 [*.{c++,cc,cpp,cppm,cxx,h,h++,hh,hpp,hxx,inl,ipp,ixx,tlh,tli}]
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -75,6 +75,36 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release"
       }
+    },
+    {
+      "name": "linux-base",
+      "inherits": "base",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+    {
+      "name": "x64-debug-linux-clang",
+      "displayName": "x64 Debug",
+      "inherits": "linux-base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "x64-release-linux-clang",
+      "displayName": "x64 Release",
+      "inherits": "linux-base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
     }
   ]
 }


### PR DESCRIPTION
Requires the user to have the cmake-tools extension installed.

Made building the project (assuming you have all the dependencies) just be a matter of choosing a development profile and building. Currently there are two profiles, x64 release and x64 debug, both built with Clang.