### PR TITLE
Make decision descriptions scrollable

### DIFF
--- a/src/gui/gui_element_types.hpp
+++ b/src/gui/gui_element_types.hpp
@@ -439,6 +439,12 @@ public:
 		auto dist = sqrt(dx * dx + dy * dy);
 		return dist <= radius ? message_result::consumed : message_result::unseen;
 	}
+	message_result on_lbutton_down(sys::state& state, int32_t x, int32_t y, sys::key_modifiers mods) noexcept override {
+		return message_result::consumed;
+	}
+	message_result on_rbutton_down(sys::state& state, int32_t x, int32_t y, sys::key_modifiers mods) noexcept override {
+		return message_result::consumed;
+	}
 	void update_tooltip(sys::state& state, int32_t x, int32_t y, text::columnar_layout& contents) noexcept override;
 };
 

--- a/src/gui/topbar_subwindows/politics_subwindows/gui_decision_window.hpp
+++ b/src/gui/topbar_subwindows/politics_subwindows/gui_decision_window.hpp
@@ -100,7 +100,7 @@ public:
 // Decision Description
 // --------------------
 
-class decision_desc : public multiline_text_element_base {
+class decision_desc : public scrollable_text {
 private:
   dcon::text_sequence_id description;
   void populate_layout(sys::state& state, text::endless_layout& contents) noexcept {
@@ -110,6 +110,11 @@ private:
   }
 
 public:
+  void on_create(sys::state& state) noexcept override {
+    base_data.size.y = 77;
+    scrollable_text::on_create(state);
+  } 
+
   void on_update(sys::state& state) noexcept override {
     Cyto::Any payload = dcon::decision_id{};
     if(parent) {
@@ -119,14 +124,11 @@ public:
       description = fat_id.get_description();
     }
     auto container = text::create_endless_layout(
-      internal_layout,
+      delegate->internal_layout,
       text::layout_parameters{ 0, 0, static_cast<int16_t>(base_data.size.x), static_cast<int16_t>(base_data.size.y), base_data.data.text.font_handle, 0, text::alignment::left, text::text_color::black }
     );
     populate_layout(state, container);
-  }
-
-  message_result test_mouse(sys::state& state, int32_t x, int32_t y) noexcept override {
-    return message_result::unseen;
+    calibrate_scrollbar(state);
   }
 };
 

--- a/src/gui/topbar_subwindows/politics_subwindows/gui_reforms_window.hpp
+++ b/src/gui/topbar_subwindows/politics_subwindows/gui_reforms_window.hpp
@@ -7,7 +7,6 @@
 namespace ui {
 
 class reforms_reform_button : public standard_nation_issue_option_button {
-	dcon::issue_option_id issue_option_id{};
 public:
 	void on_update(sys::state& state) noexcept override {
 		standard_nation_issue_option_button::on_update(state);
@@ -34,15 +33,6 @@ public:
 		auto mod_id = fat_id.get_modifier().id;
 		if(bool(mod_id)) {
 			modifier_description(state, contents, mod_id);
-		}
-	}
-
-	message_result set(sys::state& state, Cyto::Any& payload) noexcept override {
-		if(payload.holds_type<dcon::issue_option_id>()) {
-			issue_option_id = any_cast<dcon::issue_option_id>(payload);
-			return message_result::consumed;
-		} else {
-			return message_result::unseen;
 		}
 	}
 };


### PR DESCRIPTION
The scrollable_text element could also be used wherever it makes sense to use.
Also fixed a bug where the reform buttons wouldn't highlight properly, and another where clicks would phase through pie charts.

Also right now this makes scrolling in the decisions menu pretty clunky, but that should be resolved once the scrolling behaviour is reverted to scanning through the ui hierarchy instead of just using the element under mouse.