### PR TITLE
Expand effects to be beyond 64K limit

### DIFF
--- a/src/gamestate/serialization.cpp
+++ b/src/gamestate/serialization.cpp
@@ -234,6 +234,7 @@ uint8_t const* read_scenario_section(uint8_t const* ptr_in, uint8_t const* secti
 	ptr_in = deserialize(ptr_in, state.trigger_data);
 	ptr_in = deserialize(ptr_in, state.trigger_data_indices);
 	ptr_in = deserialize(ptr_in, state.effect_data);
+	ptr_in = deserialize(ptr_in, state.effect_data_indices);
 	ptr_in = deserialize(ptr_in, state.value_modifier_segments);
 	ptr_in = deserialize(ptr_in, state.value_modifiers);
 	ptr_in = deserialize(ptr_in, state.text_data);
@@ -413,6 +414,7 @@ uint8_t* write_scenario_section(uint8_t* ptr_in, sys::state& state) {
 	ptr_in = serialize(ptr_in, state.trigger_data);
 	ptr_in = serialize(ptr_in, state.trigger_data_indices);
 	ptr_in = serialize(ptr_in, state.effect_data);
+	ptr_in = serialize(ptr_in, state.effect_data_indices);
 	ptr_in = serialize(ptr_in, state.value_modifier_segments);
 	ptr_in = serialize(ptr_in, state.value_modifiers);
 	ptr_in = serialize(ptr_in, state.text_data);
@@ -586,6 +588,7 @@ size_t sizeof_scenario_section(sys::state& state) {
 	sz += serialize_size(state.trigger_data);
 	sz += serialize_size(state.trigger_data_indices);
 	sz += serialize_size(state.effect_data);
+	sz += serialize_size(state.effect_data_indices);
 	sz += serialize_size(state.value_modifier_segments);
 	sz += serialize_size(state.value_modifiers);
 	sz += serialize_size(state.text_data);

--- a/src/gamestate/serialization.hpp
+++ b/src/gamestate/serialization.hpp
@@ -128,8 +128,8 @@ uint8_t const* deserialize(uint8_t const* ptr_in, ankerl::unordered_dense::map<u
 	return ptr_in + sizeof(uint32_t) + sizeof(vec.values()[0]) * length;
 }
 
-constexpr inline uint32_t save_file_version = 23;
-constexpr inline uint32_t scenario_file_version = 72 + save_file_version;
+constexpr inline uint32_t save_file_version = 24;
+constexpr inline uint32_t scenario_file_version = 73 + save_file_version;
 
 struct scenario_header {
 	uint32_t version = scenario_file_version;

--- a/src/gamestate/system_state.cpp
+++ b/src/gamestate/system_state.cpp
@@ -968,11 +968,11 @@ dcon::trigger_key state::commit_trigger_data(std::vector<uint16_t> data) {
 		auto it = std::find(trigger_data_indices.begin(), trigger_data_indices.end(), int32_t(start));
 		if(it != trigger_data_indices.end()) {
 			auto d = std::distance(trigger_data_indices.begin(), it);
-			return dcon::trigger_key(dcon::trigger_key::value_base_t(d));
+			return dcon::trigger_key(dcon::trigger_key::value_base_t(d - 1));
 		} else {
 			trigger_data_indices.push_back(int32_t(start));
 			assert(trigger_data_indices.size() <= std::numeric_limits<uint16_t>::max());
-			return dcon::trigger_key(dcon::trigger_key::value_base_t(trigger_data_indices.size() - 1));
+			return dcon::trigger_key(dcon::trigger_key::value_base_t(trigger_data_indices.size() - 1 - 1));
 		}
 	} else {
 		auto start = trigger_data.size();
@@ -981,7 +981,7 @@ dcon::trigger_key state::commit_trigger_data(std::vector<uint16_t> data) {
 		std::copy_n(data.data(), size, trigger_data.data() + start);
 		trigger_data_indices.push_back(int32_t(start));
 		assert(trigger_data_indices.size() <= std::numeric_limits<uint16_t>::max());
-		return dcon::trigger_key(dcon::trigger_key::value_base_t(trigger_data_indices.size() - 1));
+		return dcon::trigger_key(dcon::trigger_key::value_base_t(trigger_data_indices.size() - 1 - 1));
 	}
 }
 
@@ -1004,11 +1004,11 @@ dcon::effect_key state::commit_effect_data(std::vector<uint16_t> data) {
 		auto it = std::find(effect_data_indices.begin(), effect_data_indices.end(), int32_t(start));
 		if(it != effect_data_indices.end()) {
 			auto d = std::distance(effect_data_indices.begin(), it);
-			return dcon::effect_key(dcon::effect_key::value_base_t(d));
+			return dcon::effect_key(dcon::effect_key::value_base_t(d - 1));
 		} else {
 			effect_data_indices.push_back(int32_t(start));
 			assert(effect_data_indices.size() <= std::numeric_limits<uint16_t>::max());
-			return dcon::effect_key(dcon::effect_key::value_base_t(effect_data_indices.size() - 1));
+			return dcon::effect_key(dcon::effect_key::value_base_t(effect_data_indices.size() - 1 - 1));
 		}
 	} else {
 		auto start = effect_data.size();
@@ -1017,7 +1017,7 @@ dcon::effect_key state::commit_effect_data(std::vector<uint16_t> data) {
 		std::copy_n(data.data(), size, effect_data.data() + start);
 		effect_data_indices.push_back(int32_t(start));
 		assert(effect_data_indices.size() <= std::numeric_limits<uint16_t>::max());
-		return dcon::effect_key(dcon::effect_key::value_base_t(effect_data_indices.size() - 1));
+		return dcon::effect_key(dcon::effect_key::value_base_t(effect_data_indices.size() - 1 - 1));
 	}
 }
 

--- a/src/gamestate/system_state.cpp
+++ b/src/gamestate/system_state.cpp
@@ -986,19 +986,39 @@ dcon::trigger_key state::commit_trigger_data(std::vector<uint16_t> data) {
 }
 
 dcon::effect_key state::commit_effect_data(std::vector<uint16_t> data) {
-	if(data.empty())
- 		return dcon::effect_key();
-	
-	if(effect_data.empty()) { // Create placeholder for invalid effects
+	if(data.empty()) {
+		if(effect_data_indices.empty())
+			effect_data_indices.push_back(int32_t(0));
+		return dcon::effect_key();
+	}
+
+	if(effect_data_indices.empty()) { // Create placeholder for invalid effects
+		effect_data_indices.push_back(0);
 		effect_data.push_back(uint16_t(effect::no_payload));
 	}
 
-	auto start = effect_data.size();
-	auto size = data.size();
-
-	effect_data.resize(start + size, uint16_t(0));
-	std::copy_n(data.data(), size, effect_data.data() + start);
-	return dcon::effect_key(uint16_t(start));
+	auto search_result = std::search(effect_data.data(), effect_data.data() + effect_data.size(),
+			std::boyer_moore_horspool_searcher(data.data(), data.data() + data.size()));
+	if(search_result != effect_data.data() + effect_data.size()) {
+		auto const start = search_result - effect_data.data();
+		auto it = std::find(effect_data_indices.begin(), effect_data_indices.end(), int32_t(start));
+		if(it != effect_data_indices.end()) {
+			auto d = std::distance(effect_data_indices.begin(), it);
+			return dcon::effect_key(dcon::effect_key::value_base_t(d));
+		} else {
+			effect_data_indices.push_back(int32_t(start));
+			assert(effect_data_indices.size() <= std::numeric_limits<uint16_t>::max());
+			return dcon::effect_key(dcon::effect_key::value_base_t(effect_data_indices.size() - 1));
+		}
+	} else {
+		auto start = effect_data.size();
+		auto size = data.size();
+		effect_data.resize(start + size, uint16_t(0));
+		std::copy_n(data.data(), size, effect_data.data() + start);
+		effect_data_indices.push_back(int32_t(start));
+		assert(effect_data_indices.size() <= std::numeric_limits<uint16_t>::max());
+		return dcon::effect_key(dcon::effect_key::value_base_t(effect_data_indices.size() - 1));
+	}
 }
 
 void state::save_user_settings() const {

--- a/src/gamestate/system_state.hpp
+++ b/src/gamestate/system_state.hpp
@@ -410,6 +410,7 @@ struct alignas(64) state {
 	std::vector<uint16_t> trigger_data;
 	std::vector<int32_t> trigger_data_indices;
 	std::vector<uint16_t> effect_data;
+	std::vector<int32_t> effect_data_indices;
 	std::vector<value_modifier_segment> value_modifier_segments;
 	tagged_vector<value_modifier_description, dcon::value_modifier_key> value_modifiers;
 

--- a/src/gui/gui_effect_tooltips.cpp
+++ b/src/gui/gui_effect_tooltips.cpp
@@ -6243,7 +6243,7 @@ uint32_t internal_make_effect_description(EFFECT_DISPLAY_PARAMS) {
 
 void effect_description(sys::state& state, text::layout_base& layout, dcon::effect_key k, int32_t primary_slot, int32_t this_slot,
 		int32_t from_slot, uint32_t r_lo, uint32_t r_hi) {
-	effect_tooltip::internal_make_effect_description(state, state.effect_data.data() + k.index(), layout, primary_slot, this_slot,
+	effect_tooltip::internal_make_effect_description(state, state.effect_data.data() + state.effect_data_indices[k.index()], layout, primary_slot, this_slot,
 			from_slot, r_lo, r_hi, 0);
 }
 

--- a/src/gui/gui_effect_tooltips.cpp
+++ b/src/gui/gui_effect_tooltips.cpp
@@ -169,7 +169,7 @@ void show_limit(sys::state& ws, uint16_t const* tval, text::layout_base& layout,
 		text::add_to_layout_box(ws, layout, box, text::produce_simple_string(ws, "where"));
 		text::close_layout_box(layout, box);
 
-		trigger_tooltip::make_trigger_description(ws, layout, ws.trigger_data.data() + ws.trigger_data_indices[limit.index()], -1,
+		trigger_tooltip::make_trigger_description(ws, layout, ws.trigger_data.data() + ws.trigger_data_indices[limit.index() + 1], -1,
 				this_slot, from_slot, indentation + 2 * indentation_amount, false);
 	}
 }
@@ -6243,7 +6243,7 @@ uint32_t internal_make_effect_description(EFFECT_DISPLAY_PARAMS) {
 
 void effect_description(sys::state& state, text::layout_base& layout, dcon::effect_key k, int32_t primary_slot, int32_t this_slot,
 		int32_t from_slot, uint32_t r_lo, uint32_t r_hi) {
-	effect_tooltip::internal_make_effect_description(state, state.effect_data.data() + state.effect_data_indices[k.index()], layout, primary_slot, this_slot,
+	effect_tooltip::internal_make_effect_description(state, state.effect_data.data() + state.effect_data_indices[k.index() + 1], layout, primary_slot, this_slot,
 			from_slot, r_lo, r_hi, 0);
 }
 

--- a/src/gui/gui_trigger_tooltips.cpp
+++ b/src/gui/gui_trigger_tooltips.cpp
@@ -7398,7 +7398,7 @@ void make_trigger_description(sys::state& ws, text::layout_base& layout, uint16_
 
 void trigger_description(sys::state& state, text::layout_base& layout, dcon::trigger_key k, int32_t primary_slot,
 		int32_t this_slot, int32_t from_slot) {
-	trigger_tooltip::make_trigger_description(state, layout, state.trigger_data.data() + state.trigger_data_indices[k.index()],
+	trigger_tooltip::make_trigger_description(state, layout, state.trigger_data.data() + state.trigger_data_indices[k.index() + 1],
 			primary_slot, this_slot, from_slot, 0, true);
 }
 
@@ -7441,7 +7441,7 @@ void multiplicative_value_modifier_description(sys::state& state, text::layout_b
 			text::close_layout_box(layout, box);
 
 			trigger_tooltip::make_trigger_description(state, layout,
-					state.trigger_data.data() + state.trigger_data_indices[seg.condition.index()], primary_slot, this_slot, from_slot,
+					state.trigger_data.data() + state.trigger_data_indices[seg.condition.index() + 1], primary_slot, this_slot, from_slot,
 					trigger_tooltip::indentation_amount * 2, true);
 		}
 	}
@@ -7486,7 +7486,7 @@ void additive_value_modifier_description(sys::state& state, text::layout_base& l
 			text::close_layout_box(layout, box);
 
 			trigger_tooltip::make_trigger_description(state, layout,
-					state.trigger_data.data() + state.trigger_data_indices[seg.condition.index()], primary_slot, this_slot, from_slot,
+					state.trigger_data.data() + state.trigger_data_indices[seg.condition.index() + 1], primary_slot, this_slot, from_slot,
 					trigger_tooltip::indentation_amount * 2, true);
 		}
 	}

--- a/src/gui/topbar_subwindows/gui_technology_window.hpp
+++ b/src/gui/topbar_subwindows/gui_technology_window.hpp
@@ -322,7 +322,7 @@ void technology_description(sys::state& state, text::layout_base& contents, dcon
 	state.world.for_each_invention([&](dcon::invention_id id) {
 		auto lim_trigger_k = state.world.invention_get_limit(id);
 		bool activable_by_this_tech = false;
-		trigger::recurse_over_triggers(state.trigger_data.data() + state.trigger_data_indices[lim_trigger_k.index()],
+		trigger::recurse_over_triggers(state.trigger_data.data() + state.trigger_data_indices[lim_trigger_k.index() + 1],
 				[&](uint16_t* tval) {
 					if((tval[0] & trigger::code_mask) == trigger::technology && trigger::payload(tval[1]).tech_id == tech_id)
 						activable_by_this_tech = true;
@@ -1135,7 +1135,7 @@ public:
 			state.world.for_each_invention([&](dcon::invention_id id) {
 				auto lim_trigger_k = state.world.invention_get_limit(id);
 				bool activable_by_this_tech = false;
-				trigger::recurse_over_triggers(state.trigger_data.data() + state.trigger_data_indices[lim_trigger_k.index()],
+				trigger::recurse_over_triggers(state.trigger_data.data() + state.trigger_data_indices[lim_trigger_k.index() + 1],
 						[&](uint16_t* tval) {
 							if((tval[0] & trigger::code_mask) == trigger::technology && trigger::payload(tval[1]).tech_id == content)
 								activable_by_this_tech = true;

--- a/src/scripting/effects.cpp
+++ b/src/scripting/effects.cpp
@@ -4304,7 +4304,7 @@ uint32_t internal_execute_effect(EFFECT_PARAMTERS) {
 
 void execute(sys::state& state, dcon::effect_key key, int32_t primary, int32_t this_slot, int32_t from_slot, uint32_t r_lo,
 		uint32_t r_hi) {
-	internal_execute_effect(state.effect_data.data() + key.index(), state, primary, this_slot, from_slot, r_lo, r_hi);
+	internal_execute_effect(state.effect_data.data() + state.effect_data_indices[key.index()], state, primary, this_slot, from_slot, r_lo, r_hi);
 }
 
 void execute(sys::state& state, uint16_t const* data, int32_t primary, int32_t this_slot, int32_t from_slot, uint32_t r_lo,

--- a/src/scripting/effects.cpp
+++ b/src/scripting/effects.cpp
@@ -4304,7 +4304,7 @@ uint32_t internal_execute_effect(EFFECT_PARAMTERS) {
 
 void execute(sys::state& state, dcon::effect_key key, int32_t primary, int32_t this_slot, int32_t from_slot, uint32_t r_lo,
 		uint32_t r_hi) {
-	internal_execute_effect(state.effect_data.data() + state.effect_data_indices[key.index()], state, primary, this_slot, from_slot, r_lo, r_hi);
+	internal_execute_effect(state.effect_data.data() + state.effect_data_indices[key.index() + 1], state, primary, this_slot, from_slot, r_lo, r_hi);
 }
 
 void execute(sys::state& state, uint16_t const* data, int32_t primary, int32_t this_slot, int32_t from_slot, uint32_t r_lo,

--- a/src/scripting/triggers.cpp
+++ b/src/scripting/triggers.cpp
@@ -6187,7 +6187,7 @@ float evaluate_multiplicative_modifier(sys::state& state, dcon::value_modifier_k
 	for(uint32_t i = 0; i < base.segments_count && product != 0; ++i) {
 		auto seg = state.value_modifier_segments[base.first_segment_offset + i];
 		if(seg.condition) {
-			if(test_trigger_generic<bool>(state.trigger_data.data() + state.trigger_data_indices[seg.condition.index()], state, primary,
+			if(test_trigger_generic<bool>(state.trigger_data.data() + state.trigger_data_indices[seg.condition.index() + 1], state, primary,
 						 this_slot, from_slot)) {
 				product *= seg.factor;
 			}
@@ -6202,7 +6202,7 @@ float evaluate_additive_modifier(sys::state& state, dcon::value_modifier_key mod
 	for(uint32_t i = 0; i < base.segments_count; ++i) {
 		auto seg = state.value_modifier_segments[base.first_segment_offset + i];
 		if(seg.condition) {
-			if(test_trigger_generic<bool>(state.trigger_data.data() + state.trigger_data_indices[seg.condition.index()], state, primary,
+			if(test_trigger_generic<bool>(state.trigger_data.data() + state.trigger_data_indices[seg.condition.index() + 1], state, primary,
 						 this_slot, from_slot)) {
 				sum += seg.factor;
 			}
@@ -6219,7 +6219,7 @@ ve::fp_vector evaluate_multiplicative_modifier(sys::state& state, dcon::value_mo
 		auto seg = state.value_modifier_segments[base.first_segment_offset + i];
 		if(seg.condition) {
 			auto res = test_trigger_generic<ve::mask_vector>(
-					state.trigger_data.data() + state.trigger_data_indices[seg.condition.index()], state, primary, this_slot, from_slot);
+					state.trigger_data.data() + state.trigger_data_indices[seg.condition.index() + 1], state, primary, this_slot, from_slot);
 			product = ve::select(res, product * seg.factor, product);
 		}
 	}
@@ -6233,7 +6233,7 @@ ve::fp_vector evaluate_additive_modifier(sys::state& state, dcon::value_modifier
 		auto seg = state.value_modifier_segments[base.first_segment_offset + i];
 		if(seg.condition) {
 			auto res = test_trigger_generic<ve::mask_vector>(
-					state.trigger_data.data() + state.trigger_data_indices[seg.condition.index()], state, primary, this_slot, from_slot);
+					state.trigger_data.data() + state.trigger_data_indices[seg.condition.index() + 1], state, primary, this_slot, from_slot);
 			sum = ve::select(res, sum + seg.factor, sum);
 		}
 	}
@@ -6248,7 +6248,7 @@ ve::fp_vector evaluate_multiplicative_modifier(sys::state& state, dcon::value_mo
 		auto seg = state.value_modifier_segments[base.first_segment_offset + i];
 		if(seg.condition) {
 			auto res = test_trigger_generic<ve::mask_vector>(
-					state.trigger_data.data() + state.trigger_data_indices[seg.condition.index()], state, primary, this_slot, from_slot);
+					state.trigger_data.data() + state.trigger_data_indices[seg.condition.index() + 1], state, primary, this_slot, from_slot);
 			product = ve::select(res, product * seg.factor, product);
 		}
 	}
@@ -6262,7 +6262,7 @@ ve::fp_vector evaluate_additive_modifier(sys::state& state, dcon::value_modifier
 		auto seg = state.value_modifier_segments[base.first_segment_offset + i];
 		if(seg.condition) {
 			auto res = test_trigger_generic<ve::mask_vector>(
-					state.trigger_data.data() + state.trigger_data_indices[seg.condition.index()], state, primary, this_slot, from_slot);
+					state.trigger_data.data() + state.trigger_data_indices[seg.condition.index() + 1], state, primary, this_slot, from_slot);
 			sum = ve::select(res, sum + seg.factor, sum);
 		}
 	}
@@ -6270,7 +6270,7 @@ ve::fp_vector evaluate_additive_modifier(sys::state& state, dcon::value_modifier
 }
 
 bool evaluate(sys::state& state, dcon::trigger_key key, int32_t primary, int32_t this_slot, int32_t from_slot) {
-	return test_trigger_generic<bool>(state.trigger_data.data() + state.trigger_data_indices[key.index()], state, primary,
+	return test_trigger_generic<bool>(state.trigger_data.data() + state.trigger_data_indices[key.index() + 1], state, primary,
 			this_slot, from_slot);
 }
 bool evaluate(sys::state& state, uint16_t const* data, int32_t primary, int32_t this_slot, int32_t from_slot) {
@@ -6279,7 +6279,7 @@ bool evaluate(sys::state& state, uint16_t const* data, int32_t primary, int32_t 
 
 ve::mask_vector evaluate(sys::state& state, dcon::trigger_key key, ve::contiguous_tags<int32_t> primary,
 		ve::tagged_vector<int32_t> this_slot, int32_t from_slot) {
-	return test_trigger_generic<ve::mask_vector>(state.trigger_data.data() + state.trigger_data_indices[key.index()], state,
+	return test_trigger_generic<ve::mask_vector>(state.trigger_data.data() + state.trigger_data_indices[key.index() + 1], state,
 			primary, this_slot, from_slot);
 }
 ve::mask_vector evaluate(sys::state& state, uint16_t const* data, ve::contiguous_tags<int32_t> primary,
@@ -6289,7 +6289,7 @@ ve::mask_vector evaluate(sys::state& state, uint16_t const* data, ve::contiguous
 
 ve::mask_vector evaluate(sys::state& state, dcon::trigger_key key, ve::tagged_vector<int32_t> primary,
 		ve::tagged_vector<int32_t> this_slot, int32_t from_slot) {
-	return test_trigger_generic<ve::mask_vector>(state.trigger_data.data() + state.trigger_data_indices[key.index()], state,
+	return test_trigger_generic<ve::mask_vector>(state.trigger_data.data() + state.trigger_data_indices[key.index() + 1], state,
 			primary, this_slot, from_slot);
 }
 ve::mask_vector evaluate(sys::state& state, uint16_t const* data, ve::tagged_vector<int32_t> primary,
@@ -6299,7 +6299,7 @@ ve::mask_vector evaluate(sys::state& state, uint16_t const* data, ve::tagged_vec
 
 ve::mask_vector evaluate(sys::state& state, dcon::trigger_key key, ve::contiguous_tags<int32_t> primary,
 		ve::contiguous_tags<int32_t> this_slot, int32_t from_slot) {
-	return test_trigger_generic<ve::mask_vector>(state.trigger_data.data() + state.trigger_data_indices[key.index()], state,
+	return test_trigger_generic<ve::mask_vector>(state.trigger_data.data() + state.trigger_data_indices[key.index() + 1], state,
 			primary, this_slot, from_slot);
 }
 ve::mask_vector evaluate(sys::state& state, uint16_t const* data, ve::contiguous_tags<int32_t> primary,


### PR DESCRIPTION
Fixes errors with various "big" mods like GFM and TGC. The issue is that most effects are indeed valid, however they are put way beyond the 64K barrier the effects normally have, so it "calls" whatever happens to be the key%64K, which often results in crashes. Basically, the effects are OK, they just need more "key-space".