### PR TITLE
Add Icon Actions to the Politics Window

### DIFF
--- a/src/gui/gui_topbar.hpp
+++ b/src/gui/gui_topbar.hpp
@@ -1268,6 +1268,13 @@ public:
 			text::close_layout_box(contents, box);
 		}
 	}
+
+	void button_action(sys::state& state) noexcept override {
+		state.ui_state.politics_subwindow->set_visible(state, true);
+		Cyto::Any defs = Cyto::make_any<politics_window_tab>(politics_window_tab::reforms);
+		state.ui_state.politics_subwindow->impl_get(state, defs);
+	}
+
 };
 
 class topbar_available_decisions_icon : public standard_nation_button {
@@ -1311,6 +1318,13 @@ public:
 			text::close_layout_box(contents, box);
 		}
 	}
+
+	void button_action(sys::state& state) noexcept override {
+		state.ui_state.politics_subwindow->set_visible(state, true);
+		Cyto::Any defs = Cyto::make_any<politics_window_tab>(politics_window_tab::decisions);
+		state.ui_state.politics_subwindow->impl_get(state, defs);
+	}
+
 };
 
 class topbar_ongoing_election_icon : public standard_nation_icon {
@@ -1392,6 +1406,13 @@ public:
 			text::close_layout_box(contents, box);
 		}
 	}
+
+	void button_action(sys::state& state) noexcept override {
+		state.ui_state.politics_subwindow->set_visible(state, true);
+		Cyto::Any defs = Cyto::make_any<politics_window_tab>(politics_window_tab::movements);
+		state.ui_state.politics_subwindow->impl_get(state, defs);
+	}
+
 };
 
 class topbar_colony_icon : public standard_nation_button {


### PR DESCRIPTION
Added button actions opening specified tab when player clicks on the reform, decision, or rebels icon on the topbar.

Working on learning the UI system for PA, I'll be more active cause summer & OV is mid cycle.