### PR TITLE
various ui improvments and fixes

### DIFF
--- a/src/economy/economy.cpp
+++ b/src/economy/economy.cpp
@@ -2720,6 +2720,24 @@ void for_each_new_factory(sys::state& state, dcon::state_instance_id s, F&& func
 	}
 }
 
+template<typename F>
+void for_each_upgraded_factory(sys::state& state, dcon::state_instance_id s, F&& func) {
+	for(auto st_con : state.world.state_instance_get_state_building_construction(s)) {
+		if(st_con.get_is_upgrade()) {
+			float total = 0.0f;
+			float purchased = 0.0f;
+			auto& goods = state.world.factory_type_get_construction_costs(st_con.get_type());
+
+			for(uint32_t i = 0; i < commodity_set::set_size; ++i) {
+				total += goods.commodity_amounts[i];
+				purchased += st_con.get_purchased_goods().commodity_amounts[i];
+			}
+
+			func(upgraded_factory{ total > 0.0f ? purchased / total : 0.0f, st_con.get_type().id });
+		}
+	}
+}
+
 bool state_contains_constructed_factory(sys::state& state, dcon::state_instance_id s, dcon::factory_type_id ft) {
 	auto d = state.world.state_instance_get_definition(s);
 	auto o = state.world.state_instance_get_nation_from_state_ownership(s);

--- a/src/economy/economy.hpp
+++ b/src/economy/economy.hpp
@@ -137,9 +137,15 @@ struct new_factory {
 	float progress = 0.0f;
 	dcon::factory_type_id type;
 };
-
 template<typename F>
 void for_each_new_factory(sys::state& state, dcon::state_instance_id s, F&& func); // calls the function repeatedly with new_factory as parameters
+
+struct upgraded_factory {
+	float progress = 0.0f;
+	dcon::factory_type_id type;
+};
+template<typename F>
+void for_each_upgraded_factory(sys::state& state, dcon::state_instance_id s, F&& func); // calls the function repeatedly with new_factory as parameters
 
 bool state_contains_constructed_factory(sys::state& state, dcon::state_instance_id si, dcon::factory_type_id ft);
 float unit_construction_progress(sys::state& state, dcon::province_land_construction_id c);

--- a/src/gui/gui_common_elements.hpp
+++ b/src/gui/gui_common_elements.hpp
@@ -1764,7 +1764,7 @@ class commodity_player_availability_text : public generic_simple_text<dcon::comm
 public:
 	std::string get_text(sys::state& state, dcon::commodity_id commodity_id) noexcept override {
 		if(commodity_id)
-			return text::format_percentage(state.world.nation_get_demand_satisfaction(state.local_player_nation, commodity_id));
+			return text::format_money(state.world.nation_get_demand_satisfaction(state.local_player_nation, commodity_id));
 		else
 			return "";
 	}

--- a/src/gui/gui_province_window.hpp
+++ b/src/gui/gui_province_window.hpp
@@ -425,7 +425,7 @@ public:
 		progress_bar::on_create(state);
 		base_data.position.y -= 2;
 	}
-	
+
 	void on_update(sys::state& state) noexcept override {
 		if(parent) {
 			Cyto::Any payload = dcon::province_id{};
@@ -510,7 +510,7 @@ public:
 			Cyto::Any payload = dcon::province_id{};
 			parent->impl_get(state, payload);
 			auto content = any_cast<dcon::province_id>(payload);
-			
+
 			expand_button->set_visible(state, !is_being_built(state, content));
 			under_construction_icon->set_visible(state, is_being_built(state, content));
 			building_progress->set_visible(state, is_being_built(state, content));
@@ -820,6 +820,50 @@ public:		// goto hell;
 	}
 };
 
+class province_colonise_button : public button_element_base {
+public:
+	void button_action(sys::state& state) noexcept override {
+		if(parent) {
+			Cyto::Any payload = dcon::province_id{};
+			parent->impl_get(state, payload);
+			auto content = any_cast<dcon::province_id>(payload);
+
+			command::invest_in_colony(state, state.local_player_nation, content);
+		}
+	}
+
+	void on_update(sys::state& state) noexcept override {
+		if(parent) {
+			Cyto::Any payload = dcon::province_id{};
+			parent->impl_get(state, payload);
+			auto content = any_cast<dcon::province_id>(payload);
+			disabled = !command::can_invest_in_colony(state, state.local_player_nation, content);
+		}
+	}
+};
+
+class province_withdraw_button : public button_element_base {
+public:
+	void button_action(sys::state& state) noexcept override {
+		if(parent) {
+			Cyto::Any payload = dcon::province_id{};
+			parent->impl_get(state, payload);
+			auto content = any_cast<dcon::province_id>(payload);
+
+			command::abandon_colony(state, state.local_player_nation, content);
+		}
+	}
+
+	void on_update(sys::state& state) noexcept override {
+		if(parent) {
+			Cyto::Any payload = dcon::province_id{};
+			parent->impl_get(state, payload);
+			auto content = any_cast<dcon::province_id>(payload);
+			disabled = !command::can_abandon_colony(state, state.local_player_nation, content);
+		}
+	}
+};
+
 class province_window_colony : public window_element_base {
 private:
 	province_colony_rgo_icon* rgo_icon = nullptr;
@@ -839,6 +883,10 @@ public:
 			auto ptr = make_element_by_type<province_colony_rgo_icon>(state, id);
 			rgo_icon = ptr.get();
 			return ptr;
+		} else if(name == "colonize_button") {
+			return make_element_by_type<province_colonise_button>(state, id);
+		} else if(name == "withdraw_button") {
+			return make_element_by_type<province_withdraw_button>(state, id);
 		} else {
 			return nullptr;
 		}
@@ -939,7 +987,7 @@ public:
 	void set_active_province(sys::state& state, dcon::province_id map_province) {
 		if(bool(map_province)) {
 			active_province = map_province;
-			
+
 			header_window->impl_on_update(state);
 			foreign_details_window->impl_on_update(state);
 			local_details_window->impl_on_update(state);
@@ -954,7 +1002,7 @@ public:
 			set_visible(state, false);
 		}
 	}
-	
+
 	friend class province_national_focus_button;
 };
 

--- a/src/gui/topbar_subwindows/diplomacy_subwindows/gui_diplomacy_actions_window.hpp
+++ b/src/gui/topbar_subwindows/diplomacy_subwindows/gui_diplomacy_actions_window.hpp
@@ -1126,6 +1126,8 @@ class diplomacy_action_dialog_title_text : public generic_settable_element<simpl
 			return "give_unit_commandtitle";
 		case diplomacy_action::cancel_command_units:
 			return "cancel_unit_commandtitle";
+		case diplomacy_action::make_peace:
+			return "make_peacetitle";
 		}
 		return "";
 	}
@@ -1181,6 +1183,8 @@ class diplomacy_action_dialog_description_text : public generic_settable_element
 			return "give_unit_command_desc";
 		case diplomacy_action::cancel_command_units:
 			return "cancel_unit_command_desc";
+		case diplomacy_action::make_peace:
+			return "make_peace_desc";
 		}
 		return "";
 	}
@@ -1189,11 +1193,81 @@ public:
 		set_text(state, text::produce_simple_string(state, get_title_key()));
 	}
 };
+
+struct gp_selection_query_data {
+	dcon::nation_id data{};
+};
+
 class diplomacy_action_dialog_agree_button : public generic_settable_element<button_element_base, diplomacy_action> {
+	bool get_can_perform(sys::state& state) noexcept {
+		if(parent) {
+			Cyto::Any payload = dcon::nation_id{};
+			parent->impl_get(state, payload);
+			auto target = any_cast<dcon::nation_id>(payload);
+
+			Cyto::Any gp_payload = gp_selection_query_data{};
+			parent->impl_get(state, gp_payload);
+			auto gp_target = any_cast<gp_selection_query_data>(gp_payload).data;
+
+			switch(content) {
+			case diplomacy_action::ally:
+				return false;
+			case diplomacy_action::cancel_ally:
+				return false;
+			case diplomacy_action::call_ally:
+				return false;
+			case diplomacy_action::declare_war:
+				return false;
+			case diplomacy_action::military_access:
+				return false;
+			case diplomacy_action::cancel_military_access:
+				return false;
+			case diplomacy_action::give_military_access:
+				return false;
+			case diplomacy_action::cancel_give_military_access:
+				return false;
+			case diplomacy_action::increase_relations:
+				return command::can_increase_relations(state, state.local_player_nation, target);
+			case diplomacy_action::decrease_relations:
+				return command::can_decrease_relations(state, state.local_player_nation, target);
+			case diplomacy_action::war_subsidies:
+				return command::can_give_war_subsidies(state, state.local_player_nation, target);
+			case diplomacy_action::cancel_war_subsidies:
+				return command::can_cancel_war_subsidies(state, state.local_player_nation, target);
+			case diplomacy_action::discredit:
+				return command::can_discredit_advisors(state, state.local_player_nation, target, gp_target);
+			case diplomacy_action::expel_advisors:
+				return command::can_expel_advisors(state, state.local_player_nation, target, gp_target);
+			case diplomacy_action::ban_embassy:
+				return command::can_ban_embassy(state, state.local_player_nation, target, gp_target);
+			case diplomacy_action::increase_opinion:
+				return command::can_increase_opinion(state, state.local_player_nation, target);
+			case diplomacy_action::decrease_opinion:
+				return command::can_decrease_opinion(state, state.local_player_nation, target, gp_target);
+			case diplomacy_action::add_to_sphere:
+				return false;
+			case diplomacy_action::remove_from_sphere:
+				return false;
+			case diplomacy_action::justify_war:
+				return false;
+			case diplomacy_action::command_units:
+				return false;
+			case diplomacy_action::cancel_command_units:
+				return false;
+			case diplomacy_action::make_peace:
+				return false;
+			}
+		}
+		return false;
+	}
 public:
 	void on_create(sys::state& state) noexcept override {
 		button_element_base::on_create(state);
 		set_button_text(state, text::produce_simple_string(state, "agree"));
+	}
+
+	void on_update(sys::state& state) noexcept override {
+		disabled = !get_can_perform(state);
 	}
 
 	void button_action(sys::state& state) noexcept override {
@@ -1201,6 +1275,10 @@ public:
 			Cyto::Any payload = dcon::nation_id{};
 			parent->impl_get(state, payload);
 			auto target = any_cast<dcon::nation_id>(payload);
+
+			Cyto::Any gp_payload = gp_selection_query_data{};
+			parent->impl_get(state, gp_payload);
+			auto gp_target = any_cast<gp_selection_query_data>(gp_payload).data;
 
 			switch(content) {
 			case diplomacy_action::ally:
@@ -1232,14 +1310,19 @@ public:
 				command::cancel_war_subsidies(state, state.local_player_nation, target);
 				break;
 			case diplomacy_action::discredit:
+				command::discredit_advisors(state, state.local_player_nation, target, gp_target);
 				break;
 			case diplomacy_action::expel_advisors:
+				command::expel_advisors(state, state.local_player_nation, target, gp_target);
 				break;
 			case diplomacy_action::ban_embassy:
+				command::ban_embassy(state, state.local_player_nation, target, gp_target);
 				break;
 			case diplomacy_action::increase_opinion:
+				command::increase_opinion(state, state.local_player_nation, target);
 				break;
 			case diplomacy_action::decrease_opinion:
+				command::decrease_opinion(state, state.local_player_nation, target, gp_target);
 				break;
 			case diplomacy_action::add_to_sphere:
 				break;
@@ -1251,21 +1334,18 @@ public:
 				break;
 			case diplomacy_action::cancel_command_units:
 				break;
+			case diplomacy_action::make_peace:
+				break;
 			}
 			parent->set_visible(state, false);
 		}
 	}
 };
-class diplomacy_action_dialog_decline_button : public button_element_base {
+class diplomacy_action_dialog_decline_button : public generic_close_button {
 public:
 	void on_create(sys::state& state) noexcept override {
 		button_element_base::on_create(state);
 		set_button_text(state, text::produce_simple_string(state, "decline"));
-	}
-
-	void button_action(sys::state& state) noexcept override {
-		if (parent)
-			parent->set_visible(state, false);
 	}
 };
 class diplomacy_action_dialog_window : public window_element_base {
@@ -1295,6 +1375,20 @@ public:
 	}
 };
 
+class diplomacy_action_gp_dialog_select_button : public flag_button {
+public:
+	void button_action(sys::state& state) noexcept override {
+		if(parent) {
+			Cyto::Any payload = dcon::nation_id{};
+			parent->impl_get(state, payload);
+			auto content = any_cast<dcon::nation_id>(payload);
+
+			Cyto::Any s_payload = element_selection_wrapper<dcon::nation_id>{ content };
+			parent->impl_get(state, s_payload);
+		}
+	}
+};
+
 class diplomacy_action_gp_dialog_select_window : public window_element_base {
 public:
 	uint8_t rank = 0;
@@ -1319,6 +1413,7 @@ public:
 };
 
 class diplomacy_gp_action_dialog_window : public window_element_base {
+	dcon::nation_id selected_gp{};
 public:
 	void on_create(sys::state& state) noexcept override {
 		window_element_base::on_create(state);
@@ -1361,6 +1456,17 @@ public:
 		} else {
 			return nullptr;
 		}
+	}
+
+	message_result get(sys::state& state, Cyto::Any& payload) noexcept override {
+		if(payload.holds_type<element_selection_wrapper<dcon::nation_id>>()) {
+			selected_gp = any_cast<element_selection_wrapper<dcon::nation_id>>(payload).data;
+			return message_result::consumed;
+		} else if(payload.holds_type<gp_selection_query_data>()) {
+			payload.emplace<gp_selection_query_data>(gp_selection_query_data{ selected_gp });
+			return message_result::consumed;
+		}
+		return window_element_base::get(state, payload);
 	}
 };
 

--- a/src/gui/topbar_subwindows/gui_budget_window.hpp
+++ b/src/gui/topbar_subwindows/gui_budget_window.hpp
@@ -25,21 +25,6 @@ class pop_satisfaction_wrapper_fat {
 	static text_sequence_id names[5];
 public:
 	uint8_t value = 0;
-	uint32_t get_color() noexcept {
-		switch(value) {
-		case 0: // red
-			return sys::pack_color(0.9f, 0.2f, 0.1f);
-		case 1: // yellow
-			return sys::pack_color(0.9f, 0.9f, 0.1f);
-		case 2: // green
-			return sys::pack_color(0.2f, 0.95f, 0.2f);
-		case 3: // blue
-			return sys::pack_color(0.5f, 0.5f, 1.0f);
-		case 4: // light blue
-			return sys::pack_color(0.2f, 0.2f, 0.8f);
-		}
-		return 0;
-	}
 	void set_name(text_sequence_id text) noexcept {
 		names[value] = text;
 	}
@@ -62,7 +47,19 @@ pop_satisfaction_wrapper_fat fatten(data_container const& c, pop_satisfaction_wr
 namespace ogl {
 template<>
 uint32_t get_ui_color(sys::state& state, dcon::pop_satisfaction_wrapper_id id){
-	return ogl::color_from_hash(uint32_t(id.index()));
+	switch(id.value) {
+	case 0: // red
+		return sys::pack_color(0.9f, 0.2f, 0.1f);
+	case 1: // yellow
+		return sys::pack_color(0.9f, 0.9f, 0.1f);
+	case 2: // green
+		return sys::pack_color(0.2f, 0.95f, 0.2f);
+	case 3: // blue
+		return sys::pack_color(0.5f, 0.5f, 1.0f);
+	case 4: // light blue
+		return sys::pack_color(0.2f, 0.2f, 0.8f);
+	}
+	return 0;
 }
 }
 

--- a/src/gui/topbar_subwindows/gui_diplomacy_window.hpp
+++ b/src/gui/topbar_subwindows/gui_diplomacy_window.hpp
@@ -145,6 +145,61 @@ public:
 
 class diplomacy_priority_button : public button_element_base {
 public:
+	void on_update(sys::state& state) noexcept override {
+		if(parent) {
+			Cyto::Any payload = dcon::nation_id{};
+			parent->impl_get(state, payload);
+			auto nation_id = any_cast<dcon::nation_id>(payload);
+
+			auto rel = state.world.get_gp_relationship_by_gp_influence_pair(nation_id, state.local_player_nation);
+			uint8_t flags = bool(rel) ? state.world.gp_relationship_get_status(rel) : 0;
+			switch(flags & nations::influence::priority_mask) {
+			case nations::influence::priority_zero:
+				frame = 0;
+				disabled = !command::can_change_influence_priority(state, state.local_player_nation, nation_id, 1);
+				break;
+			case nations::influence::priority_one:
+				frame = 1;
+				disabled = !command::can_change_influence_priority(state, state.local_player_nation, nation_id, 2);
+				break;
+			case nations::influence::priority_two:
+				frame = 2;
+				disabled = !command::can_change_influence_priority(state, state.local_player_nation, nation_id, 3);
+				break;
+			case nations::influence::priority_three:
+				frame = 3;
+				disabled = !command::can_change_influence_priority(state, state.local_player_nation, nation_id, 0);
+				break;
+			}
+		}
+	}
+
+	void button_action(sys::state& state) noexcept override {
+		if(parent) {
+			Cyto::Any payload = dcon::nation_id{};
+			parent->impl_get(state, payload);
+			auto nation_id = any_cast<dcon::nation_id>(payload);
+
+			auto rel = state.world.get_gp_relationship_by_gp_influence_pair(nation_id, state.local_player_nation);
+			uint8_t flags = bool(rel) ? state.world.gp_relationship_get_status(rel) : 0;
+
+			switch(flags & nations::influence::priority_mask) {
+			case nations::influence::priority_zero:
+				command::change_influence_priority(state, state.local_player_nation, nation_id, 1);
+				break;
+			case nations::influence::priority_one:
+				command::change_influence_priority(state, state.local_player_nation, nation_id, 2);
+				break;
+			case nations::influence::priority_two:
+				command::change_influence_priority(state, state.local_player_nation, nation_id, 3);
+				break;
+			case nations::influence::priority_three:
+				command::change_influence_priority(state, state.local_player_nation, nation_id, 0);
+				break;
+			}
+		}
+	}
+
 	message_result test_mouse(sys::state& state, int32_t x, int32_t y) noexcept override {
 		return message_result::consumed;
 	}

--- a/src/gui/topbar_subwindows/gui_diplomacy_window.hpp
+++ b/src/gui/topbar_subwindows/gui_diplomacy_window.hpp
@@ -152,8 +152,8 @@ public:
 			auto nation_id = any_cast<dcon::nation_id>(payload);
 
 			auto rel = state.world.get_gp_relationship_by_gp_influence_pair(nation_id, state.local_player_nation);
-			uint8_t flags = bool(rel) ? state.world.gp_relationship_get_status(rel) : 0;
-			switch(flags & nations::influence::priority_mask) {
+			uint8_t rel_flags = bool(rel) ? state.world.gp_relationship_get_status(rel) : 0;
+			switch(rel_flags & nations::influence::priority_mask) {
 			case nations::influence::priority_zero:
 				frame = 0;
 				disabled = !command::can_change_influence_priority(state, state.local_player_nation, nation_id, 1);
@@ -181,9 +181,8 @@ public:
 			auto nation_id = any_cast<dcon::nation_id>(payload);
 
 			auto rel = state.world.get_gp_relationship_by_gp_influence_pair(nation_id, state.local_player_nation);
-			uint8_t flags = bool(rel) ? state.world.gp_relationship_get_status(rel) : 0;
-
-			switch(flags & nations::influence::priority_mask) {
+			uint8_t rel_flags = bool(rel) ? state.world.gp_relationship_get_status(rel) : 0;
+			switch(rel_flags & nations::influence::priority_mask) {
 			case nations::influence::priority_zero:
 				command::change_influence_priority(state, state.local_player_nation, nation_id, 1);
 				break;

--- a/src/gui/topbar_subwindows/gui_diplomacy_window.hpp
+++ b/src/gui/topbar_subwindows/gui_diplomacy_window.hpp
@@ -970,18 +970,6 @@ public:
 			make_cb_win->set_visible(state, false);
 			Cyto::Any new_payload = facts_nation_id;
 			switch(v) {
-			case diplomacy_action::discredit:
-				command::discredit_advisors(state, state.local_player_nation, facts_nation_id, dcon::fatten(state.world, facts_nation_id).get_in_sphere_of().id);
-				break;
-			case diplomacy_action::expel_advisors:
-				command::expel_advisors(state, state.local_player_nation, facts_nation_id, dcon::fatten(state.world, facts_nation_id).get_in_sphere_of().id);
-				break;
-			case diplomacy_action::ban_embassy:
-				command::ban_embassy(state, state.local_player_nation, facts_nation_id, dcon::fatten(state.world, facts_nation_id).get_in_sphere_of().id);
-				break;
-			case diplomacy_action::increase_opinion:
-				command::increase_opinion(state, state.local_player_nation, facts_nation_id);
-				break;
 			case diplomacy_action::decrease_opinion:
 				gp_action_dialog_win->set_visible(state, true);
 				gp_action_dialog_win->impl_set(state, new_payload);

--- a/src/gui/topbar_subwindows/gui_production_window.hpp
+++ b/src/gui/topbar_subwindows/gui_production_window.hpp
@@ -981,8 +981,8 @@ public:
 			return message_result::consumed;
 		} else if(payload.holds_type<commodity_filter_set_all_data>()) {
 			bool content = any_cast<commodity_filter_set_all_data>(payload).data;
-			for(bool& e : commodity_filters)
-				e = content;
+			for(auto it = commodity_filters.begin(); it != commodity_filters.end(); it++)
+				*it = content;
 			impl_on_update(state);
 			return message_result::consumed;
 		}

--- a/src/gui/topbar_subwindows/gui_production_window.hpp
+++ b/src/gui/topbar_subwindows/gui_production_window.hpp
@@ -487,13 +487,15 @@ public:
 				e->set_visible(state, is_closed);
 		}
 
-		auto cid = fat_btid.get_output().id;
-		output_icon->frame = int32_t(state.world.commodity_get_icon(cid));
+		{
+			dcon::commodity_id cid = fat_btid.get_output().id;
+			output_icon->frame = int32_t(state.world.commodity_get_icon(cid));
+		}
 		// Commodity set
 		auto cset = fat_btid.get_inputs();
 		for(uint32_t i = 0; i < economy::commodity_set::set_size; ++i)
 			if(input_icons[size_t(i)]) {
-				auto cid = cset.commodity_type[size_t(i)];
+				dcon::commodity_id cid = cset.commodity_type[size_t(i)];
 				input_icons[size_t(i)]->frame = int32_t(state.world.commodity_get_icon(cid));
 				bool is_lack = cid != dcon::commodity_id{} ? state.world.nation_get_demand_satisfaction(state.local_player_nation, cid) < 0.5f : false;
 				input_lack_icons[size_t(i)]->set_visible(state, is_lack);

--- a/src/gui/topbar_subwindows/gui_production_window.hpp
+++ b/src/gui/topbar_subwindows/gui_production_window.hpp
@@ -979,10 +979,30 @@ public:
 			commodity_filters[content.data.index()] = !commodity_filters[content.data.index()];
 			impl_on_update(state);
 			return message_result::consumed;
-		} else if(payload.holds_type<commodity_filter_set_all_data>()) {
-			bool content = any_cast<commodity_filter_set_all_data>(payload).data;
-			for(auto it = commodity_filters.begin(); it != commodity_filters.end(); it++)
-				*it = content;
+		} else if(payload.holds_type<element_selection_wrapper<factory_all_actions>>()) {
+			auto content = any_cast<element_selection_wrapper<factory_all_actions>>(payload).data;
+			switch(content) {
+				case factory_all_actions::subsidise_all:
+					break;
+				case factory_all_actions::unsubsidise_all:
+					break;
+				case factory_all_actions::filter_select_all:
+					for(uint32_t i = 0; i < commodity_filters.size(); i++) {
+						commodity_filters[i] = true;
+					}
+					break;
+				case factory_all_actions::filter_deselect_all:
+					for(uint32_t i = 0; i < commodity_filters.size(); i++) {
+						commodity_filters[i] = false;
+					}
+					break;
+				case factory_all_actions::open_all:
+					break;
+				case factory_all_actions::close_all:
+					break;
+				default:
+					break;
+			}
 			impl_on_update(state);
 			return message_result::consumed;
 		}

--- a/src/gui/topbar_subwindows/gui_production_window.hpp
+++ b/src/gui/topbar_subwindows/gui_production_window.hpp
@@ -917,10 +917,6 @@ public:
 			project_elements.push_back(ptr.get());
 			ptr->set_visible(state, false);
 			return ptr;
-		} else if(name == "select_all") {
-			return make_element_by_type<commodity_filter_select_button<true>>(state, id);
-		} else if(name == "deselect_all") {
-			return make_element_by_type<commodity_filter_select_button<false>>(state, id);
 		} else {
 			return nullptr;
 		}

--- a/src/gui/topbar_subwindows/production_subwindows/gui_build_factory_window.hpp
+++ b/src/gui/topbar_subwindows/production_subwindows/gui_build_factory_window.hpp
@@ -178,9 +178,20 @@ protected:
 public:
 	void on_update(sys::state& state) noexcept override{
 		if(parent) {
+			Cyto::Any s_payload = dcon::state_instance_id{};
+			parent->impl_get(state, s_payload);
+			auto sid = any_cast<dcon::state_instance_id>(s_payload);
+
 			row_contents.clear();
-			state.world.for_each_factory_type([&](dcon::factory_type_id ident) {
-				row_contents.push_back(ident);
+			// First the buildable factories
+			state.world.for_each_factory_type([&](dcon::factory_type_id ftid) {
+				if(command::can_begin_factory_building_construction(state, state.local_player_nation, sid, ftid, false))
+					row_contents.push_back(ftid);
+			});
+			// Then the ones that can't be built
+			state.world.for_each_factory_type([&](dcon::factory_type_id ftid) {
+				if(!command::can_begin_factory_building_construction(state, state.local_player_nation, sid, ftid, false))
+					row_contents.push_back(ftid);
 			});
 			update(state);
 		}

--- a/src/gui/topbar_subwindows/production_subwindows/gui_commodity_filters_window.hpp
+++ b/src/gui/topbar_subwindows/production_subwindows/gui_commodity_filters_window.hpp
@@ -9,7 +9,6 @@ struct commodity_filter_query_data {
 	bool filter;
 };
 struct commodity_filter_toggle_data : public element_selection_wrapper<dcon::commodity_id> {};
-struct commodity_filter_set_all_data : public element_selection_wrapper<bool> {};
 
 class commodity_filter_button : public button_element_base {
 public:
@@ -74,36 +73,32 @@ public:
 	}
 };
 
-template<bool B>
-class commodity_filter_select_button : public button_element_base {
-public:
-	void button_action(sys::state& state) noexcept override {
-		if(parent) {
-			Cyto::Any payload = commodity_filter_set_all_data{ B };
-			parent->impl_get(state, payload);
-		}
-	}
-};
-
 class commodity_filters_window : public window_element_base {
 public:
 	void on_create(sys::state& state) noexcept override {
 		window_element_base::on_create(state);
-		state.world.for_each_commodity([&](dcon::commodity_id id) {
-			if(!bool(id))
+
+		int16_t index = 0;
+		state.world.for_each_commodity([&](dcon::commodity_id cid) {
+			bool can_be_produced = false;
+			state.world.for_each_factory_type([&](dcon::factory_type_id ftid) {
+				can_be_produced = can_be_produced || state.world.factory_type_get_output(ftid) == cid;
+			});
+			if(!can_be_produced)
 				return;
 			
 			auto ptr = make_element_by_type<commodity_filter_item>(state, "goods_filter_template");
-			static_cast<commodity_filter_item*>(ptr.get())->content = id;
-			int16_t currgood = int16_t(id.index());
-			int16_t rowlimiter = currgood - (24 * (currgood / 24));
+			static_cast<commodity_filter_item*>(ptr.get())->content = cid;
+
+			int16_t rowlimiter = index - (24 * (index / 24));
 			if(rowlimiter == 0) {
 				ptr->base_data.position.x = int16_t(33 * rowlimiter);
 			} else {
 				ptr->base_data.position.x = int16_t((33 * rowlimiter) - (rowlimiter * 2));
 			}
-			ptr->base_data.position.y = int16_t(30 * (currgood / 24));
+			ptr->base_data.position.y = int16_t(30 * (index / 24));
 			add_child_to_back(std::move(ptr));
+			index++;
 		});
 	}
 };

--- a/src/gui/topbar_subwindows/production_subwindows/gui_commodity_filters_window.hpp
+++ b/src/gui/topbar_subwindows/production_subwindows/gui_commodity_filters_window.hpp
@@ -9,6 +9,7 @@ struct commodity_filter_query_data {
 	bool filter;
 };
 struct commodity_filter_toggle_data : public element_selection_wrapper<dcon::commodity_id> {};
+struct commodity_filter_set_all_data : public element_selection_wrapper<bool> {};
 
 class commodity_filter_button : public button_element_base {
 public:
@@ -70,6 +71,17 @@ public:
 			return message_result::consumed;
 		}
 		return message_result::unseen;
+	}
+};
+
+template<bool B>
+class commodity_filter_select_button : public button_element_base {
+public:
+	void button_action(sys::state& state) noexcept override {
+		if(parent) {
+			Cyto::Any payload = commodity_filter_set_all_data{ B };
+			parent->impl_get(state, payload);
+		}
 	}
 };
 

--- a/src/gui/topbar_subwindows/production_subwindows/gui_factory_buttons_window.hpp
+++ b/src/gui/topbar_subwindows/production_subwindows/gui_factory_buttons_window.hpp
@@ -5,8 +5,24 @@
 
 namespace ui {
 
+enum class factory_all_actions : uint8_t {
+	subsidise_all,
+	unsubsidise_all,
+	filter_select_all,
+	filter_deselect_all,
+	open_all,
+	close_all,
+};
+
 class factory_prod_subsidise_all_button : public button_element_base {
 public:
+	void button_action(sys::state& state) noexcept override {
+		if(parent) {
+			Cyto::Any payload = element_selection_wrapper<factory_all_actions>{factory_all_actions{factory_all_actions::subsidise_all}};
+			parent->impl_get(state, payload);
+		}
+	}
+
 	message_result test_mouse(sys::state& state, int32_t x, int32_t y) noexcept override {
 		return message_result::consumed;
 	}
@@ -24,6 +40,13 @@ public:
 
 class factory_prod_unsubsidise_all_button : public button_element_base {
 public:
+	void button_action(sys::state& state) noexcept override {
+		if(parent) {
+			Cyto::Any payload = element_selection_wrapper<factory_all_actions>{factory_all_actions{factory_all_actions::unsubsidise_all}};
+			parent->impl_get(state, payload);
+		}
+	}
+
 	message_result test_mouse(sys::state& state, int32_t x, int32_t y) noexcept override {
 		return message_result::consumed;
 	}
@@ -41,6 +64,13 @@ public:
 
 class factory_prod_open_all_button : public button_element_base {
 public:
+	void button_action(sys::state& state) noexcept override {
+		if(parent) {
+			Cyto::Any payload = element_selection_wrapper<factory_all_actions>{factory_all_actions{factory_all_actions::open_all}};
+			parent->impl_get(state, payload);
+		}
+	}
+
 	message_result test_mouse(sys::state& state, int32_t x, int32_t y) noexcept override {
 		return message_result::consumed;
 	}
@@ -58,6 +88,13 @@ public:
 
 class factory_prod_close_all_button : public button_element_base {
 public:
+	void button_action(sys::state& state) noexcept override {
+		if(parent) {
+			Cyto::Any payload = element_selection_wrapper<factory_all_actions>{factory_all_actions{factory_all_actions::close_all}};
+			parent->impl_get(state, payload);
+		}
+	}
+
 	message_result test_mouse(sys::state& state, int32_t x, int32_t y) noexcept override {
 		return message_result::consumed;
 	}
@@ -75,6 +112,13 @@ public:
 
 class factory_select_all_button : public button_element_base {
 public:
+	void button_action(sys::state& state) noexcept override {
+		if(parent) {
+			Cyto::Any payload = element_selection_wrapper<factory_all_actions>{factory_all_actions{factory_all_actions::filter_select_all}};
+			parent->impl_get(state, payload);
+		}
+	}
+
 	message_result test_mouse(sys::state& state, int32_t x, int32_t y) noexcept override {
 		return message_result::consumed;
 	}
@@ -92,6 +136,13 @@ public:
 
 class factory_deselect_all_button : public button_element_base {
 public:
+	void button_action(sys::state& state) noexcept override {
+		if(parent) {
+			Cyto::Any payload = element_selection_wrapper<factory_all_actions>{factory_all_actions{factory_all_actions::filter_deselect_all}};
+			parent->impl_get(state, payload);
+		}
+	}
+
 	message_result test_mouse(sys::state& state, int32_t x, int32_t y) noexcept override {
 		return message_result::consumed;
 	}

--- a/src/gui/topbar_subwindows/production_subwindows/gui_projects_window.hpp
+++ b/src/gui/topbar_subwindows/production_subwindows/gui_projects_window.hpp
@@ -22,7 +22,7 @@ class production_project_input_item : public listbox_row_element_base<production
 public:
     void on_create(sys::state& state) noexcept override {
         listbox_row_element_base<production_project_input_data>::on_create(state);
-        amount_text->base_data.position.y = commodity_icon->base_data.position.y + commodity_icon->base_data.size.y;
+        amount_text->base_data.position.y = commodity_icon->base_data.position.y + commodity_icon->base_data.size.y - 4;
     }
 
 	std::unique_ptr<element_base> make_child(sys::state& state, std::string_view name, dcon::gui_def_id id) noexcept override {
@@ -66,10 +66,10 @@ class production_project_info : public listbox_row_element_base<production_proje
     simple_text_element_base* cost_text = nullptr;
     production_project_input_listbox* input_listbox = nullptr;
 
-    float get_cost(sys::state& state, economy::commodity_set& cset) {
-        auto total = 0.f;
+    float get_cost(sys::state& state, const economy::commodity_set& cset) {
+        float total = 0.f;
         for(uint32_t i = 0; i < economy::commodity_set::set_size; ++i) {
-            auto cid = cset.commodity_type[i];
+            dcon::commodity_id cid = cset.commodity_type[i];
             if(bool(cid))
                 total += state.world.commodity_get_current_price(cid) * cset.commodity_amounts[i];
         }
@@ -175,9 +175,9 @@ public:
             input_listbox->update(state);
         }
 
-        auto cost = get_cost(state, satisfied_commodities);
-        auto total_cost = get_cost(state, needed_commodities);
-        cost_text->set_text(state, text::format_money(cost) + "/" + text::format_money(total_cost));
+        float purchased_cost = get_cost(state, satisfied_commodities);
+        float total_cost = get_cost(state, needed_commodities);
+        cost_text->set_text(state, text::format_money(purchased_cost) + "/" + text::format_money(total_cost));
     }
 
 	message_result get(sys::state& state, Cyto::Any& payload) noexcept override {

--- a/src/gui/topbar_subwindows/production_subwindows/gui_projects_window.hpp
+++ b/src/gui/topbar_subwindows/production_subwindows/gui_projects_window.hpp
@@ -18,10 +18,18 @@ struct production_project_input_data {
 
 class production_project_input_item : public listbox_row_element_base<production_project_input_data> {
     simple_text_element_base* amount_text = nullptr;
+    element_base* commodity_icon = nullptr;
 public:
+    void on_create(sys::state& state) noexcept override {
+        listbox_row_element_base<production_project_input_data>::on_create(state);
+        amount_text->base_data.position.y = commodity_icon->base_data.position.y + commodity_icon->base_data.size.y;
+    }
+
 	std::unique_ptr<element_base> make_child(sys::state& state, std::string_view name, dcon::gui_def_id id) noexcept override {
 		if(name == "goods_type") {
-			return make_element_by_type<commodity_factory_image>(state, id);
+			auto ptr = make_element_by_type<commodity_factory_image>(state, id);
+            commodity_icon = ptr.get();
+            return ptr;
         } else if(name == "goods_amount") {
 			auto ptr = make_element_by_type<simple_text_element_base>(state, id);
             amount_text = ptr.get();
@@ -144,6 +152,7 @@ public:
                 needed_commodities = state.economy_definitions.naval_base_definition.cost;
                 break;
             }
+            satisfied_commodities = fat_id.get_purchased_goods();
         } else if(std::holds_alternative<dcon::state_building_construction_id>(content)) {
             factory_icon->set_visible(state, true);
             building_icon->set_visible(state, false);


### PR DESCRIPTION
- fix alignment on projects window with inputs
- show construction factories, the upgrading of factories and the factories normally
- influence diplomacy actions now show a window instead of immediately doing action
- fixed bug with gp selection on diplo window not being used as the affected_gp in influence actions
- fixed crash with console
- fixed colours of budget window
- various production disable buttons if not used
- select/deselect all commodity filters