### PR TITLE
Ban and kick buttons and commands

### DIFF
--- a/assets/alice.csv
+++ b/assets/alice.csv
@@ -1052,6 +1052,8 @@ alice_retreat_1;It has been at least $x$ days since the battle started
 alice_retreat_2;You are the lead attacker or defender
 chat_player_joins;@$x$ $playername$ has joined the game;;;@$x$ $playername$ se ha unido;;;;;;;;;x
 chat_player_leaves;@$x$ $playername$ has left the game;;;@$x$ $playername$ se ha ido;;;;;;;;;x
+chat_player_ban;@$x$ $playername$ has been banned;;;@$x$ $playername$ ha sido baneado;;;;;;;;;x
+chat_player_kick;@$x$ $playername$ has been kicked;;;@$x$ $playername$ ha sido vetado;;;;;;;;;x
 message_name_text;Message
 msg_for_us;About: your nation
 msg_for_interesting;Interesting nation

--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -4445,10 +4445,10 @@ void execute_command(sys::state& state, payload& c) {
 		break;
 	}
 	case command_type::notify_player_ban:
-		execute_notify_player_ban(state, c.source);
+		execute_notify_player_ban(state, c.source, c.data.nation_pick.target);
 		break;
 	case command_type::notify_player_kick:
-		execute_notify_player_kick(state, c.source);
+		execute_notify_player_kick(state, c.source, c.data.nation_pick.target);
 		break;
 	case command_type::notify_player_joins:
 		execute_notify_player_joins(state, c.source);

--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -4094,6 +4094,63 @@ void execute_notify_player_leaves(sys::state& state, dcon::nation_id source) {
 	post_chat_message(state, m);
 }
 
+void notify_player_ban(sys::state& state, dcon::nation_id source, dcon::nation_id target) {
+	payload p;
+	memset(&p, 0, sizeof(payload));
+	p.type = command_type::notify_player_ban;
+	p.source = source;
+	p.data.nation_pick.target = target;
+	add_to_command_queue(state, p);
+}
+bool can_notify_player_ban(sys::state& state, dcon::nation_id source, dcon::nation_id target) {
+	if(source == target) // can't perform on self
+		return false;
+	return state.network_mode == sys::network_mode::host;
+}
+void execute_notify_player_ban(sys::state& state, dcon::nation_id source, dcon::nation_id target) {
+	if(!can_notify_player_ban(state, source, target))
+		return;
+	if(state.network_mode == sys::network_mode::host) {
+		// TODO: add to banned MAC/IP list
+	}
+	state.world.nation_set_is_player_controlled(target, false);
+
+	ui::chat_message m{};
+	m.source = source;
+	text::substitution_map sub{};
+	text::add_to_substitution_map(sub, text::variable_type::x, std::string_view(nations::int_to_tag(state.world.national_identity_get_identifying_int(state.world.nation_get_identity_from_identity_holder(source)))));
+	text::add_to_substitution_map(sub, text::variable_type::playername, source);
+	m.body = text::resolve_string_substitution(state, "chat_player_ban", sub);
+	post_chat_message(state, m);
+}
+
+void notify_player_kick(sys::state& state, dcon::nation_id source, dcon::nation_id target) {
+	payload p;
+	memset(&p, 0, sizeof(payload));
+	p.type = command_type::notify_player_kick;
+	p.source = source;
+	p.data.nation_pick.target = target;
+	add_to_command_queue(state, p);
+}
+bool can_notify_player_kick(sys::state& state, dcon::nation_id source, dcon::nation_id target) {
+	if(source == target) // can't perform on self
+		return false;
+	return state.network_mode == sys::network_mode::host;
+}
+void execute_notify_player_kick(sys::state& state, dcon::nation_id source, dcon::nation_id target) {
+	if(!can_notify_player_kick(state, source, target))
+		return;
+	state.world.nation_set_is_player_controlled(target, false);
+
+	ui::chat_message m{};
+	m.source = source;
+	text::substitution_map sub{};
+	text::add_to_substitution_map(sub, text::variable_type::x, std::string_view(nations::int_to_tag(state.world.national_identity_get_identifying_int(state.world.nation_get_identity_from_identity_holder(source)))));
+	text::add_to_substitution_map(sub, text::variable_type::playername, source);
+	m.body = text::resolve_string_substitution(state, "chat_player_kick", sub);
+	post_chat_message(state, m);
+}
+
 void notify_player_picks_nation(sys::state& state, dcon::nation_id source, dcon::nation_id target) {
 	payload p;
 	memset(&p, 0, sizeof(payload));
@@ -4387,6 +4444,12 @@ void execute_command(sys::state& state, payload& c) {
 		execute_chat_message(state, c.source, sv, c.data.chat_message.target);
 		break;
 	}
+	case command_type::notify_player_ban:
+		execute_notify_player_ban(state, c.source);
+		break;
+	case command_type::notify_player_kick:
+		execute_notify_player_kick(state, c.source);
+		break;
 	case command_type::notify_player_joins:
 		execute_notify_player_joins(state, c.source);
 		break;

--- a/src/gamestate/commands.hpp
+++ b/src/gamestate/commands.hpp
@@ -88,7 +88,9 @@ enum class command_type : uint8_t {
 	change_general = 79,
 	toggle_mobilization = 80,
 	give_military_access = 81,
-
+	
+	notify_player_ban = 117,
+	notify_player_kick = 118,
 	notify_player_picks_nation = 119,
 	notify_player_joins = 120,
 	notify_player_leaves = 121,
@@ -697,11 +699,15 @@ bool can_send_crisis_peace_offer(sys::state& state, dcon::nation_id source);
 
 void chat_message(sys::state& state, dcon::nation_id source, std::string_view body, dcon::nation_id target);
 bool can_chat_message(sys::state& state, dcon::nation_id source, std::string_view body, dcon::nation_id target);
+
+void notify_player_ban(sys::state& state, dcon::nation_id source, dcon::nation_id target);
+bool can_notify_player_ban(sys::state& state, dcon::nation_id source, dcon::nation_id target);
+void notify_player_kick(sys::state& state, dcon::nation_id source, dcon::nation_id target);
+bool can_notify_player_kick(sys::state& state, dcon::nation_id source, dcon::nation_id target);
 void notify_player_joins(sys::state& state, dcon::nation_id source);
 bool can_notify_player_joins(sys::state& state, dcon::nation_id source);
 void notify_player_leaves(sys::state& state, dcon::nation_id source);
 bool can_notify_player_leaves(sys::state& state, dcon::nation_id source);
-
 void notify_player_picks_nation(sys::state& state, dcon::nation_id source, dcon::nation_id target);
 bool can_notify_player_picks_nation(sys::state& state, dcon::nation_id source, dcon::nation_id target);
 

--- a/src/gui/gui_nation_picker.hpp
+++ b/src/gui/gui_nation_picker.hpp
@@ -434,7 +434,7 @@ public:
 	}
 
 	void button_action(sys::state& state) noexcept override {
-		
+
 	}
 
 	tooltip_behavior has_tooltip(sys::state& state) noexcept override {
@@ -467,7 +467,7 @@ public:
 			ptr->base_data.position.y += 7; // Nudge
 			return ptr;
 		} else if(name == "button_kick") {
-			auto ptr = make_element_by_type<button_element_base>(state, id);
+			auto ptr = make_element_by_type<nation_picker_kick_button>(state, id);
 			ptr->base_data.position.x += 10; // Nudge
 			ptr->base_data.position.y += 7; // Nudge
 			return ptr;

--- a/src/gui/gui_nation_picker.hpp
+++ b/src/gui/gui_nation_picker.hpp
@@ -406,6 +406,48 @@ public:
 	}
 };
 
+class nation_picker_kick_button : public button_element_base {
+public:
+	void on_update(sys::state& state) noexcept override {
+		disabled = (state.network_mode != sys::network_mode::host);
+	}
+
+	void button_action(sys::state& state) noexcept override {
+	
+	}
+
+	tooltip_behavior has_tooltip(sys::state& state) noexcept override {
+		return tooltip_behavior::variable_tooltip;
+	}
+
+	void update_tooltip(sys::state& state, int32_t x, int32_t y, text::columnar_layout& contents) noexcept override {
+		auto box = text::open_layout_box(contents, 0);
+		text::localised_format_box(state, contents, box, std::string_view("tip_kick"));
+		text::close_layout_box(contents, box);
+	}
+};
+
+class nation_picker_ban_button : public button_element_base {
+public:
+	void on_update(sys::state& state) noexcept override {
+		disabled = (state.network_mode != sys::network_mode::host);
+	}
+
+	void button_action(sys::state& state) noexcept override {
+		
+	}
+
+	tooltip_behavior has_tooltip(sys::state& state) noexcept override {
+		return tooltip_behavior::variable_tooltip;
+	}
+
+	void update_tooltip(sys::state& state, int32_t x, int32_t y, text::columnar_layout& contents) noexcept override {
+		auto box = text::open_layout_box(contents, 0);
+		text::localised_format_box(state, contents, box, std::string_view("tip_ban"));
+		text::close_layout_box(contents, box);
+	}
+};
+
 class nation_picker_multiplayer_entry : public listbox_row_element_base<dcon::nation_id> {
 public:
 	std::unique_ptr<element_base> make_child(sys::state& state, std::string_view name, dcon::gui_def_id id) noexcept override {
@@ -430,7 +472,7 @@ public:
 			ptr->base_data.position.y += 7; // Nudge
 			return ptr;
 		} else if(name == "button_ban") {
-			auto ptr = make_element_by_type<button_element_base>(state, id);
+			auto ptr = make_element_by_type<nation_picker_ban_button>(state, id);
 			ptr->base_data.position.x += 10; // Nudge
 			ptr->base_data.position.y += 7; // Nudge
 			return ptr;

--- a/src/gui/gui_nation_picker.hpp
+++ b/src/gui/gui_nation_picker.hpp
@@ -409,11 +409,13 @@ public:
 class nation_picker_kick_button : public button_element_base {
 public:
 	void on_update(sys::state& state) noexcept override {
-		disabled = (state.network_mode != sys::network_mode::host);
+		auto n = retrieve<dcon::nation_id>(state, parent);
+		disabled = !command::can_notify_player_kick(state, state.local_player_nation, n);
 	}
 
 	void button_action(sys::state& state) noexcept override {
-	
+		auto n = retrieve<dcon::nation_id>(state, parent);
+		command::notify_player_kick(state, state.local_player_nation, n);
 	}
 
 	tooltip_behavior has_tooltip(sys::state& state) noexcept override {
@@ -430,11 +432,13 @@ public:
 class nation_picker_ban_button : public button_element_base {
 public:
 	void on_update(sys::state& state) noexcept override {
-		disabled = (state.network_mode != sys::network_mode::host);
+		auto n = retrieve<dcon::nation_id>(state, parent);
+		disabled = !command::can_notify_player_ban(state, state.local_player_nation, n);
 	}
 
 	void button_action(sys::state& state) noexcept override {
-
+		auto n = retrieve<dcon::nation_id>(state, parent);
+		command::notify_player_ban(state, state.local_player_nation, n);
 	}
 
 	tooltip_behavior has_tooltip(sys::state& state) noexcept override {


### PR DESCRIPTION
- why have ban and kick, why not only ban/kick?
- ban -> prevent people from rejoining
- kick -> to kick people from the lobby [but not disallow them from rejoining]