### PR TITLE
placeholder trigger and effects

### DIFF
--- a/src/gamestate/system_state.cpp
+++ b/src/gamestate/system_state.cpp
@@ -934,10 +934,16 @@ std::string_view state::to_string_view(dcon::unit_name_id tag) const {
 }
 
 dcon::trigger_key state::commit_trigger_data(std::vector<uint16_t> data) {
-	if(data.size() == 0) {
+	if(data.empty()) {
 		if(trigger_data_indices.empty())
 			trigger_data_indices.push_back(int32_t(0));
 		return dcon::trigger_key();
+	}
+	if(trigger_data_indices.empty()) { // Create placeholder for invalid triggers
+		trigger_data_indices.push_back(0);
+		trigger_data.push_back(uint16_t(trigger::integer_scope));
+		trigger_data.push_back(uint16_t(2));
+		trigger_data.push_back(uint16_t(1));
 	}
 
 	auto search_result = std::search(trigger_data.data(), trigger_data.data() + trigger_data.size(),
@@ -965,8 +971,14 @@ dcon::trigger_key state::commit_trigger_data(std::vector<uint16_t> data) {
 }
 
 dcon::effect_key state::commit_effect_data(std::vector<uint16_t> data) {
-	if(data.size() == 0)
-		return dcon::effect_key();
+	if(data.empty())
+ 		return dcon::effect_key();
+	
+	if(effect_data.empty()) { // Create placeholder for invalid effects
+		effect_data.push_back(uint16_t(trigger::integer_scope));
+		effect_data.push_back(uint16_t(2));
+		effect_data.push_back(uint16_t(1));
+	}
 
 	auto start = effect_data.size();
 	auto size = data.size();

--- a/src/gamestate/system_state.cpp
+++ b/src/gamestate/system_state.cpp
@@ -943,7 +943,7 @@ dcon::trigger_key state::commit_trigger_data(std::vector<uint16_t> data) {
 		trigger_data_indices.push_back(0);
 		trigger_data.push_back(uint16_t(trigger::integer_scope));
 		trigger_data.push_back(uint16_t(2));
-		trigger_data.push_back(uint16_t(1));
+		trigger_data.push_back(uint16_t(0));
 	}
 
 	auto search_result = std::search(trigger_data.data(), trigger_data.data() + trigger_data.size(),
@@ -977,7 +977,7 @@ dcon::effect_key state::commit_effect_data(std::vector<uint16_t> data) {
 	if(effect_data.empty()) { // Create placeholder for invalid effects
 		effect_data.push_back(uint16_t(trigger::integer_scope));
 		effect_data.push_back(uint16_t(2));
-		effect_data.push_back(uint16_t(1));
+		effect_data.push_back(uint16_t(0));
 	}
 
 	auto start = effect_data.size();

--- a/src/gamestate/system_state.cpp
+++ b/src/gamestate/system_state.cpp
@@ -939,11 +939,10 @@ dcon::trigger_key state::commit_trigger_data(std::vector<uint16_t> data) {
 			trigger_data_indices.push_back(int32_t(0));
 		return dcon::trigger_key();
 	}
+	
 	if(trigger_data_indices.empty()) { // Create placeholder for invalid triggers
 		trigger_data_indices.push_back(0);
-		trigger_data.push_back(uint16_t(trigger::integer_scope));
-		trigger_data.push_back(uint16_t(2));
-		trigger_data.push_back(uint16_t(0));
+		trigger_data.push_back(uint16_t(trigger::always | trigger::no_payload | trigger::association_ne));
 	}
 
 	auto search_result = std::search(trigger_data.data(), trigger_data.data() + trigger_data.size(),
@@ -975,9 +974,7 @@ dcon::effect_key state::commit_effect_data(std::vector<uint16_t> data) {
  		return dcon::effect_key();
 	
 	if(effect_data.empty()) { // Create placeholder for invalid effects
-		effect_data.push_back(uint16_t(trigger::integer_scope));
-		effect_data.push_back(uint16_t(2));
-		effect_data.push_back(uint16_t(0));
+		effect_data.push_back(uint16_t(effect::no_payload | effect::none));
 	}
 
 	auto start = effect_data.size();

--- a/src/gamestate/system_state.cpp
+++ b/src/gamestate/system_state.cpp
@@ -939,7 +939,7 @@ dcon::trigger_key state::commit_trigger_data(std::vector<uint16_t> data) {
 			trigger_data_indices.push_back(int32_t(0));
 		return dcon::trigger_key();
 	}
-	
+
 	if(trigger_data_indices.empty()) { // Create placeholder for invalid triggers
 		trigger_data_indices.push_back(0);
 		trigger_data.push_back(uint16_t(trigger::always | trigger::no_payload | trigger::association_ne));
@@ -974,7 +974,7 @@ dcon::effect_key state::commit_effect_data(std::vector<uint16_t> data) {
  		return dcon::effect_key();
 	
 	if(effect_data.empty()) { // Create placeholder for invalid effects
-		effect_data.push_back(uint16_t(effect::no_payload | effect::none));
+		effect_data.push_back(uint16_t(effect::no_payload));
 	}
 
 	auto start = effect_data.size();

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -667,7 +667,7 @@ void display_data::set_unit_arrows(std::vector<std::vector<glm::vec2>> const& ar
 GLuint load_dds_texture(simple_fs::directory const& dir, native_string_view file_name) {
 	auto file = simple_fs::open_file(dir, file_name);
 	if(!bool(file)) {
-		auto full_message = std::string("Can't load DDS file ") + simple_fs::native_to_utf8(file_name);
+		auto full_message = std::string("Can't load DDS file ") + simple_fs::native_to_utf8(file_name) + "\n";
 #ifdef _WIN64
 		OutputDebugStringA(full_message.c_str());
 #else

--- a/src/parsing/effect_parsing.cpp
+++ b/src/parsing/effect_parsing.cpp
@@ -1094,7 +1094,10 @@ void recurse_over_effects(uint16_t* source, T const& f) {
 }
 
 dcon::effect_key make_effect(token_generator& gen, error_handler& err, effect_building_context& context) {
-	ef_scope_hidden_tooltip(gen, err, context);
+	error_handler e_err(err);
+	ef_scope_hidden_tooltip(gen, e_err, context);
+	err.accumulated_errors += e_err.accumulated_errors;
+	err.accumulated_warnings += e_err.accumulated_warnings;
 
 	if(context.compiled_effect.size() >= std::numeric_limits<uint16_t>::max()) {
 		err.accumulated_errors += "effect is " + std::to_string(context.compiled_effect.size()) +
@@ -1102,7 +1105,7 @@ dcon::effect_key make_effect(token_generator& gen, error_handler& err, effect_bu
 		return dcon::effect_key{0};
 	}
 
-	if(err.accumulated_errors.empty()) {
+	if(e_err.accumulated_errors.empty()) {
 		auto const new_size = simplify_effect(context.compiled_effect.data());
 		context.compiled_effect.resize(static_cast<size_t>(new_size));
 	} else {

--- a/src/parsing/effect_parsing.cpp
+++ b/src/parsing/effect_parsing.cpp
@@ -1102,9 +1102,12 @@ dcon::effect_key make_effect(token_generator& gen, error_handler& err, effect_bu
 		return dcon::effect_key{0};
 	}
 
-	auto const new_size = simplify_effect(context.compiled_effect.data());
-	context.compiled_effect.resize(static_cast<size_t>(new_size));
-
+	if(err.accumulated_errors.empty()) {
+		auto const new_size = simplify_effect(context.compiled_effect.data());
+		context.compiled_effect.resize(static_cast<size_t>(new_size));
+	} else {
+		context.compiled_effect.clear();
+	}
 	return context.outer_context.state.commit_effect_data(context.compiled_effect);
 }
 

--- a/src/parsing/effect_parsing.cpp
+++ b/src/parsing/effect_parsing.cpp
@@ -1094,10 +1094,8 @@ void recurse_over_effects(uint16_t* source, T const& f) {
 }
 
 dcon::effect_key make_effect(token_generator& gen, error_handler& err, effect_building_context& context) {
-	error_handler e_err(err);
-	ef_scope_hidden_tooltip(gen, e_err, context);
-	err.accumulated_errors += e_err.accumulated_errors;
-	err.accumulated_warnings += e_err.accumulated_warnings;
+	auto old_err_size = err.accumulated_errors.size();
+	ef_scope_hidden_tooltip(gen, err, context);
 
 	if(context.compiled_effect.size() >= std::numeric_limits<uint16_t>::max()) {
 		err.accumulated_errors += "effect is " + std::to_string(context.compiled_effect.size()) +
@@ -1105,7 +1103,7 @@ dcon::effect_key make_effect(token_generator& gen, error_handler& err, effect_bu
 		return dcon::effect_key{0};
 	}
 
-	if(e_err.accumulated_errors.empty()) {
+	if(err.accumulated_errors.size() == old_err_size) {
 		auto const new_size = simplify_effect(context.compiled_effect.data());
 		context.compiled_effect.resize(static_cast<size_t>(new_size));
 	} else {

--- a/src/parsing/nations_parsing.cpp
+++ b/src/parsing/nations_parsing.cpp
@@ -968,10 +968,8 @@ sys::event_option make_event_option(token_generator& gen, error_handler& err, ev
 	e_context.limit_position = e_context.compiled_effect.size();
 	e_context.compiled_effect.push_back(trigger::payload(dcon::trigger_key()).value);
 
-	error_handler e_err(err);
-	auto opt_result = parse_event_option(gen, e_err, e_context);
-	err.accumulated_errors += e_err.accumulated_errors;
-	err.accumulated_warnings += e_err.accumulated_warnings;
+	auto old_err_size = err.accumulated_errors.size();
+	auto opt_result = parse_event_option(gen, err, e_context);
 
 	e_context.compiled_effect[payload_size_offset] = uint16_t(e_context.compiled_effect.size() - payload_size_offset);
 
@@ -982,7 +980,7 @@ sys::event_option make_event_option(token_generator& gen, error_handler& err, ev
 		return sys::event_option{opt_result.name_, opt_result.ai_chance, dcon::effect_key{0}};
 	}
 
-	if(e_err.accumulated_errors.empty()) {
+	if(err.accumulated_errors.size() == old_err_size) {
 		auto const new_size = simplify_effect(e_context.compiled_effect.data());
 		e_context.compiled_effect.resize(static_cast<size_t>(new_size));
 	} else {

--- a/src/parsing/nations_parsing.cpp
+++ b/src/parsing/nations_parsing.cpp
@@ -978,11 +978,15 @@ sys::event_option make_event_option(token_generator& gen, error_handler& err, ev
 															" cells big, which exceeds 64 KB bytecode limit (" + err.file_name + ")";
 		return sys::event_option{opt_result.name_, opt_result.ai_chance, dcon::effect_key{0}};
 	}
-	auto const new_size = simplify_effect(e_context.compiled_effect.data());
-	e_context.compiled_effect.resize(static_cast<size_t>(new_size));
+
+	if(err.accumulated_errors.empty()) {
+		auto const new_size = simplify_effect(e_context.compiled_effect.data());
+		e_context.compiled_effect.resize(static_cast<size_t>(new_size));
+	} else {
+		e_context.compiled_effect.clear();
+	}
 
 	auto effect_id = context.outer_context.state.commit_effect_data(e_context.compiled_effect);
-
 	return sys::event_option{opt_result.name_, opt_result.ai_chance, effect_id};
 }
 void commit_pending_events(error_handler& err, scenario_building_context& context) {

--- a/src/parsing/nations_parsing.cpp
+++ b/src/parsing/nations_parsing.cpp
@@ -968,7 +968,10 @@ sys::event_option make_event_option(token_generator& gen, error_handler& err, ev
 	e_context.limit_position = e_context.compiled_effect.size();
 	e_context.compiled_effect.push_back(trigger::payload(dcon::trigger_key()).value);
 
-	auto opt_result = parse_event_option(gen, err, e_context);
+	error_handler e_err(err);
+	auto opt_result = parse_event_option(gen, e_err, e_context);
+	err.accumulated_errors += e_err.accumulated_errors;
+	err.accumulated_warnings += e_err.accumulated_warnings;
 
 	e_context.compiled_effect[payload_size_offset] = uint16_t(e_context.compiled_effect.size() - payload_size_offset);
 
@@ -979,7 +982,7 @@ sys::event_option make_event_option(token_generator& gen, error_handler& err, ev
 		return sys::event_option{opt_result.name_, opt_result.ai_chance, dcon::effect_key{0}};
 	}
 
-	if(err.accumulated_errors.empty()) {
+	if(e_err.accumulated_errors.empty()) {
 		auto const new_size = simplify_effect(e_context.compiled_effect.data());
 		e_context.compiled_effect.resize(static_cast<size_t>(new_size));
 	} else {

--- a/src/parsing/trigger_parsing.cpp
+++ b/src/parsing/trigger_parsing.cpp
@@ -691,11 +691,9 @@ int32_t simplify_trigger(uint16_t* source) {
 }
 
 dcon::trigger_key make_trigger(token_generator& gen, error_handler& err, trigger_building_context& context) {
-	error_handler t_err(err);
-	tr_scope_and(gen, t_err, context);
-	err.accumulated_errors += t_err.accumulated_errors;
-	err.accumulated_warnings += t_err.accumulated_warnings;
-	if(t_err.accumulated_errors.empty()) {
+	auto old_err_size = err.accumulated_errors.size();
+	tr_scope_and(gen, err, context);
+	if(err.accumulated_errors.size() == old_err_size) {
 		auto const new_size = simplify_trigger(context.compiled_trigger.data());
 		context.compiled_trigger.resize(static_cast<size_t>(new_size));
 	} else {
@@ -708,15 +706,13 @@ void make_value_modifier_segment(token_generator& gen, error_handler& err, trigg
 	auto old_factor = context.factor;
 	context.factor = 0.0f;
 
-	error_handler t_err(err);
-	tr_scope_and(gen, t_err, context);
-	err.accumulated_errors += t_err.accumulated_errors;
-	err.accumulated_warnings += t_err.accumulated_warnings;
+	auto old_err_size = err.accumulated_errors.size();
+	tr_scope_and(gen, err, context);
 
 	auto new_factor = context.factor;
 	context.factor = old_factor;
 
-	if(t_err.accumulated_errors.empty()) {
+	if(err.accumulated_errors.size() == old_err_size) {
 		auto const new_size = simplify_trigger(context.compiled_trigger.data());
 		context.compiled_trigger.resize(static_cast<size_t>(new_size));
 	} else {

--- a/src/parsing/trigger_parsing.cpp
+++ b/src/parsing/trigger_parsing.cpp
@@ -691,8 +691,11 @@ int32_t simplify_trigger(uint16_t* source) {
 }
 
 dcon::trigger_key make_trigger(token_generator& gen, error_handler& err, trigger_building_context& context) {
-	tr_scope_and(gen, err, context);
-	if(err.accumulated_errors.empty()) {
+	error_handler t_err(err);
+	tr_scope_and(gen, t_err, context);
+	err.accumulated_errors += t_err.accumulated_errors;
+	err.accumulated_warnings += t_err.accumulated_warnings;
+	if(t_err.accumulated_errors.empty()) {
 		auto const new_size = simplify_trigger(context.compiled_trigger.data());
 		context.compiled_trigger.resize(static_cast<size_t>(new_size));
 	} else {
@@ -704,11 +707,16 @@ dcon::trigger_key make_trigger(token_generator& gen, error_handler& err, trigger
 void make_value_modifier_segment(token_generator& gen, error_handler& err, trigger_building_context& context) {
 	auto old_factor = context.factor;
 	context.factor = 0.0f;
-	tr_scope_and(gen, err, context);
+
+	error_handler t_err(err);
+	tr_scope_and(gen, t_err, context);
+	err.accumulated_errors += t_err.accumulated_errors;
+	err.accumulated_warnings += t_err.accumulated_warnings;
+
 	auto new_factor = context.factor;
 	context.factor = old_factor;
 
-	if(err.accumulated_errors.empty()) {
+	if(t_err.accumulated_errors.empty()) {
 		auto const new_size = simplify_trigger(context.compiled_trigger.data());
 		context.compiled_trigger.resize(static_cast<size_t>(new_size));
 	} else {

--- a/src/parsing/trigger_parsing.cpp
+++ b/src/parsing/trigger_parsing.cpp
@@ -692,9 +692,12 @@ int32_t simplify_trigger(uint16_t* source) {
 
 dcon::trigger_key make_trigger(token_generator& gen, error_handler& err, trigger_building_context& context) {
 	tr_scope_and(gen, err, context);
-	auto const new_size = simplify_trigger(context.compiled_trigger.data());
-	context.compiled_trigger.resize(static_cast<size_t>(new_size));
-
+	if(err.accumulated_errors.empty()) {
+		auto const new_size = simplify_trigger(context.compiled_trigger.data());
+		context.compiled_trigger.resize(static_cast<size_t>(new_size));
+	} else {
+		context.compiled_trigger.clear();
+	}
 	return context.outer_context.state.commit_trigger_data(context.compiled_trigger);
 }
 
@@ -705,8 +708,12 @@ void make_value_modifier_segment(token_generator& gen, error_handler& err, trigg
 	auto new_factor = context.factor;
 	context.factor = old_factor;
 
-	auto const new_size = simplify_trigger(context.compiled_trigger.data());
-	context.compiled_trigger.resize(static_cast<size_t>(new_size));
+	if(err.accumulated_errors.empty()) {
+		auto const new_size = simplify_trigger(context.compiled_trigger.data());
+		context.compiled_trigger.resize(static_cast<size_t>(new_size));
+	} else {
+		context.compiled_trigger.clear();
+	}
 
 	auto tkey = context.outer_context.state.commit_trigger_data(context.compiled_trigger);
 	context.compiled_trigger.clear();


### PR DESCRIPTION
why:

some mods have hundreds and hundreds of invalid and malformed effects and triggers, this causes a **crash** in Project Alice, rather than crashing we would do:

a) emit warning and error messages
b) let the user continue if so they wish

I think a PR like this was submitted very early on, but it didn't have placeholder triggers/effects, here it does have them and it allows most invalid triggers and effects to simply call a "dummy" no-operation trigger.

it evaluates to false, so it never gets executed and doesn't cause a cascade of invalid errors and event chains, etc.

this is mainly for improving the user experience of "it works out of the box" - yes, it means some content will not be accessible due to it having errors - but it will also allow users to experience the content without having to wait for the mod developers to fix the mod for alice

also some mods are no longer updated, as such we should probably allow for potentially erroneous triggers and effects to be "dummy"-ified, so we are able to run popular, unupdated mods