### PR TITLE
use posix_fadvise to map files beforehand

### DIFF
--- a/src/filesystem/simple_fs_nix.cpp
+++ b/src/filesystem/simple_fs_nix.cpp
@@ -70,6 +70,9 @@ file::file(native_string const& full_path) {
 		struct stat sb;
 		if(fstat(file_descriptor, &sb) != -1) {
 			content.file_size = sb.st_size;
+#if _POSIX_C_SOURCE >= 200112L
+			posix_fadvise(file_descriptor, 0, static_cast<off_t>(content.file_size), POSIX_FADV_WILLNEED);
+#endif
 #if defined(_GNU_SOURCE) || defined(_DEFAULT_SOURCE) || defined(_BSD_SOURCE) || defined(_SVID_SOURCE)
 			mapping_handle = mmap(0, content.file_size, PROT_READ, MAP_PRIVATE, file_descriptor, 0);
 			if(mapping_handle == MAP_FAILED) {


### PR DESCRIPTION
according to https://man7.org/linux/man-pages/man2/posix_fadvise.2.html posix_fadvice can tell the kernel to load pages beforehand for the specified file - may help to improve performance