### PR TITLE
Chat window

### DIFF
--- a/src/common_types/constants.hpp
+++ b/src/common_types/constants.hpp
@@ -303,6 +303,7 @@ namespace ui {
 
 enum class production_sort_order { name, factories, primary_workers, secondary_workers, owners, infrastructure };
 enum class production_window_tab : uint8_t { factories = 0x0, investments = 0x1, projects = 0x2, goods = 0x3 };
+constexpr inline uint32_t max_chat_message_len = 40;
 
 }
 

--- a/src/common_types/constants.hpp
+++ b/src/common_types/constants.hpp
@@ -303,7 +303,7 @@ namespace ui {
 
 enum class production_sort_order { name, factories, primary_workers, secondary_workers, owners, infrastructure };
 enum class production_window_tab : uint8_t { factories = 0x0, investments = 0x1, projects = 0x2, goods = 0x3 };
-constexpr inline uint32_t max_chat_message_len = 40;
+constexpr inline uint32_t max_chat_message_len = 24;
 
 }
 

--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -3992,10 +3992,9 @@ void execute_chat_message(sys::state& state, dcon::nation_id source, std::string
 	memcpy(m.body, std::string(body).c_str(), ui::max_chat_message_len);
 	m.body[ui::max_chat_message_len - 1] = '\0';
 
-	state.ui_state.chat_messages.push_back(m);
-	if(state.ui_state.chat_messages.size() >= 30) {
-		state.ui_state.chat_messages.pop_front();
-	}
+	state.ui_state.chat_messages[chat_messages_index++] = m;
+	if(chat_messages_index >= chat_messages.size())
+		chat_messages_index = 0;
 }
 
 void execute_pending_commands(sys::state& state) {

--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -4,6 +4,11 @@
 
 namespace command {
 
+static void add_to_command_queue(sys::state& state, payload& p) {
+	// TODO: pushes for client/server once available
+	bool b = state.incoming_commands.try_push(p);
+}
+
 bool console_command(sys::state& state, command_type t) {
 	return (uint8_t(t) & 0x80) != 0;
 }
@@ -16,7 +21,7 @@ void set_national_focus(sys::state& state, dcon::nation_id source, dcon::state_i
 	p.source = source;
 	p.data.nat_focus.focus = focus;
 	p.data.nat_focus.target_state = target_state;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 
 bool can_set_national_focus(sys::state& state, dcon::nation_id source, dcon::state_instance_id target_state,
@@ -77,7 +82,7 @@ void start_research(sys::state& state, dcon::nation_id source, dcon::technology_
 	p.type = command_type::start_research;
 	p.source = source;
 	p.data.start_research.tech = tech;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 
 bool can_start_research(sys::state& state, dcon::nation_id source, dcon::technology_id tech) {
@@ -117,7 +122,7 @@ void make_leader(sys::state& state, dcon::nation_id source, bool general) {
 	p.type = command_type::make_leader;
 	p.source = source;
 	p.data.make_leader.is_general = general;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_make_leader(sys::state& state, dcon::nation_id source, bool general) {
 	return state.world.nation_get_leadership_points(source) >= state.defines.leader_recruit_cost;
@@ -136,7 +141,7 @@ void give_war_subsidies(sys::state& state, dcon::nation_id source, dcon::nation_
 	p.type = command_type::war_subsidies;
 	p.source = source;
 	p.data.diplo_action.target = target;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_give_war_subsidies(sys::state& state, dcon::nation_id source, dcon::nation_id target) {
 	/* Can only perform if, the nations are not at war, the nation isn't already being given war subsidies, and there is
@@ -183,7 +188,7 @@ void cancel_war_subsidies(sys::state& state, dcon::nation_id source, dcon::natio
 	p.type = command_type::cancel_war_subsidies;
 	p.source = source;
 	p.data.diplo_action.target = target;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_cancel_war_subsidies(sys::state& state, dcon::nation_id source, dcon::nation_id target) {
 	/* Can only perform if, the nations are not at war, the nation is already being given war subsidies, and there is
@@ -233,7 +238,7 @@ void increase_relations(sys::state& state, dcon::nation_id source, dcon::nation_
 	p.type = command_type::increase_relations;
 	p.source = source;
 	p.data.diplo_action.target = target;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_increase_relations(sys::state& state, dcon::nation_id source, dcon::nation_id target) {
 	/* Can only perform if, the nations are not at war, the relation value isn't maxed out at 200, and has
@@ -281,7 +286,7 @@ void decrease_relations(sys::state& state, dcon::nation_id source, dcon::nation_
 	p.type = command_type::decrease_relations;
 	p.source = source;
 	p.data.diplo_action.target = target;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_decrease_relations(sys::state& state, dcon::nation_id source, dcon::nation_id target) {
 	/* Can only perform if, the nations are not at war, the relation value isn't maxxed out at -200, and has
@@ -328,7 +333,7 @@ void begin_province_building_construction(sys::state& state, dcon::nation_id sou
 	p.source = source;
 	p.data.start_province_building.location = prov;
 	p.data.start_province_building.type = type;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_begin_province_building_construction(sys::state& state, dcon::nation_id source, dcon::province_id p, economy::province_building_type type) {
 
@@ -383,7 +388,7 @@ void begin_factory_building_construction(sys::state& state, dcon::nation_id sour
 	p.data.start_factory_building.location = location;
 	p.data.start_factory_building.type = type;
 	p.data.start_factory_building.is_upgrade = is_upgrade;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 
 bool can_begin_factory_building_construction(sys::state& state, dcon::nation_id source, dcon::state_instance_id location, dcon::factory_type_id type, bool is_upgrade) {
@@ -519,7 +524,7 @@ void start_naval_unit_construction(sys::state& state, dcon::nation_id source, dc
 	p.source = source;
 	p.data.naval_unit_construction.location = location;
 	p.data.naval_unit_construction.type = type;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 
 bool can_start_naval_unit_construction(sys::state& state, dcon::nation_id source, dcon::province_id location, dcon::unit_type_id type) {
@@ -577,7 +582,7 @@ void start_land_unit_construction(sys::state& state, dcon::nation_id source, dco
 	p.data.land_unit_construction.location = location;
 	p.data.land_unit_construction.type = type;
 	p.data.land_unit_construction.pop_culture = soldier_culture;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_start_land_unit_construction(sys::state& state, dcon::nation_id source, dcon::province_id location, dcon::culture_id soldier_culture, dcon::unit_type_id type) {
 	/*
@@ -622,7 +627,7 @@ void cancel_naval_unit_construction(sys::state& state, dcon::nation_id source, d
 	p.source = source;
 	p.data.naval_unit_construction.location = location;
 	p.data.naval_unit_construction.type = type;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 
 bool can_cancel_naval_unit_construction(sys::state& state, dcon::nation_id source, dcon::province_id location, dcon::unit_type_id type) {
@@ -650,7 +655,7 @@ void cancel_land_unit_construction(sys::state& state, dcon::nation_id source, dc
 	p.data.land_unit_construction.location = location;
 	p.data.land_unit_construction.type = type;
 	p.data.land_unit_construction.pop_culture = soldier_culture;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_cancel_land_unit_construction(sys::state& state, dcon::nation_id source, dcon::province_id location, dcon::culture_id soldier_culture, dcon::unit_type_id type) {
 	return state.world.province_get_nation_from_province_ownership(location) == source;
@@ -678,7 +683,7 @@ void delete_factory(sys::state& state, dcon::nation_id source, dcon::factory_id 
 	p.source = source;
 	p.data.factory.location = state.world.factory_get_province_from_factory_location(f);
 	p.data.factory.type = state.world.factory_get_building_type(f);
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_delete_factory(sys::state& state, dcon::nation_id source, dcon::factory_id f) {
 	auto loc = state.world.factory_get_province_from_factory_location(f);
@@ -714,7 +719,7 @@ void change_factory_settings(sys::state& state, dcon::nation_id source, dcon::fa
 	p.data.factory.type = state.world.factory_get_building_type(f);
 	p.data.factory.priority = priority;
 	p.data.factory.subsidize = subsidized;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_change_factory_settings(sys::state& state, dcon::nation_id source, dcon::factory_id f, uint8_t priority, bool subsidized) {
 	auto loc = state.world.factory_get_province_from_factory_location(f);
@@ -769,7 +774,7 @@ void make_vassal(sys::state& state, dcon::nation_id source, dcon::national_ident
 	p.type = command_type::make_vassal;
 	p.source = source;
 	p.data.tag_target.ident = t;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_make_vassal(sys::state& state, dcon::nation_id source, dcon::national_identity_id t) {
 	return nations::can_release_as_vassal(state, source, t);
@@ -798,7 +803,7 @@ void release_and_play_as(sys::state& state, dcon::nation_id source, dcon::nation
 	p.type = command_type::release_and_play_nation;
 	p.source = source;
 	p.data.tag_target.ident = t;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_release_and_play_as(sys::state& state, dcon::nation_id source, dcon::national_identity_id t) {
 	return nations::can_release_as_vassal(state, source, t);
@@ -835,7 +840,7 @@ void change_budget_settings(sys::state& state, dcon::nation_id source, budget_se
 	p.type = command_type::change_budget;
 	p.source = source;
 	p.data.budget_data = values;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 void execute_change_budget_settings(sys::state& state, dcon::nation_id source, budget_settings_data const& values) {
 	if(!can_change_budget_settings(state, source, values))
@@ -882,7 +887,7 @@ void start_election(sys::state& state, dcon::nation_id source) {
 	memset(&p, 0, sizeof(payload));
 	p.type = command_type::start_election;
 	p.source = source;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_start_election(sys::state& state, dcon::nation_id source) {
 	auto type = state.world.nation_get_government_type(source);
@@ -901,7 +906,7 @@ void change_influence_priority(sys::state& state, dcon::nation_id source, dcon::
 	p.source = source;
 	p.data.influence_priority.influence_target = influence_target;
 	p.data.influence_priority.priority = priority;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_change_influence_priority(sys::state& state, dcon::nation_id source, dcon::nation_id influence_target, uint8_t priority) {
 	// The source must be a great power, while the target must not be a great power.
@@ -940,7 +945,7 @@ void discredit_advisors(sys::state& state, dcon::nation_id source, dcon::nation_
 	p.source = source;
 	p.data.influence_action.influence_target = influence_target;
 	p.data.influence_action.gp_target = affected_gp;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_discredit_advisors(sys::state& state, dcon::nation_id source, dcon::nation_id influence_target, dcon::nation_id affected_gp) {
 	/*
@@ -1027,7 +1032,7 @@ void expel_advisors(sys::state& state, dcon::nation_id source, dcon::nation_id i
 	p.source = source;
 	p.data.influence_action.influence_target = influence_target;
 	p.data.influence_action.gp_target = affected_gp;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_expel_advisors(sys::state& state, dcon::nation_id source, dcon::nation_id influence_target, dcon::nation_id affected_gp) {
 	/*
@@ -1108,7 +1113,7 @@ void ban_embassy(sys::state& state, dcon::nation_id source, dcon::nation_id infl
 	p.source = source;
 	p.data.influence_action.influence_target = influence_target;
 	p.data.influence_action.gp_target = affected_gp;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_ban_embassy(sys::state& state, dcon::nation_id source, dcon::nation_id influence_target, dcon::nation_id affected_gp) {
 	/*
@@ -1190,7 +1195,7 @@ void increase_opinion(sys::state& state, dcon::nation_id source, dcon::nation_id
 	p.type = command_type::increase_opinion;
 	p.source = source;
 	p.data.influence_action.influence_target = influence_target;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_increase_opinion(sys::state& state, dcon::nation_id source, dcon::nation_id influence_target) {
 	/*
@@ -1251,7 +1256,7 @@ void decrease_opinion(sys::state& state, dcon::nation_id source, dcon::nation_id
 	p.source = source;
 	p.data.influence_action.influence_target = influence_target;
 	p.data.influence_action.gp_target = affected_gp;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_decrease_opinion(sys::state& state, dcon::nation_id source, dcon::nation_id influence_target, dcon::nation_id affected_gp) {
 	/*
@@ -1341,7 +1346,7 @@ void add_to_sphere(sys::state& state, dcon::nation_id source, dcon::nation_id in
 	p.type = command_type::add_to_sphere;
 	p.source = source;
 	p.data.influence_action.influence_target = influence_target;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_add_to_sphere(sys::state& state, dcon::nation_id source, dcon::nation_id influence_target) {
 	/*
@@ -1412,7 +1417,7 @@ void remove_from_sphere(sys::state& state, dcon::nation_id source, dcon::nation_
 	p.source = source;
 	p.data.influence_action.influence_target = influence_target;
 	p.data.influence_action.gp_target = affected_gp;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_remove_from_sphere(sys::state& state, dcon::nation_id source, dcon::nation_id influence_target, dcon::nation_id affected_gp) {
 	/*
@@ -1515,7 +1520,7 @@ void upgrade_colony_to_state(sys::state& state, dcon::nation_id source, dcon::st
 	p.type = command_type::upgrade_colony_to_state;
 	p.source = source;
 	p.data.generic_location.prov = state.world.state_instance_get_capital(si);
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_upgrade_colony_to_state(sys::state& state, dcon::nation_id source, dcon::state_instance_id si) {
 	return state.world.state_instance_get_nation_from_state_ownership(si) == source && province::can_integrate_colony(state, si);
@@ -1533,7 +1538,7 @@ void invest_in_colony(sys::state& state, dcon::nation_id source, dcon::province_
 	p.type = command_type::invest_in_colony;
 	p.source = source;
 	p.data.generic_location.prov = pr;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_invest_in_colony(sys::state& state, dcon::nation_id source, dcon::province_id p) {
 	auto state_def = state.world.province_get_state_from_abstract_state_membership(p);
@@ -1581,7 +1586,7 @@ void abandon_colony(sys::state& state, dcon::nation_id source, dcon::province_id
 	p.type = command_type::abandon_colony;
 	p.source = source;
 	p.data.generic_location.prov = pr;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 
 bool can_abandon_colony(sys::state& state, dcon::nation_id source, dcon::province_id pr) {
@@ -1605,7 +1610,7 @@ void finish_colonization(sys::state& state, dcon::nation_id source, dcon::provin
 	p.type = command_type::finish_colonization;
 	p.source = source;
 	p.data.generic_location.prov = pr;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_finish_colonization(sys::state& state, dcon::nation_id source, dcon::province_id p) {
 	auto state_def = state.world.province_get_state_from_abstract_state_membership(p);
@@ -1645,7 +1650,7 @@ void intervene_in_war(sys::state& state, dcon::nation_id source, dcon::war_id w,
 	p.source = source;
 	p.data.war_target.war = w;
 	p.data.war_target.for_attacker = for_attacker;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_intervene_in_war(sys::state& state, dcon::nation_id source, dcon::war_id w, bool for_attacker) {
 	/*
@@ -1765,7 +1770,7 @@ void suppress_movement(sys::state& state, dcon::nation_id source, dcon::movement
 	p.source = source;
 	p.data.movement.iopt = state.world.movement_get_associated_issue_option(m);
 	p.data.movement.tag = state.world.movement_get_associated_independence(m);
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_suppress_movement(sys::state& state, dcon::nation_id source, dcon::movement_id m) {
 	if(state.world.movement_get_nation_from_movement_within(m) != source)
@@ -1794,7 +1799,7 @@ void civilize_nation(sys::state& state, dcon::nation_id source) {
 	memset(&p, 0, sizeof(payload));
 	p.type = command_type::civilize_nation;
 	p.source = source;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_civilize_nation(sys::state& state, dcon::nation_id source) {
 	return state.world.nation_get_modifier_values(source, sys::national_mod_offsets::civilization_progress_modifier) >= 1.0f && !state.world.nation_get_is_civilized(source);
@@ -1811,7 +1816,7 @@ void appoint_ruling_party(sys::state& state, dcon::nation_id source, dcon::polit
 	p.type = command_type::appoint_ruling_party;
 	p.source = source;
 	p.data.political_party.p = pa;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_appoint_ruling_party(sys::state& state, dcon::nation_id source, dcon::political_party_id p) {
 	/*
@@ -1854,7 +1859,7 @@ void enact_reform(sys::state& state, dcon::nation_id source, dcon::reform_option
 	p.type = command_type::change_reform_option;
 	p.source = source;
 	p.data.reform_selection.r = r;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_enact_reform(sys::state& state, dcon::nation_id source, dcon::reform_option_id r) {
 	bool is_military = state.world.reform_get_reform_type(state.world.reform_option_get_parent_reform(r)) ==
@@ -1877,7 +1882,7 @@ void enact_issue(sys::state& state, dcon::nation_id source, dcon::issue_option_i
 	p.type = command_type::change_issue_option;
 	p.source = source;
 	p.data.issue_selection.r = i;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_enact_issue(sys::state& state, dcon::nation_id source, dcon::issue_option_id i) {
 	auto type = state.world.issue_get_issue_type(state.world.issue_option_get_parent_issue(i));
@@ -1899,7 +1904,7 @@ void become_interested_in_crisis(sys::state& state, dcon::nation_id source) {
 	memset(&p, 0, sizeof(payload));
 	p.type = command_type::become_interested_in_crisis;
 	p.source = source;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_become_interested_in_crisis(sys::state& state, dcon::nation_id source) {
 	/*
@@ -1945,7 +1950,7 @@ void take_sides_in_crisis(sys::state& state, dcon::nation_id source, bool join_a
 	p.type = command_type::take_sides_in_crisis;
 	p.source = source;
 	p.data.crisis_join.join_attackers = join_attacker;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_take_sides_in_crisis(sys::state& state, dcon::nation_id source, bool join_attacker) {
 	/*
@@ -2003,7 +2008,7 @@ void change_stockpile_settings(sys::state& state, dcon::nation_id source, dcon::
 	p.data.stockpile_settings.amount = target_amount;
 	p.data.stockpile_settings.c = c;
 	p.data.stockpile_settings.draw_on_stockpiles = draw_on_stockpiles;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 
 void execute_change_stockpile_settings(sys::state& state, dcon::nation_id source, dcon::commodity_id c, float target_amount,
@@ -2018,7 +2023,7 @@ void take_decision(sys::state& state, dcon::nation_id source, dcon::decision_id 
 	p.type = command_type::take_decision;
 	p.source = source;
 	p.data.decision.d = d;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_take_decision(sys::state& state, dcon::nation_id source, dcon::decision_id d) {
 	{
@@ -2070,7 +2075,7 @@ void make_event_choice(sys::state& state, event::pending_human_n_event const& e,
 	p.data.pending_human_n_event.pt = e.pt;
 	p.data.pending_human_n_event.r_hi = e.r_hi;
 	p.data.pending_human_n_event.r_lo = e.r_lo;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 void make_event_choice(sys::state& state, event::pending_human_f_n_event const& e, uint8_t option_id) {
 	payload p;
@@ -2082,7 +2087,7 @@ void make_event_choice(sys::state& state, event::pending_human_f_n_event const& 
 	p.data.pending_human_f_n_event.opt_choice = option_id;
 	p.data.pending_human_f_n_event.r_hi = e.r_hi;
 	p.data.pending_human_f_n_event.r_lo = e.r_lo;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 void make_event_choice(sys::state& state, event::pending_human_p_event const& e, uint8_t option_id) {
 	payload p;
@@ -2097,7 +2102,7 @@ void make_event_choice(sys::state& state, event::pending_human_p_event const& e,
 	p.data.pending_human_p_event.opt_choice = option_id;
 	p.data.pending_human_p_event.r_hi = e.r_hi;
 	p.data.pending_human_p_event.r_lo = e.r_lo;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 void make_event_choice(sys::state& state, event::pending_human_f_p_event const& e, uint8_t option_id) {
 	payload p;
@@ -2110,7 +2115,7 @@ void make_event_choice(sys::state& state, event::pending_human_f_p_event const& 
 	p.data.pending_human_f_p_event.opt_choice = option_id;
 	p.data.pending_human_f_p_event.r_hi = e.r_hi;
 	p.data.pending_human_f_p_event.r_lo = e.r_lo;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 void execute_make_event_choice(sys::state& state, dcon::nation_id source, pending_human_n_event_data const& e) {
 	event::take_option(state,
@@ -2139,7 +2144,7 @@ void fabricate_cb(sys::state& state, dcon::nation_id source, dcon::nation_id tar
 	p.source = source;
 	p.data.cb_fabrication.target = target;
 	p.data.cb_fabrication.type = type;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_fabricate_cb(sys::state& state, dcon::nation_id source, dcon::nation_id target, dcon::cb_type_id type) {
 	if(source == target)
@@ -2198,7 +2203,7 @@ void cancel_cb_fabrication(sys::state& state, dcon::nation_id source) {
 	memset(&p, 0, sizeof(payload));
 	p.type = command_type::cancel_cb_fabrication;
 	p.source = source;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 void execute_cancel_cb_fabrication(sys::state& state, dcon::nation_id source) {
 	state.world.nation_set_constructing_cb_target(source, dcon::nation_id{});
@@ -2213,7 +2218,7 @@ void ask_for_military_access(sys::state& state, dcon::nation_id asker, dcon::nat
 	p.type = command_type::ask_for_military_access;
 	p.source = asker;
 	p.data.diplo_action.target = target;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_ask_for_access(sys::state& state, dcon::nation_id asker, dcon::nation_id target, bool ignore_cost) {
 	/*
@@ -2256,7 +2261,7 @@ void give_military_access(sys::state& state, dcon::nation_id asker, dcon::nation
 	p.type = command_type::give_military_access;
 	p.source = asker;
 	p.data.diplo_action.target = target;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_give_military_access(sys::state& state, dcon::nation_id asker, dcon::nation_id target) {
 	if(asker == target)
@@ -2293,7 +2298,7 @@ void ask_for_alliance(sys::state& state, dcon::nation_id asker, dcon::nation_id 
 	p.type = command_type::ask_for_alliance;
 	p.source = asker;
 	p.data.diplo_action.target = target;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_ask_for_alliance(sys::state& state, dcon::nation_id asker, dcon::nation_id target, bool ignore_cost) {
 	/*
@@ -2347,7 +2352,7 @@ void call_to_arms(sys::state& state, dcon::nation_id asker, dcon::nation_id targ
 	p.source = asker;
 	p.data.call_to_arms.target = target;
 	p.data.call_to_arms.war = w;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_call_to_arms(sys::state& state, dcon::nation_id asker, dcon::nation_id target, dcon::war_id w, bool ignore_cost) {
 	if(asker == target)
@@ -2395,7 +2400,7 @@ void respond_to_diplomatic_message(sys::state& state, dcon::nation_id source, dc
 	p.data.message.accept = accept;
 	p.data.message.from = from;
 	p.data.message.type = type;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 void execute_respond_to_diplomatic_message(sys::state& state, dcon::nation_id source, dcon::nation_id from,
 		diplomatic_message::type type, bool accept) {
@@ -2420,7 +2425,7 @@ void cancel_military_access(sys::state& state, dcon::nation_id source, dcon::nat
 	p.type = command_type::cancel_military_access;
 	p.source = source;
 	p.data.diplo_action.target = target;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_cancel_military_access(sys::state& state, dcon::nation_id source, dcon::nation_id target) {
 	if(source == target)
@@ -2469,7 +2474,7 @@ void cancel_given_military_access(sys::state& state, dcon::nation_id source, dco
 	p.type = command_type::cancel_given_military_access;
 	p.source = source;
 	p.data.diplo_action.target = target;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_cancel_given_military_access(sys::state& state, dcon::nation_id source, dcon::nation_id target) {
 	auto rel = state.world.get_unilateral_relationship_by_unilateral_pair(source, target);
@@ -2518,7 +2523,7 @@ void cancel_alliance(sys::state& state, dcon::nation_id source, dcon::nation_id 
 	p.type = command_type::cancel_alliance;
 	p.source = source;
 	p.data.diplo_action.target = target;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_cancel_alliance(sys::state& state, dcon::nation_id source, dcon::nation_id target) {
 	if(source == target)
@@ -2563,7 +2568,7 @@ void declare_war(sys::state& state, dcon::nation_id source, dcon::nation_id targ
 	p.data.new_war.cb_tag = cb_tag;
 	p.data.new_war.cb_secondary_nation = cb_secondary_nation;
 	p.data.new_war.call_attacker_allies = call_attacker_allies;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 
 bool can_declare_war(sys::state& state, dcon::nation_id source, dcon::nation_id target, dcon::cb_type_id primary_cb,
@@ -2661,7 +2666,7 @@ void add_war_goal(sys::state& state, dcon::nation_id source, dcon::war_id w, dco
 	p.data.new_war_goal.cb_tag = cb_tag;
 	p.data.new_war_goal.cb_secondary_nation = cb_secondary_nation;
 	p.data.new_war_goal.war = w;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_add_war_goal(sys::state& state, dcon::nation_id source, dcon::war_id w, dcon::nation_id target, dcon::cb_type_id cb_type,
 		dcon::state_definition_id cb_state, dcon::national_identity_id cb_tag, dcon::nation_id cb_secondary_nation) {
@@ -2750,7 +2755,7 @@ void switch_nation(sys::state& state, dcon::nation_id source, dcon::national_ide
 	p.type = command_type::switch_nation;
 	p.source = source;
 	p.data.tag_target.ident = t;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_switch_nation(sys::state& state, dcon::nation_id source, dcon::national_identity_id t) {
 	dcon::nation_id n = state.world.national_identity_get_nation_from_identity_holder(t);
@@ -2778,7 +2783,7 @@ void start_peace_offer(sys::state& state, dcon::nation_id source, dcon::nation_i
 	p.data.new_offer.target = target;
 	p.data.new_offer.war = war;
 	p.data.new_offer.is_concession = is_concession;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_start_peace_offer(sys::state& state, dcon::nation_id source, dcon::nation_id target, dcon::war_id war,
 		bool is_concession) {
@@ -2837,7 +2842,7 @@ void start_crisis_peace_offer(sys::state& state, dcon::nation_id source, bool is
 	p.type = command_type::start_crisis_peace_offer;
 	p.source = source;
 	p.data.new_offer.is_concession = is_concession;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_start_crisis_peace_offer(sys::state& state, dcon::nation_id source, bool is_concession) {
 	if(source != state.primary_crisis_attacker && source != state.primary_crisis_defender)
@@ -2900,7 +2905,7 @@ void add_to_peace_offer(sys::state& state, dcon::nation_id source, dcon::wargoal
 	p.type = command_type::add_peace_offer_term;
 	p.source = source;
 	p.data.offer_wargoal.wg = goal;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_add_to_peace_offer(sys::state& state, dcon::nation_id source, dcon::wargoal_id goal) {
 	auto pending = state.world.nation_get_peace_offer_from_pending_peace_offer(source);
@@ -2981,7 +2986,7 @@ void add_to_crisis_peace_offer(sys::state& state, dcon::nation_id source, dcon::
 	p.data.crisis_invitation.cb_state = cb_state;
 	p.data.crisis_invitation.cb_tag = cb_tag;
 	p.data.crisis_invitation.cb_secondary_nation = cb_secondary_nation;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_add_to_crisis_peace_offer(sys::state& state, dcon::nation_id source, dcon::nation_id wargoal_from,
 		dcon::nation_id target, dcon::cb_type_id primary_cb, dcon::state_definition_id cb_state, dcon::national_identity_id cb_tag,
@@ -3045,7 +3050,7 @@ void send_peace_offer(sys::state& state, dcon::nation_id source) {
 	memset(&p, 0, sizeof(payload));
 	p.type = command_type::send_peace_offer;
 	p.source = source;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_send_peace_offer(sys::state& state, dcon::nation_id source) {
 	auto pending = state.world.nation_get_peace_offer_from_pending_peace_offer(source);
@@ -3084,7 +3089,7 @@ void send_crisis_peace_offer(sys::state& state, dcon::nation_id source) {
 	memset(&p, 0, sizeof(payload));
 	p.type = command_type::send_crisis_peace_offer;
 	p.source = source;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_send_crisis_peace_offer(sys::state& state, dcon::nation_id source) {
 	auto pending = state.world.nation_get_peace_offer_from_pending_peace_offer(source);
@@ -3128,7 +3133,7 @@ void c_change_diplo_points(sys::state& state, dcon::nation_id source, float valu
 	p.type = command_type::c_change_diplo_points;
 	p.source = source;
 	p.data.cheat.value = value;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 void execute_c_change_diplo_points(sys::state& state, dcon::nation_id source, float value) {
 	state.world.nation_get_diplomatic_points(source) += value;
@@ -3139,7 +3144,7 @@ void c_change_money(sys::state& state, dcon::nation_id source, float value) {
 	p.type = command_type::c_change_money;
 	p.source = source;
 	p.data.cheat.value = value;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 void execute_c_change_money(sys::state& state, dcon::nation_id source, float value) {
 	// state.world.nation_get_diplomatic_points(source) += value;
@@ -3149,7 +3154,7 @@ void c_westernize(sys::state& state, dcon::nation_id source) {
 	memset(&p, 0, sizeof(payload));
 	p.type = command_type::c_westernize;
 	p.source = source;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 void execute_c_westernize(sys::state& state, dcon::nation_id source) {
 	state.world.nation_set_is_civilized(source, true);
@@ -3159,7 +3164,7 @@ void c_unwesternize(sys::state& state, dcon::nation_id source) {
 	memset(&p, 0, sizeof(payload));
 	p.type = command_type::c_unwesternize;
 	p.source = source;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 void execute_c_unwesternize(sys::state& state, dcon::nation_id source) {
 	state.world.nation_set_is_civilized(source, false);
@@ -3170,7 +3175,7 @@ void c_change_research_points(sys::state& state, dcon::nation_id source, float v
 	p.type = command_type::c_change_research_points;
 	p.source = source;
 	p.data.cheat.value = value;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 void execute_c_change_research_points(sys::state& state, dcon::nation_id source, float value) {
 	state.world.nation_get_research_points(source) += value;
@@ -3181,7 +3186,7 @@ void c_change_cb_progress(sys::state& state, dcon::nation_id source, float value
 	p.type = command_type::c_change_cb_progress;
 	p.source = source;
 	p.data.cheat.value = value;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 void execute_c_change_cb_progress(sys::state& state, dcon::nation_id source, float value) {
 	state.world.nation_get_constructing_cb_progress(source) += value;
@@ -3192,7 +3197,7 @@ void c_change_infamy(sys::state& state, dcon::nation_id source, float value) {
 	p.type = command_type::c_change_infamy;
 	p.source = source;
 	p.data.cheat.value = value;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 void execute_c_change_infamy(sys::state& state, dcon::nation_id source, float value) {
 	state.world.nation_get_infamy(source) += value;
@@ -3202,7 +3207,7 @@ void c_force_crisis(sys::state& state, dcon::nation_id source) {
 	memset(&p, 0, sizeof(payload));
 	p.type = command_type::c_force_crisis;
 	p.source = source;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 void execute_c_force_crisis(sys::state& state, dcon::nation_id source) {
 	if(state.current_crisis == sys::crisis_type::none) {
@@ -3237,7 +3242,7 @@ void c_change_national_militancy(sys::state& state, dcon::nation_id source, floa
 	p.type = command_type::c_change_national_militancy;
 	p.source = source;
 	p.data.cheat.value = value;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 void execute_c_change_national_militancy(sys::state& state, dcon::nation_id source, float value) {
 	for(auto pr : state.world.nation_get_province_ownership(source))
@@ -3252,7 +3257,7 @@ void move_army(sys::state& state, dcon::nation_id source, dcon::army_id a, dcon:
 	p.source = source;
 	p.data.army_movement.a = a;
 	p.data.army_movement.dest = dest;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 
 std::vector<dcon::province_id> can_move_army(sys::state& state, dcon::nation_id source, dcon::army_id a, dcon::province_id dest) {
@@ -3336,7 +3341,7 @@ void move_navy(sys::state& state, dcon::nation_id source, dcon::navy_id n, dcon:
 	p.source = source;
 	p.data.navy_movement.n = n;
 	p.data.navy_movement.dest = dest;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 std::vector<dcon::province_id> can_move_navy(sys::state& state, dcon::nation_id source, dcon::navy_id n, dcon::province_id dest) {
 	if(source != state.world.navy_get_controller_from_navy_control(n))
@@ -3409,7 +3414,7 @@ void embark_army(sys::state& state, dcon::nation_id source, dcon::army_id a) {
 	p.type = command_type::embark_army;
 	p.source = source;
 	p.data.army_movement.a = a;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 
 bool can_embark_army(sys::state& state, dcon::nation_id source, dcon::army_id a) {
@@ -3465,7 +3470,7 @@ void merge_armies(sys::state& state, dcon::nation_id source, dcon::army_id a, dc
 	p.source = source;
 	p.data.merge_army.a = a;
 	p.data.merge_army.b = b;
-	auto x = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_merge_armies(sys::state& state, dcon::nation_id source, dcon::army_id a, dcon::army_id b) {
 	if(state.world.army_get_controller_from_army_control(a) != source)
@@ -3519,7 +3524,7 @@ void merge_navies(sys::state& state, dcon::nation_id source, dcon::navy_id a, dc
 	p.source = source;
 	p.data.merge_navy.a = a;
 	p.data.merge_navy.b = b;
-	auto x = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_merge_navies(sys::state& state, dcon::nation_id source, dcon::navy_id a, dcon::navy_id b) {
 	if(state.world.navy_get_controller_from_navy_control(a) != source)
@@ -3577,7 +3582,7 @@ void split_army(sys::state& state, dcon::nation_id source, dcon::army_id a) {
 	p.type = command_type::split_army;
 	p.source = source;
 	p.data.army_movement.a = a;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_split_army(sys::state& state, dcon::nation_id source, dcon::army_id a) {
 	return state.world.army_get_controller_from_army_control(a) == source && !state.world.army_get_is_retreating(a) &&
@@ -3628,7 +3633,7 @@ void split_navy(sys::state& state, dcon::nation_id source, dcon::navy_id a) {
 	p.type = command_type::split_navy;
 	p.source = source;
 	p.data.navy_movement.n = a;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_split_navy(sys::state& state, dcon::nation_id source, dcon::navy_id a) {
 	auto embarked = state.world.navy_get_army_transport(a);
@@ -3678,7 +3683,7 @@ void delete_army(sys::state& state, dcon::nation_id source, dcon::army_id a) {
 	p.type = command_type::delete_army;
 	p.source = source;
 	p.data.army_movement.a = a;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_delete_army(sys::state& state, dcon::nation_id source, dcon::army_id a) {
 	return state.world.army_get_controller_from_army_control(a) == source && !state.world.army_get_is_retreating(a) &&
@@ -3701,7 +3706,7 @@ void delete_navy(sys::state& state, dcon::nation_id source, dcon::navy_id a) {
 	p.type = command_type::delete_navy;
 	p.source = source;
 	p.data.navy_movement.n = a;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 
 bool can_delete_navy(sys::state& state, dcon::nation_id source, dcon::navy_id a) {
@@ -3727,7 +3732,7 @@ void change_general(sys::state& state, dcon::nation_id source, dcon::army_id a, 
 	p.source = source;
 	p.data.new_general.a = a;
 	p.data.new_general.l = l;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_change_general(sys::state& state, dcon::nation_id source, dcon::army_id a, dcon::leader_id l) {
 	return state.world.army_get_controller_from_army_control(a) == source && !state.world.army_get_is_retreating(a) &&
@@ -3749,7 +3754,7 @@ void change_admiral(sys::state& state, dcon::nation_id source, dcon::navy_id a, 
 	p.source = source;
 	p.data.new_admiral.a = a;
 	p.data.new_admiral.l = l;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_change_admiral(sys::state& state, dcon::nation_id source, dcon::navy_id a, dcon::leader_id l) {
 	return state.world.navy_get_controller_from_navy_control(a) == source && !state.world.navy_get_is_retreating(a) &&
@@ -3772,7 +3777,7 @@ void mark_regiments_to_split(sys::state& state, dcon::nation_id source,
 	p.type = command_type::designate_split_regiments;
 	p.source = source;
 	std::copy_n(list.data(), num_packed_units, p.data.split_regiments.regs);
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 void execute_mark_regiments_to_split(sys::state& state, dcon::nation_id source, dcon::regiment_id const* regs) {
 	for(uint32_t i = 0; i < num_packed_units; ++i) {
@@ -3791,7 +3796,8 @@ void mark_ships_to_split(sys::state& state, dcon::nation_id source, std::array<d
 	p.type = command_type::designate_split_ships;
 	p.source = source;
 	std::copy_n(list.data(), num_packed_units, p.data.split_ships.ships);
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
+
 }
 void execute_mark_ships_to_split(sys::state& state, dcon::nation_id source, dcon::ship_id const* regs) {
 	for(uint32_t i = 0; i < num_packed_units; ++i) {
@@ -3809,7 +3815,7 @@ void retreat_from_naval_battle(sys::state& state, dcon::nation_id source, dcon::
 	p.type = command_type::naval_retreat;
 	p.source = source;
 	p.data.naval_battle.b = b;
-	auto discard = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_retreat_from_naval_battle(sys::state& state, dcon::nation_id source, dcon::naval_battle_id b) {
 	if(!military::can_retreat_from_battle(state, b))
@@ -3836,7 +3842,7 @@ void retreat_from_land_battle(sys::state& state, dcon::nation_id source, dcon::l
 	p.type = command_type::land_retreat;
 	p.source = source;
 	p.data.land_battle.b = b;
-	auto discard = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 
 bool can_retreat_from_land_battle(sys::state& state, dcon::nation_id source, dcon::land_battle_id b) {
@@ -3871,7 +3877,7 @@ void invite_to_crisis(sys::state& state, dcon::nation_id source, dcon::nation_id
 	p.data.crisis_invitation.cb_state = cb_state;
 	p.data.crisis_invitation.cb_tag = cb_tag;
 	p.data.crisis_invitation.cb_secondary_nation = cb_secondary_nation;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 bool can_invite_to_crisis(sys::state& state, dcon::nation_id source, dcon::nation_id invitation_to, dcon::nation_id target,
 		dcon::cb_type_id primary_cb, dcon::state_definition_id cb_state, dcon::national_identity_id cb_tag,
@@ -3953,7 +3959,7 @@ void toggle_mobilization(sys::state& state, dcon::nation_id source) {
 	memset(&p, 0, sizeof(payload));
 	p.type = command_type::toggle_mobilization;
 	p.source = source;
-	auto b = state.incoming_commands.try_push(p);
+	add_to_command_queue(state, p);
 }
 
 void execute_toggle_mobilization(sys::state& state, dcon::nation_id source) {
@@ -3961,6 +3967,34 @@ void execute_toggle_mobilization(sys::state& state, dcon::nation_id source) {
 		military::end_mobilization(state, source);
 	} else {
 		military::start_mobilization(state, source);
+	}
+}
+
+void chat_message(sys::state& state, dcon::nation_id source, std::string_view body) {
+	payload p;
+	memset(&p, 0, sizeof(payload));
+	p.type = command_type::chat_message;
+	p.source = source;
+	memcpy(p.data.chat_message.body, std::string(body).c_str(), ui::max_chat_message_len);
+	p.data.chat_message.body[ui::max_chat_message_len - 1] = '\0';
+	add_to_command_queue(state, p);
+}
+bool can_chat_message(sys::state& state, dcon::nation_id source, std::string_view body) {
+	// TODO: bans, kicks, mutes?
+	return true;
+}
+void execute_chat_message(sys::state& state, dcon::nation_id source, std::string_view body) {
+	if(!can_chat_message(state, source, body))
+		return;
+	
+	ui::chat_message m;
+	m.source = source;
+	memcpy(m.body, std::string(body).c_str(), ui::max_chat_message_len);
+	m.body[ui::max_chat_message_len - 1] = '\0';
+
+	state.ui_state.chat_messages.push_back(m);
+	if(state.ui_state.chat_messages.size() >= 30) {
+		state.ui_state.chat_messages.pop_front();
 	}
 }
 
@@ -4225,6 +4259,11 @@ void execute_pending_commands(sys::state& state) {
 			break;
 		case command_type::give_military_access:
 			execute_give_military_access(state, c->source, c->data.diplo_action.target);
+			break;
+
+		// common mp commands
+		case command_type::chat_message:
+			execute_chat_message(state, c->source, c->data.chat_message.body);
 			break;
 
 		// console commands

--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -3992,9 +3992,9 @@ void execute_chat_message(sys::state& state, dcon::nation_id source, std::string
 	memcpy(m.body, std::string(body).c_str(), ui::max_chat_message_len);
 	m.body[ui::max_chat_message_len - 1] = '\0';
 
-	state.ui_state.chat_messages[chat_messages_index++] = m;
-	if(chat_messages_index >= chat_messages.size())
-		chat_messages_index = 0;
+	state.ui_state.chat_messages[state.ui_state.chat_messages_index++] = m;
+	if(state.ui_state.chat_messages_index >= state.ui_state.chat_messages.size())
+		state.ui_state.chat_messages_index = 0;
 }
 
 void execute_pending_commands(sys::state& state) {

--- a/src/gamestate/commands.hpp
+++ b/src/gamestate/commands.hpp
@@ -88,6 +88,9 @@ enum class command_type : uint8_t {
 	change_general = 79,
 	toggle_mobilization = 80,
 	give_military_access = 81,
+	
+	advance_tick = 122,
+	chat_message = 123,
 
 	// console cheats
 	switch_nation = 128,
@@ -356,6 +359,10 @@ struct cheat_data {
 	float value;
 };
 
+struct chat_message_data {
+	char body[ui::max_chat_message_len];
+};
+
 struct payload {
 	union dtype {
 		national_focus_data nat_focus;
@@ -403,6 +410,7 @@ struct payload {
 		crisis_invitation_data crisis_invitation;
 		new_general_data new_general;
 		new_admiral_data new_admiral;
+		chat_message_data chat_message;
 
 		dtype() { }
 	} data;
@@ -677,6 +685,9 @@ bool can_add_to_crisis_peace_offer(sys::state& state, dcon::nation_id source, dc
 void send_crisis_peace_offer(sys::state& state, dcon::nation_id source);
 bool can_send_crisis_peace_offer(sys::state& state, dcon::nation_id source);
 
+void chat_message(sys::state& state, dcon::nation_id source, std::string_view body);
+bool can_chat_message(sys::state& state, dcon::nation_id source, std::string_view body);
+
 void switch_nation(sys::state& state, dcon::nation_id source, dcon::national_identity_id t);
 bool can_switch_nation(sys::state& state, dcon::nation_id source, dcon::national_identity_id t);
 void execute_switch_nation(sys::state& state, dcon::nation_id source, dcon::national_identity_id t);
@@ -689,6 +700,7 @@ void c_change_cb_progress(sys::state& state, dcon::nation_id source, float value
 void c_change_infamy(sys::state& state, dcon::nation_id source, float value);
 void c_force_crisis(sys::state& state, dcon::nation_id source);
 void c_change_national_militancy(sys::state& state, dcon::nation_id source, float value);
+
 void execute_pending_commands(sys::state& state);
 
 } // namespace command

--- a/src/gamestate/commands.hpp
+++ b/src/gamestate/commands.hpp
@@ -414,6 +414,7 @@ struct payload {
 
 		dtype() { }
 	} data;
+	static_assert(sizeof(dtype) == 40);
 	dcon::nation_id source;
 	command_type type = command_type::invalid;
 

--- a/src/gamestate/commands.hpp
+++ b/src/gamestate/commands.hpp
@@ -361,6 +361,7 @@ struct cheat_data {
 
 struct chat_message_data {
 	char body[ui::max_chat_message_len];
+	dcon::nation_id target;
 };
 
 struct payload {
@@ -414,7 +415,6 @@ struct payload {
 
 		dtype() { }
 	} data;
-	static_assert(sizeof(dtype) == 40);
 	dcon::nation_id source;
 	command_type type = command_type::invalid;
 
@@ -686,8 +686,8 @@ bool can_add_to_crisis_peace_offer(sys::state& state, dcon::nation_id source, dc
 void send_crisis_peace_offer(sys::state& state, dcon::nation_id source);
 bool can_send_crisis_peace_offer(sys::state& state, dcon::nation_id source);
 
-void chat_message(sys::state& state, dcon::nation_id source, std::string_view body);
-bool can_chat_message(sys::state& state, dcon::nation_id source, std::string_view body);
+void chat_message(sys::state& state, dcon::nation_id source, std::string_view body, dcon::nation_id target);
+bool can_chat_message(sys::state& state, dcon::nation_id source, std::string_view body, dcon::nation_id target);
 
 void switch_nation(sys::state& state, dcon::nation_id source, dcon::national_identity_id t);
 bool can_switch_nation(sys::state& state, dcon::nation_id source, dcon::national_identity_id t);

--- a/src/gamestate/system_state.cpp
+++ b/src/gamestate/system_state.cpp
@@ -20,6 +20,7 @@
 #include "gui_message_window.hpp"
 #include "gui_naval_combat.hpp"
 #include "gui_land_combat.hpp"
+#include "gui_chat_window.hpp"
 #include "map_tooltip.hpp"
 #include "unit_tooltip.hpp"
 #include "main_menu/gui_country_selection_window.hpp"

--- a/src/gamestate/system_state.cpp
+++ b/src/gamestate/system_state.cpp
@@ -224,6 +224,9 @@ void state::on_key_down(virtual_key keycode, key_modifiers mod) {
 					ui::show_main_menu(*this);
 			} else if(keycode == virtual_key::TILDA || keycode == virtual_key::BACK_SLASH) {
 				ui::console_window::show_toggle(*this);
+			} else if(keycode == virtual_key::TAB) {
+				ui_state.chat_window->set_visible(*this, !ui_state.chat_window->is_visible());
+				ui_state.root->move_child_to_front(ui_state.chat_window);
 			}
 			map_state.on_key_down(keycode, mod);
 
@@ -786,6 +789,13 @@ void state::on_create() {
 	}
 	{
 		auto new_elm = ui::make_element_by_type<ui::province_view_window>(*this, "province_view");
+		ui_state.root->add_child_to_front(std::move(new_elm));
+	}
+	{
+		auto new_elm = ui::make_element_by_type<ui::chat_window>(*this, "ingame_lobby_window");
+		// TODO: don't hide when on an actual multiplayer session
+		new_elm->set_visible(*this, false); // hidden by default
+		ui_state.chat_window = new_elm.get();
 		ui_state.root->add_child_to_front(std::move(new_elm));
 	}
 	{

--- a/src/gui/gui_chat_window.hpp
+++ b/src/gui/gui_chat_window.hpp
@@ -4,11 +4,40 @@
 
 namespace ui {
 
+class chat_message_text : public multiline_text_element_base {
+public:
+	void on_update(sys::state& state) noexcept override {
+		auto border = base_data.data.text.border_size;
+		auto content = retrieve<chat_message>(state, parent);
+		auto color = black_text ? text::text_color::black : text::text_color::white;
+		if(!black_text) {
+			// Highlight private messages
+			if(content.target) {
+				color = text::text_color::orange;
+			}
+		}
+		auto container = text::create_endless_layout(
+			internal_layout,
+			text::layout_parameters{
+				border.x,
+				border.y,
+				int16_t(base_data.size.x - border.x * 2),
+				int16_t(base_data.size.y - border.y * 2),
+				base_data.data.text.font_handle,
+				0,
+				text::alignment::left,
+				color,
+				false});
+		
+		std::string text_form_msg = std::string(content.body);
+		auto box = text::open_layout_box(container);
+		text::add_to_layout_box(state, container, box, text_form_msg);
+		text::close_layout_box(container, box);
+	}
+};
+
 class chat_message_entry : public listbox_row_element_base<chat_message> {
 	flag_button* country_flag = nullptr;
-	simple_text_element_base* text_shadow = nullptr;
-	simple_text_element_base* text = nullptr;
-	std::string text_form_msg;
 public:
 	std::unique_ptr<element_base> make_child(sys::state& state, std::string_view name, dcon::gui_def_id id) noexcept override {
 		if(name == "shield") {
@@ -16,13 +45,9 @@ public:
 			country_flag = ptr.get();
 			return ptr;
 		} else if(name == "text_shadow") {
-			auto ptr = make_element_by_type<simple_text_element_base>(state, id);
-			text_shadow = ptr.get();
-			return ptr;
+			return make_element_by_type<chat_message_text>(state, id);
 		} else if(name == "text") {
-			auto ptr = make_element_by_type<simple_text_element_base>(state, id);
-			text = ptr.get();
-			return ptr;
+			return make_element_by_type<chat_message_text>(state, id);
 		} else {
 			return nullptr;
 		}
@@ -32,15 +57,15 @@ public:
 		if(payload.holds_type<dcon::nation_id>()) {
 			payload.emplace<dcon::nation_id>(content.source);
 			return message_result::consumed;
+		} else if(payload.holds_type<chat_message>()) {
+			payload.emplace<chat_message>(content);
+			return message_result::consumed;
 		}
 		return listbox_row_element_base::get(state, payload);
 	}
 
 	void update(sys::state& state) noexcept override {
 		country_flag->on_update(state);
-		text_form_msg = std::string(content.body);
-		text_shadow->set_text(state, text_form_msg);
-		text->set_text(state, text_form_msg);
 	}
 };
 
@@ -92,11 +117,21 @@ public:
 class chat_edit_box : public edit_box_element_base {
 public:
 	void edit_box_enter(sys::state& state, std::string_view s) noexcept override {
+		dcon::nation_id target{};
+		if(s.length() > 4 && s[0] == '@') {
+			state.world.for_each_national_identity([&](dcon::national_identity_id id) {
+				auto curr = nations::int_to_tag(state.world.national_identity_get_identifying_int(id));
+				if(curr == s.substr(1, 3))
+					target = state.world.national_identity_get_nation_from_identity_holder(id);
+			});
+		}
+		
 		char body[max_chat_message_len];
 		size_t len = s.length() >= max_chat_message_len ? max_chat_message_len : s.length();
 		memcpy(body, s.data(), len);
 		body[len] = '\0';
-		command::chat_message(state, state.local_player_nation, body);
+
+		command::chat_message(state, state.local_player_nation, body, target);
 	}
 };
 

--- a/src/gui/gui_chat_window.hpp
+++ b/src/gui/gui_chat_window.hpp
@@ -1,0 +1,130 @@
+#pragma once
+
+#include "gui_element_types.hpp"
+
+namespace ui {
+
+class chat_message_entry : public listbox_row_element_base<chat_message> {
+	flag_button* country_flag = nullptr;
+	simple_text_element_base* text_shadow = nullptr;
+	simple_text_element_base* text = nullptr;
+	std::string text_form_msg;
+public:
+	std::unique_ptr<element_base> make_child(sys::state& state, std::string_view name, dcon::gui_def_id id) noexcept override {
+		if(name == "shield") {
+			auto ptr = make_element_by_type<flag_button>(state, id);
+			country_flag = ptr.get();
+			return ptr;
+		} else if(name == "text_shadow") {
+			auto ptr = make_element_by_type<simple_text_element_base>(state, id);
+			text_shadow = ptr.get();
+			return ptr;
+		} else if(name == "text") {
+			auto ptr = make_element_by_type<simple_text_element_base>(state, id);
+			text = ptr.get();
+			return ptr;
+		} else {
+			return nullptr;
+		}
+	}
+
+	message_result get(sys::state& state, Cyto::Any& payload) noexcept override {
+		if(payload.holds_type<dcon::nation_id>()) {
+			payload.emplace<dcon::nation_id>(content.source);
+			return message_result::consumed;
+		}
+		return listbox_row_element_base::get(state, payload);
+	}
+
+	void update(sys::state& state) noexcept override {
+		country_flag->on_update(state);
+		text_form_msg = std::string(content.body);
+		text_shadow->set_text(state, text_form_msg);
+		text->set_text(state, text_form_msg);
+	}
+};
+
+class chat_message_listbox : public listbox_element_base<chat_message_entry, chat_message> {
+protected:
+	std::string_view get_row_element_name() override {
+		return "chat_entry";
+	}
+public:
+	void on_update(sys::state& state) noexcept override {
+		row_contents.clear();
+		for(auto const& c : state.ui_state.chat_messages)
+			row_contents.push_back(c);
+		update(state);
+	}
+};
+
+class chat_player_entry : public listbox_row_element_base<dcon::nation_id> {
+public:
+	std::unique_ptr<element_base> make_child(sys::state& state, std::string_view name, dcon::gui_def_id id) noexcept override {
+		if(name == "player_shield") {
+			return make_element_by_type<flag_button>(state, id);
+		} else if(name == "name") {
+			return make_element_by_type<generic_name_text<dcon::nation_id>>(state, id);
+		} else if(name == "button_kick") {
+			return make_element_by_type<button_element_base>(state, id);
+		} else {
+			return nullptr;
+		}
+	}
+};
+
+class chat_player_listbox : public listbox_element_base<chat_player_entry, dcon::nation_id> {
+protected:
+	std::string_view get_row_element_name() override {
+		return "ingame_multiplayer_entry";
+	}
+public:
+	void on_update(sys::state& state) noexcept override {
+		row_contents.clear();
+		state.world.for_each_nation([&](dcon::nation_id n) {
+			if(state.world.nation_get_is_player_controlled(n))
+				row_contents.push_back(n);
+		});
+		update(state);
+	}
+};
+
+class chat_edit_box : public edit_box_element_base {
+public:
+	void edit_box_enter(sys::state& state, std::string_view s) noexcept override {
+		char body[max_chat_message_len];
+		size_t len = s.length() >= max_chat_message_len ? max_chat_message_len : s.length();
+		memcpy(body, s.data(), len);
+		body[len] = '\0';
+		command::chat_message(state, state.local_player_nation, body);
+	}
+};
+
+class chat_window : public window_element_base {
+public:
+	void on_create(sys::state& state) noexcept override {
+		window_element_base::on_create(state);
+	}
+
+	std::unique_ptr<element_base> make_child(sys::state& state, std::string_view name, dcon::gui_def_id id) noexcept override {
+		if(name == "start_button") {
+			return make_element_by_type<generic_close_button>(state, id);
+		} else if(name == "background") {
+			return make_element_by_type<draggable_target>(state, id);
+		} else if(name == "chatlog") {
+			return make_element_by_type<chat_message_listbox>(state, id);
+		} else if(name == "multiplayer_list") {
+			return make_element_by_type<chat_player_listbox>(state, id);
+		} else if(name == "lobby_chat_edit") {
+			return make_element_by_type<chat_edit_box>(state, id);
+		} else if(name == "back_button") {
+			auto ptr = make_element_by_type<button_element_base>(state, id);
+			ptr->set_visible(state, false);
+			return ptr;
+		} else {
+			return nullptr;
+		}
+	}
+};
+
+}

--- a/src/gui/gui_graphics.hpp
+++ b/src/gui/gui_graphics.hpp
@@ -339,14 +339,15 @@ class unit_details_window;
 
 struct chat_message {
 	dcon::nation_id source{};
+	dcon::nation_id target{};
 	char body[max_chat_message_len] = {};
 
 	chat_message() = default;
-    chat_message(const chat_message&) = default;
-    chat_message(chat_message&&) = default;
-    chat_message& operator=(const chat_message&) = default;
-    chat_message& operator=(chat_message&&) = default;
-    ~chat_message() = default;
+	chat_message(const chat_message&) = default;
+	chat_message(chat_message&&) = default;
+	chat_message& operator=(const chat_message&) = default;
+	chat_message& operator=(chat_message&&) = default;
+	~chat_message() = default;
 };
 
 struct state {

--- a/src/gui/gui_graphics.hpp
+++ b/src/gui/gui_graphics.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include <deque>
 #include "constants.hpp"
 #include "dcon_generated.hpp"
 #include "unordered_dense.h"

--- a/src/gui/gui_graphics.hpp
+++ b/src/gui/gui_graphics.hpp
@@ -336,6 +336,18 @@ class grid_box;
 template<class T>
 class unit_details_window;
 
+struct chat_message {
+	dcon::nation_id source{};
+	char body[max_chat_message_len] = {};
+
+	chat_message() = default;
+    chat_message(const chat_message&) = default;
+    chat_message(chat_message&&) = default;
+    chat_message& operator=(const chat_message&) = default;
+    chat_message& operator=(chat_message&&) = default;
+    ~chat_message() = default;
+};
+
 struct state {
 	element_base* under_mouse = nullptr;
 	element_base* scroll_target = nullptr;
@@ -383,6 +395,8 @@ struct state {
 	element_base* msg_log_window = nullptr;
 	element_base* msg_window = nullptr;
 	element_base* main_menu_win = nullptr; // The actual main menu
+	element_base* chat_window = nullptr;
+	std::deque<chat_message> chat_messages;
 
 	element_base* major_event_window = nullptr;
 	element_base* national_event_window = nullptr;

--- a/src/gui/gui_graphics.hpp
+++ b/src/gui/gui_graphics.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <vector>
-#include <deque>
+#include <array>
 #include "constants.hpp"
 #include "dcon_generated.hpp"
 #include "unordered_dense.h"
@@ -397,7 +397,8 @@ struct state {
 	element_base* msg_window = nullptr;
 	element_base* main_menu_win = nullptr; // The actual main menu
 	element_base* chat_window = nullptr;
-	std::deque<chat_message> chat_messages;
+	std::array<chat_message, 32> chat_messages;
+	uint8_t chat_messages_index = 0;
 
 	element_base* major_event_window = nullptr;
 	element_base* national_event_window = nullptr;

--- a/src/gui/gui_minimap.hpp
+++ b/src/gui/gui_minimap.hpp
@@ -6,6 +6,7 @@
 #include "gui_search_window.hpp"
 #include "gui_main_menu.hpp"
 #include "gui_message_filters_window.hpp"
+#include "gui_chat_window.hpp"
 #include "opengl_wrapper.hpp"
 #include "map.hpp"
 #include "map_modes.hpp"
@@ -305,35 +306,6 @@ public:
 	}
 };
 
-class minimap_chat_window : public window_element_base {
-public:
-	std::unique_ptr<element_base> make_child(sys::state& state, std::string_view name, dcon::gui_def_id id) noexcept override {
-		if(name == "closebutton") {
-			return make_element_by_type<generic_close_button>(state, id);
-		} else if(name == "chat_bg") {
-			return make_element_by_type<image_element_base>(state, id);
-		} else if(name == "none") {
-			auto ptr = make_element_by_type<button_element_base>(state, id);
-			ptr->set_visible(state, false);
-			return ptr;
-		} else if(name == "allies") {
-			auto ptr = make_element_by_type<button_element_base>(state, id);
-			ptr->set_visible(state, false);
-			return ptr;
-		} else if(name == "enemies") {
-			auto ptr = make_element_by_type<button_element_base>(state, id);
-			ptr->set_visible(state, false);
-			return ptr;
-		} else if(name == "all") {
-			auto ptr = make_element_by_type<button_element_base>(state, id);
-			ptr->set_visible(state, false);
-			return ptr;
-		} else {
-			return nullptr;
-		}
-	}
-};
-
 class minimap_container_window : public window_element_base {
 	const std::string_view mapmode_btn_prefix{"mapmode_"};
 
@@ -347,7 +319,7 @@ public:
 		} else if(name == "openbutton") {
 			return make_element_by_type<open_msg_log_button>(state, id);
 		} else if(name == "chat_window") {
-			auto ptr = make_element_immediate(state, id);
+			auto ptr = make_element_by_type<window_element_base>(state, id);
 			ptr->set_visible(state, false);
 			return ptr;
 		} else if(name == "menu_button") {
@@ -370,8 +342,6 @@ public:
 			return make_element_by_type<minimap_msg_event_button>(state, id);
 		} else if(name == "menubar_msg_other") {
 			return make_element_by_type<minimap_msg_other_button>(state, id);
-		} else if(name == "chat_window") {
-			return make_element_by_type<minimap_chat_window>(state, id);
 		} else if(name.starts_with(mapmode_btn_prefix)) {
 			auto ptr = make_element_by_type<minimap_mapmode_button>(state, id);
 			size_t num_index = name.rfind("_") + 1;

--- a/src/gui/gui_minimap.hpp
+++ b/src/gui/gui_minimap.hpp
@@ -6,7 +6,6 @@
 #include "gui_search_window.hpp"
 #include "gui_main_menu.hpp"
 #include "gui_message_filters_window.hpp"
-#include "gui_chat_window.hpp"
 #include "opengl_wrapper.hpp"
 #include "map.hpp"
 #include "map_modes.hpp"

--- a/src/gui/gui_minimap.hpp
+++ b/src/gui/gui_minimap.hpp
@@ -305,6 +305,35 @@ public:
 	}
 };
 
+class minimap_chat_window : public window_element_base {
+public:
+	std::unique_ptr<element_base> make_child(sys::state& state, std::string_view name, dcon::gui_def_id id) noexcept override {
+		if(name == "closebutton") {
+			return make_element_by_type<generic_close_button>(state, id);
+		} else if(name == "chat_bg") {
+			return make_element_by_type<image_element_base>(state, id);
+		} else if(name == "none") {
+			auto ptr = make_element_by_type<button_element_base>(state, id);
+			ptr->set_visible(state, false);
+			return ptr;
+		} else if(name == "allies") {
+			auto ptr = make_element_by_type<button_element_base>(state, id);
+			ptr->set_visible(state, false);
+			return ptr;
+		} else if(name == "enemies") {
+			auto ptr = make_element_by_type<button_element_base>(state, id);
+			ptr->set_visible(state, false);
+			return ptr;
+		} else if(name == "all") {
+			auto ptr = make_element_by_type<button_element_base>(state, id);
+			ptr->set_visible(state, false);
+			return ptr;
+		} else {
+			return nullptr;
+		}
+	}
+};
+
 class minimap_container_window : public window_element_base {
 	const std::string_view mapmode_btn_prefix{"mapmode_"};
 
@@ -341,6 +370,8 @@ public:
 			return make_element_by_type<minimap_msg_event_button>(state, id);
 		} else if(name == "menubar_msg_other") {
 			return make_element_by_type<minimap_msg_other_button>(state, id);
+		} else if(name == "chat_window") {
+			return make_element_by_type<minimap_chat_window>(state, id);
 		} else if(name.starts_with(mapmode_btn_prefix)) {
 			auto ptr = make_element_by_type<minimap_mapmode_button>(state, id);
 			size_t num_index = name.rfind("_") + 1;


### PR DESCRIPTION
doesn't add anything multiplayer - you can talk to yourself on singleplayer :)

i used the in-game lobby window instead of the "normal" chat window, mainly because:

a) the ingame lobby window provides kick buttons and a list of all the players (useful for QoL features like kicking and banning in-game)

b) provides the chat log in a window that can be toggled with <TAB>

c) of course it is hidden at the start of the game, but on mutliplayer we should maybeeeeee show it at the start, as it is important in multiplayers