### PR TITLE
misc fixes

### DIFF
--- a/assets/alice.csv
+++ b/assets/alice.csv
@@ -1219,6 +1219,7 @@ rr_build_tt_1;Our ruling party allows the government to construct rail roads
 tech_ol_tt;§G$x$§! from your overlord having this technology
 tech_year_tt;§G$x$§! from the current year
 disband_all;Disband all selected units
+alice_play_checksum_host;Checksum mismatch with host, ensure you have the same mods and savefiles
 ai_will_accept_po;The AI will accept this offer
 ai_will_not_accept_po;The AI will NOT accept this offer
 ;;;;;;;;;;;;;x

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -29,6 +29,8 @@ The build uses CMake and should "just work", with some annoying exceptions.
 3. Open the project in Visual Studio and let it configure (CMake should run in the output window and download dependencies; this may take some time).
 4. Go look at the "Final Touches" section at the bottom of this page.
 
+If you experience problems with audio playback, you may wish to install Windows Media Player and Windows Media Feature Pack (https://support.microsoft.com/en-us/windows/get-windows-media-player-81718e0d-cfce-25b1-aee3-94596b658287) to be able to properly playback MP3 files (the music jukebox).
+
 #### Linux (Debian-based distro)
 
 Make sure to install the required dependencies.

--- a/docs/multiplayer.md
+++ b/docs/multiplayer.md
@@ -8,6 +8,8 @@ The server will receive commands from the clients. The server will then send bac
 
 The commands should be sent in chronological order. Clients **will** advance one tick when told so, and then execute the commands afterwards as if the player was doing it. This means that all commands should be properly acknowledged by the client as they occurred chronologically.
 
+Everytime a client connects, it is given the checksum of the server, this checksum is for failsafe purpouses, to not let the client enter into an invalid state. The "play" button on the nation picker will bre greyed out if the checksum of the client and the host mismatch. Everytime a savefile is selected on the host, it will tell all it's clients that the checksum has indeed, changed now. This prevents clients who are otherwise not given yet a savefile to connect a game, or clients with different mods to connect a server for example.
+
 ### Deterministic reimplementations
 
 The standard C++ and C library provide `sin`, `cos`, and `acos` functions for performing their respective mathematical functions. However the implementation of these vary per platform and library, and since we're trying to provide a cross platform experience we reimplemented the mathematical functions from scratch, into a house-built solution.
@@ -18,6 +20,9 @@ The standard C++ and C library provide `sin`, `cos`, and `acos` functions for pe
 
 `notify_player_joins` - Tells the clients that a player has joined, marks the `source` nation as player-controlled.
 `notify_player_pick_nation` - Picks a nation, this is useful for example on the lobby where players are switching nations constantly, IF the `source` is invalid (i.e a `dcon::nation_id{}`) then it refers to the current local player nation of the client, this is useful to set the "temporal nation" on the lobby so that clients can be identified by their nation automatically assigned by the server. Otherwise the `source` is the client who requested to pick a nation `target` in `data.nation_pick.target`.
+`update_session_info` - Updates the game seed (important to keep in sync with clients and host), and the session checksum, used to check discrepancies between clients and hosts that could hinder gameplay and throw it into an invalid state.
+`notify_player_kick` - When kicking a player, it is disconnected, but allowed to rejoin.
+`notify_player_ban` - When banning a player, it is disconnected, and not allowed to rejoin.
 
 The server will send new clients a `notify_player_joins` for each connected player. It will send a `notify_player_pick_nation` to the client, with an invalid source, telling it what is their "assigned nation".
 
@@ -25,4 +30,6 @@ An assigned nation is a "random" nation that the server will hand out to the cli
 
 ### Out-of-sync (OOS)
 
-No more oos :D
+On debug builds, a checksum will be generated every tick to ensure synchronisation hasn't been broken. If a desync happens, it will be pointed out in the tick where it occurred.
+
+Otherwise, the goal is no more oos :D

--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -4483,7 +4483,7 @@ void execute_notify_player_picks_nation(sys::state& state, dcon::nation_id sourc
 
 void execute_advance_tick(sys::state& state, dcon::nation_id source, sys::checksum_key& checksum) {
 #ifndef NDEBUG
-	sys::checksum_key current = state.get_network_checksum();
+	sys::checksum_key current = state.get_save_checksum();
 	if(!current.is_equal(checksum)) {
 #ifdef _WIN64
 		std::string msg = "Network has gotten out of sync: ";
@@ -4506,7 +4506,7 @@ void update_session_info(sys::state& state, dcon::nation_id source) {
 	p.type = command::command_type::update_session_info;
 	p.source = source;
 	p.data.update_session_info.seed = state.game_seed;
-	p.data.update_session_info.checksum = state.get_network_checksum();
+	p.data.update_session_info.checksum = state.get_save_checksum();
 	add_to_command_queue(state, p);
 }
 

--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -10,36 +10,37 @@ bool is_console_command(command_type t) {
 
 static void add_to_command_queue(sys::state& state, payload& p) {
 	switch(p.type) {
-		case command_type::notify_player_joins:
-		case command_type::notify_player_leaves:
-		case command_type::notify_player_picks_nation:
-		case command_type::notify_player_ban:
-		case command_type::notify_player_kick:
-			// Notifications can be sent because it's an-always do thing
-			break;
-		default:
-			// Normal commands are discarded iff we are not in the game
-			if(state.mode != sys::game_mode_type::in_game)
-				return;
-			break;
+	case command_type::notify_player_joins:
+	case command_type::notify_player_leaves:
+	case command_type::notify_player_picks_nation:
+	case command_type::notify_player_ban:
+	case command_type::notify_player_kick:
+	case command_type::update_session_info:
+		// Notifications can be sent because it's an-always do thing
+		break;
+	default:
+		// Normal commands are discarded iff we are not in the game
+		if(state.mode != sys::game_mode_type::in_game)
+			return;
+		break;
 	}
 
 	switch(state.network_mode) {
-		case sys::network_mode_type::single_player:
-		{
-			bool b = state.incoming_commands.try_push(p);
-			break;
-		}
-		case sys::network_mode_type::client:
-		case sys::network_mode_type::host:
-		{
-			/*
-			bool b = state.network_state.outgoing_commands.try_push(p);
-			*/
-			break;
-		}
-		default:
-			break;
+	case sys::network_mode_type::single_player:
+	{
+		bool b = state.incoming_commands.try_push(p);
+		break;
+	}
+	case sys::network_mode_type::client:
+	case sys::network_mode_type::host:
+	{
+		/*
+		state.network_state.outgoing_commands.push(p);
+		*/
+		break;
+	}
+	default:
+		break;
 	}
 }
 
@@ -406,12 +407,12 @@ void begin_province_building_construction(sys::state& state, dcon::nation_id sou
 bool can_begin_province_building_construction(sys::state& state, dcon::nation_id source, dcon::province_id p, economy::province_building_type type) {
 
 	switch(type) {
-		case economy::province_building_type::railroad:
-			return province::can_build_railroads(state, p, source);
-		case economy::province_building_type::fort:
-			return province::can_build_fort(state, p, source);
-		case economy::province_building_type::naval_base:
-			return province::can_build_naval_base(state, p, source);
+	case economy::province_building_type::railroad:
+		return province::can_build_railroads(state, p, source);
+	case economy::province_building_type::fort:
+		return province::can_build_fort(state, p, source);
+	case economy::province_building_type::naval_base:
+		return province::can_build_naval_base(state, p, source);
 	}
 
 	return false;
@@ -1028,20 +1029,20 @@ void execute_change_influence_priority(sys::state& state, dcon::nation_id source
 	}
 	auto& flags = state.world.gp_relationship_get_status(rel);
 	switch(priority) {
-		case 0:
-			flags = (flags & ~nations::influence::priority_mask) | nations::influence::priority_zero;
-			break;
-		case 1:
-			flags = (flags & ~nations::influence::priority_mask) | nations::influence::priority_one;
-			break;
-		case 2:
-			flags = (flags & ~nations::influence::priority_mask) | nations::influence::priority_two;
-			break;
-		case 3:
-			flags = (flags & ~nations::influence::priority_mask) | nations::influence::priority_three;
-			break;
-		default:
-			break;
+	case 0:
+		flags = (flags & ~nations::influence::priority_mask) | nations::influence::priority_zero;
+		break;
+	case 1:
+		flags = (flags & ~nations::influence::priority_mask) | nations::influence::priority_one;
+		break;
+	case 2:
+		flags = (flags & ~nations::influence::priority_mask) | nations::influence::priority_two;
+		break;
+	case 3:
+		flags = (flags & ~nations::influence::priority_mask) | nations::influence::priority_three;
+		break;
+	default:
+		break;
 	}
 }
 
@@ -4303,6 +4304,7 @@ void chat_message(sys::state& state, dcon::nation_id source, std::string_view bo
 	p.source = source;
 	p.data.chat_message.target = target;
 	memcpy(p.data.chat_message.body, std::string(body).c_str(), std::min<size_t>(body.length() + 1, size_t(ui::max_chat_message_len)));
+	p.data.chat_message.body[ui::max_chat_message_len - 1] = '\0';
 	add_to_command_queue(state, p);
 }
 bool can_chat_message(sys::state& state, dcon::nation_id source, std::string_view body, dcon::nation_id target) {
@@ -4479,352 +4481,384 @@ void execute_notify_player_picks_nation(sys::state& state, dcon::nation_id sourc
 	}
 }
 
+void execute_advance_tick(sys::state& state, dcon::nation_id source, sys::checksum_key& checksum) {
+#ifndef NDEBUG
+	sys::checksum_key current = state.get_network_checksum();
+	if(!current.is_equal(checksum)) {
+#ifdef _WIN64
+		std::string msg = "Network has gotten out of sync: ";
+		MessageBoxA(NULL, "Out of sync", msg.c_str(), MB_OK);
+#endif
+		std::abort();
+	}
+#endif
+	state.single_game_tick();
+}
+
+void execute_update_session_info(sys::state& state, dcon::nation_id source, uint32_t seed, sys::checksum_key& k) {
+	state.game_seed = seed;
+	state.session_host_checksum = k;
+}
+
+void update_session_info(sys::state& state, dcon::nation_id source) {
+	payload p;
+	memset(&p, 0, sizeof(payload));
+	p.type = command::command_type::update_session_info;
+	p.source = source;
+	p.data.update_session_info.seed = state.game_seed;
+	p.data.update_session_info.checksum = state.get_network_checksum();
+	add_to_command_queue(state, p);
+}
+
 void execute_command(sys::state& state, payload& c) {
 	switch(c.type) {
-		case command_type::invalid:
-			std::abort(); // invalid command
-			break;
-		case command_type::change_nat_focus:
-			execute_set_national_focus(state, c.source, c.data.nat_focus.target_state, c.data.nat_focus.focus);
-			break;
-		case command_type::start_research:
-			execute_start_research(state, c.source, c.data.start_research.tech);
-			break;
-		case command_type::make_leader:
-			execute_make_leader(state, c.source, c.data.make_leader.is_general);
-			break;
-		case command_type::begin_province_building_construction:
-			execute_begin_province_building_construction(state, c.source, c.data.start_province_building.location,
-					c.data.start_province_building.type);
-			break;
-		case command_type::war_subsidies:
-			execute_give_war_subsidies(state, c.source, c.data.diplo_action.target);
-			break;
-		case command_type::cancel_war_subsidies:
-			execute_cancel_war_subsidies(state, c.source, c.data.diplo_action.target);
-			break;
-		case command_type::increase_relations:
-			execute_increase_relations(state, c.source, c.data.diplo_action.target);
-			break;
-		case command_type::decrease_relations:
-			execute_decrease_relations(state, c.source, c.data.diplo_action.target);
-			break;
-		case command_type::begin_factory_building_construction:
-			execute_begin_factory_building_construction(state, c.source, c.data.start_factory_building.location,
-					c.data.start_factory_building.type, c.data.start_factory_building.is_upgrade);
-			break;
-		case command_type::begin_naval_unit_construction:
-			execute_start_naval_unit_construction(state, c.source, c.data.naval_unit_construction.location,
-					c.data.naval_unit_construction.type);
-			break;
-		case command_type::cancel_naval_unit_construction:
-			execute_cancel_naval_unit_construction(state, c.source, c.data.naval_unit_construction.location,
-					c.data.naval_unit_construction.type);
-			break;
-		case command_type::begin_land_unit_construction:
-			execute_start_land_unit_construction(state, c.source, c.data.land_unit_construction.location,
-					c.data.land_unit_construction.pop_culture, c.data.land_unit_construction.type);
-			break;
-		case command_type::cancel_land_unit_construction:
-			execute_cancel_land_unit_construction(state, c.source, c.data.land_unit_construction.location,
-					c.data.land_unit_construction.pop_culture, c.data.land_unit_construction.type);
-			break;
-		case command_type::delete_factory:
-			execute_delete_factory(state, c.source, c.data.factory.location, c.data.factory.type);
-			break;
-		case command_type::change_factory_settings:
-			execute_change_factory_settings(state, c.source, c.data.factory.location, c.data.factory.type, c.data.factory.priority,
-					c.data.factory.subsidize);
-			break;
-		case command_type::make_vassal:
-			execute_make_vassal(state, c.source, c.data.tag_target.ident);
-			break;
-		case command_type::release_and_play_nation:
-			execute_release_and_play_as(state, c.source, c.data.tag_target.ident);
-			break;
-		case command_type::change_budget:
-			execute_change_budget_settings(state, c.source, c.data.budget_data);
-			break;
-		case command_type::start_election:
-			execute_start_election(state, c.source);
-			break;
-		case command_type::change_influence_priority:
-			execute_change_influence_priority(state, c.source, c.data.influence_priority.influence_target,
-					c.data.influence_priority.priority);
-			break;
-		case command_type::expel_advisors:
-			execute_expel_advisors(state, c.source, c.data.influence_action.influence_target, c.data.influence_action.gp_target);
-			break;
-		case command_type::ban_embassy:
-			execute_ban_embassy(state, c.source, c.data.influence_action.influence_target, c.data.influence_action.gp_target);
-			break;
-		case command_type::discredit_advisors:
-			execute_discredit_advisors(state, c.source, c.data.influence_action.influence_target, c.data.influence_action.gp_target);
-			break;
-		case command_type::decrease_opinion:
-			execute_decrease_opinion(state, c.source, c.data.influence_action.influence_target, c.data.influence_action.gp_target);
-			break;
-		case command_type::remove_from_sphere:
-			execute_remove_from_sphere(state, c.source, c.data.influence_action.influence_target, c.data.influence_action.gp_target);
-			break;
-		case command_type::increase_opinion:
-			execute_increase_opinion(state, c.source, c.data.influence_action.influence_target);
-			break;
-		case command_type::add_to_sphere:
-			execute_add_to_sphere(state, c.source, c.data.influence_action.influence_target);
-			break;
-		case command_type::upgrade_colony_to_state:
-			execute_upgrade_colony_to_state(state, c.source, state.world.province_get_state_membership(c.data.generic_location.prov));
-			break;
-		case command_type::invest_in_colony:
-			execute_invest_in_colony(state, c.source, c.data.generic_location.prov);
-			break;
-		case command_type::abandon_colony:
-			execute_abandon_colony(state, c.source, c.data.generic_location.prov);
-			break;
-		case command_type::finish_colonization:
-			execute_finish_colonization(state, c.source, c.data.generic_location.prov);
-			break;
-		case command_type::intervene_in_war:
-			execute_intervene_in_war(state, c.source, c.data.war_target.war, c.data.war_target.for_attacker);
-			break;
-		case command_type::suppress_movement:
-			execute_suppress_movement(state, c.source, c.data.movement.iopt, c.data.movement.tag);
-			break;
-		case command_type::civilize_nation:
-			execute_civilize_nation(state, c.source);
-			break;
-		case command_type::appoint_ruling_party:
-			execute_appoint_ruling_party(state, c.source, c.data.political_party.p);
-			break;
-		case command_type::change_issue_option:
-			execute_enact_issue(state, c.source, c.data.issue_selection.r);
-			break;
-		case command_type::change_reform_option:
-			execute_enact_reform(state, c.source, c.data.reform_selection.r);
-			break;
-		case command_type::become_interested_in_crisis:
-			execute_become_interested_in_crisis(state, c.source);
-			break;
-		case command_type::take_sides_in_crisis:
-			execute_take_sides_in_crisis(state, c.source, c.data.crisis_join.join_attackers);
-			break;
-		case command_type::change_stockpile_settings:
-			execute_change_stockpile_settings(state, c.source, c.data.stockpile_settings.c, c.data.stockpile_settings.amount,
-					c.data.stockpile_settings.draw_on_stockpiles);
-			break;
-		case command_type::take_decision:
-			execute_take_decision(state, c.source, c.data.decision.d);
-			break;
-		case command_type::make_n_event_choice:
-			execute_make_event_choice(state, c.source, c.data.pending_human_n_event);
-			break;
-		case command_type::make_f_n_event_choice:
-			execute_make_event_choice(state, c.source, c.data.pending_human_f_n_event);
-			break;
-		case command_type::make_p_event_choice:
-			execute_make_event_choice(state, c.source, c.data.pending_human_p_event);
-			break;
-		case command_type::make_f_p_event_choice:
-			execute_make_event_choice(state, c.source, c.data.pending_human_f_p_event);
-			break;
-		case command_type::cancel_cb_fabrication:
-			execute_cancel_cb_fabrication(state, c.source);
-			break;
-		case command_type::fabricate_cb:
-			execute_fabricate_cb(state, c.source, c.data.cb_fabrication.target, c.data.cb_fabrication.type);
-			break;
-		case command_type::ask_for_military_access:
-			execute_ask_for_access(state, c.source, c.data.diplo_action.target);
-			break;
-		case command_type::ask_for_alliance:
-			execute_ask_for_alliance(state, c.source, c.data.diplo_action.target);
-			break;
-		case command_type::call_to_arms:
-			execute_call_to_arms(state, c.source, c.data.call_to_arms.target, c.data.call_to_arms.war);
-			break;
-		case command_type::respond_to_diplomatic_message:
-			execute_respond_to_diplomatic_message(state, c.source, c.data.message.from, c.data.message.type, c.data.message.accept);
-			break;
-		case command_type::cancel_military_access:
-			execute_cancel_military_access(state, c.source, c.data.diplo_action.target);
-			break;
-		case command_type::cancel_alliance:
-			execute_cancel_alliance(state, c.source, c.data.diplo_action.target);
-			break;
-		case command_type::cancel_given_military_access:
-			execute_cancel_given_military_access(state, c.source, c.data.diplo_action.target);
-			break;
-		case command_type::declare_war:
-			execute_declare_war(state, c.source, c.data.new_war.target, c.data.new_war.primary_cb, c.data.new_war.cb_state,
-					c.data.new_war.cb_tag, c.data.new_war.cb_secondary_nation, c.data.new_war.call_attacker_allies);
-			break;
-		case command_type::add_war_goal:
-			execute_add_war_goal(state, c.source, c.data.new_war_goal.war, c.data.new_war_goal.target, c.data.new_war_goal.cb_type,
-					c.data.new_war_goal.cb_state, c.data.new_war_goal.cb_tag, c.data.new_war_goal.cb_secondary_nation);
-			break;
-		case command_type::start_peace_offer:
-			execute_start_peace_offer(state, c.source, c.data.new_offer.target, c.data.new_offer.war,
-					c.data.new_offer.is_concession);
-			break;
-		case command_type::add_peace_offer_term:
-			execute_add_to_peace_offer(state, c.source, c.data.offer_wargoal.wg);
-			break;
-		case command_type::send_peace_offer:
-			execute_send_peace_offer(state, c.source);
-			break;
-		case command_type::move_army:
-			execute_move_army(state, c.source, c.data.army_movement.a, c.data.army_movement.dest);
-			break;
-		case command_type::move_navy:
-			execute_move_navy(state, c.source, c.data.navy_movement.n, c.data.navy_movement.dest);
-			break;
-		case command_type::embark_army:
-			execute_embark_army(state, c.source, c.data.army_movement.a);
-			break;
-		case command_type::merge_armies:
-			execute_merge_armies(state, c.source, c.data.merge_army.a, c.data.merge_army.b);
-			break;
-		case command_type::merge_navies:
-			execute_merge_navies(state, c.source, c.data.merge_navy.a, c.data.merge_navy.b);
-			break;
-		case command_type::split_army:
-			execute_split_army(state, c.source, c.data.army_movement.a);
-			break;
-		case command_type::split_navy:
-			execute_split_navy(state, c.source, c.data.navy_movement.n);
-			break;
-		case command_type::delete_army:
-			execute_delete_army(state, c.source, c.data.army_movement.a);
-			break;
-		case command_type::delete_navy:
-			execute_delete_navy(state, c.source, c.data.navy_movement.n);
-			break;
-		case command_type::designate_split_regiments:
-			execute_mark_regiments_to_split(state, c.source, c.data.split_regiments.regs);
-			break;
-		case command_type::designate_split_ships:
-			execute_mark_ships_to_split(state, c.source, c.data.split_ships.ships);
-			break;
-		case command_type::naval_retreat:
-			execute_retreat_from_naval_battle(state, c.source, c.data.naval_battle.b);
-			break;
-		case command_type::land_retreat:
-			execute_retreat_from_land_battle(state, c.source, c.data.land_battle.b);
-			break;
-		case command_type::start_crisis_peace_offer:
-			execute_start_crisis_peace_offer(state, c.source, c.data.new_offer.is_concession);
-			break;
-		case command_type::invite_to_crisis:
-			execute_invite_to_crisis(state, c.source, c.data.crisis_invitation);
-			break;
-		case command_type::add_wargoal_to_crisis_offer:
-			execute_add_to_crisis_peace_offer(state, c.source, c.data.crisis_invitation);
-			break;
-		case command_type::send_crisis_peace_offer:
-			execute_send_crisis_peace_offer(state, c.source);
-			break;
-		case command_type::change_admiral:
-			execute_change_admiral(state, c.source, c.data.new_admiral.a, c.data.new_admiral.l);
-			break;
-		case command_type::change_general:
-			execute_change_general(state, c.source, c.data.new_general.a, c.data.new_general.l);
-			break;
-		case command_type::toggle_mobilization:
-			execute_toggle_mobilization(state, c.source);
-			break;
-		case command_type::give_military_access:
-			execute_give_military_access(state, c.source, c.data.diplo_action.target);
-			break;
-		case command_type::set_rally_point:
-			execute_set_rally_point(state, c.source, c.data.rally_point.location, c.data.rally_point.naval, c.data.rally_point.enable);
-			break;
-		case command_type::save_game:
-			execute_save_game(state, c.source, c.data.save_game.and_quit);
-			break;
-		case command_type::cancel_factory_building_construction:
-			execute_cancel_factory_building_construction(state, c.source, c.data.start_factory_building.location, c.data.start_factory_building.type);
-			break;
-		case command_type::disband_undermanned:
-			execute_disband_undermanned_regiments(state, c.source, c.data.army_movement.a);
-			break;
-		case command_type::even_split_army:
-			execute_evenly_split_army(state, c.source, c.data.army_movement.a);
-			break;
-		case command_type::even_split_navy:
-			execute_evenly_split_navy(state, c.source, c.data.navy_movement.n);
-			break;
+	case command_type::invalid:
+		std::abort(); // invalid command
+		break;
+	case command_type::change_nat_focus:
+		execute_set_national_focus(state, c.source, c.data.nat_focus.target_state, c.data.nat_focus.focus);
+		break;
+	case command_type::start_research:
+		execute_start_research(state, c.source, c.data.start_research.tech);
+		break;
+	case command_type::make_leader:
+		execute_make_leader(state, c.source, c.data.make_leader.is_general);
+		break;
+	case command_type::begin_province_building_construction:
+		execute_begin_province_building_construction(state, c.source, c.data.start_province_building.location,
+				c.data.start_province_building.type);
+		break;
+	case command_type::war_subsidies:
+		execute_give_war_subsidies(state, c.source, c.data.diplo_action.target);
+		break;
+	case command_type::cancel_war_subsidies:
+		execute_cancel_war_subsidies(state, c.source, c.data.diplo_action.target);
+		break;
+	case command_type::increase_relations:
+		execute_increase_relations(state, c.source, c.data.diplo_action.target);
+		break;
+	case command_type::decrease_relations:
+		execute_decrease_relations(state, c.source, c.data.diplo_action.target);
+		break;
+	case command_type::begin_factory_building_construction:
+		execute_begin_factory_building_construction(state, c.source, c.data.start_factory_building.location,
+				c.data.start_factory_building.type, c.data.start_factory_building.is_upgrade);
+		break;
+	case command_type::begin_naval_unit_construction:
+		execute_start_naval_unit_construction(state, c.source, c.data.naval_unit_construction.location,
+				c.data.naval_unit_construction.type);
+		break;
+	case command_type::cancel_naval_unit_construction:
+		execute_cancel_naval_unit_construction(state, c.source, c.data.naval_unit_construction.location,
+				c.data.naval_unit_construction.type);
+		break;
+	case command_type::begin_land_unit_construction:
+		execute_start_land_unit_construction(state, c.source, c.data.land_unit_construction.location,
+				c.data.land_unit_construction.pop_culture, c.data.land_unit_construction.type);
+		break;
+	case command_type::cancel_land_unit_construction:
+		execute_cancel_land_unit_construction(state, c.source, c.data.land_unit_construction.location,
+				c.data.land_unit_construction.pop_culture, c.data.land_unit_construction.type);
+		break;
+	case command_type::delete_factory:
+		execute_delete_factory(state, c.source, c.data.factory.location, c.data.factory.type);
+		break;
+	case command_type::change_factory_settings:
+		execute_change_factory_settings(state, c.source, c.data.factory.location, c.data.factory.type, c.data.factory.priority,
+				c.data.factory.subsidize);
+		break;
+	case command_type::make_vassal:
+		execute_make_vassal(state, c.source, c.data.tag_target.ident);
+		break;
+	case command_type::release_and_play_nation:
+		execute_release_and_play_as(state, c.source, c.data.tag_target.ident);
+		break;
+	case command_type::change_budget:
+		execute_change_budget_settings(state, c.source, c.data.budget_data);
+		break;
+	case command_type::start_election:
+		execute_start_election(state, c.source);
+		break;
+	case command_type::change_influence_priority:
+		execute_change_influence_priority(state, c.source, c.data.influence_priority.influence_target,
+				c.data.influence_priority.priority);
+		break;
+	case command_type::expel_advisors:
+		execute_expel_advisors(state, c.source, c.data.influence_action.influence_target, c.data.influence_action.gp_target);
+		break;
+	case command_type::ban_embassy:
+		execute_ban_embassy(state, c.source, c.data.influence_action.influence_target, c.data.influence_action.gp_target);
+		break;
+	case command_type::discredit_advisors:
+		execute_discredit_advisors(state, c.source, c.data.influence_action.influence_target, c.data.influence_action.gp_target);
+		break;
+	case command_type::decrease_opinion:
+		execute_decrease_opinion(state, c.source, c.data.influence_action.influence_target, c.data.influence_action.gp_target);
+		break;
+	case command_type::remove_from_sphere:
+		execute_remove_from_sphere(state, c.source, c.data.influence_action.influence_target, c.data.influence_action.gp_target);
+		break;
+	case command_type::increase_opinion:
+		execute_increase_opinion(state, c.source, c.data.influence_action.influence_target);
+		break;
+	case command_type::add_to_sphere:
+		execute_add_to_sphere(state, c.source, c.data.influence_action.influence_target);
+		break;
+	case command_type::upgrade_colony_to_state:
+		execute_upgrade_colony_to_state(state, c.source, state.world.province_get_state_membership(c.data.generic_location.prov));
+		break;
+	case command_type::invest_in_colony:
+		execute_invest_in_colony(state, c.source, c.data.generic_location.prov);
+		break;
+	case command_type::abandon_colony:
+		execute_abandon_colony(state, c.source, c.data.generic_location.prov);
+		break;
+	case command_type::finish_colonization:
+		execute_finish_colonization(state, c.source, c.data.generic_location.prov);
+		break;
+	case command_type::intervene_in_war:
+		execute_intervene_in_war(state, c.source, c.data.war_target.war, c.data.war_target.for_attacker);
+		break;
+	case command_type::suppress_movement:
+		execute_suppress_movement(state, c.source, c.data.movement.iopt, c.data.movement.tag);
+		break;
+	case command_type::civilize_nation:
+		execute_civilize_nation(state, c.source);
+		break;
+	case command_type::appoint_ruling_party:
+		execute_appoint_ruling_party(state, c.source, c.data.political_party.p);
+		break;
+	case command_type::change_issue_option:
+		execute_enact_issue(state, c.source, c.data.issue_selection.r);
+		break;
+	case command_type::change_reform_option:
+		execute_enact_reform(state, c.source, c.data.reform_selection.r);
+		break;
+	case command_type::become_interested_in_crisis:
+		execute_become_interested_in_crisis(state, c.source);
+		break;
+	case command_type::take_sides_in_crisis:
+		execute_take_sides_in_crisis(state, c.source, c.data.crisis_join.join_attackers);
+		break;
+	case command_type::change_stockpile_settings:
+		execute_change_stockpile_settings(state, c.source, c.data.stockpile_settings.c, c.data.stockpile_settings.amount,
+				c.data.stockpile_settings.draw_on_stockpiles);
+		break;
+	case command_type::take_decision:
+		execute_take_decision(state, c.source, c.data.decision.d);
+		break;
+	case command_type::make_n_event_choice:
+		execute_make_event_choice(state, c.source, c.data.pending_human_n_event);
+		break;
+	case command_type::make_f_n_event_choice:
+		execute_make_event_choice(state, c.source, c.data.pending_human_f_n_event);
+		break;
+	case command_type::make_p_event_choice:
+		execute_make_event_choice(state, c.source, c.data.pending_human_p_event);
+		break;
+	case command_type::make_f_p_event_choice:
+		execute_make_event_choice(state, c.source, c.data.pending_human_f_p_event);
+		break;
+	case command_type::cancel_cb_fabrication:
+		execute_cancel_cb_fabrication(state, c.source);
+		break;
+	case command_type::fabricate_cb:
+		execute_fabricate_cb(state, c.source, c.data.cb_fabrication.target, c.data.cb_fabrication.type);
+		break;
+	case command_type::ask_for_military_access:
+		execute_ask_for_access(state, c.source, c.data.diplo_action.target);
+		break;
+	case command_type::ask_for_alliance:
+		execute_ask_for_alliance(state, c.source, c.data.diplo_action.target);
+		break;
+	case command_type::call_to_arms:
+		execute_call_to_arms(state, c.source, c.data.call_to_arms.target, c.data.call_to_arms.war);
+		break;
+	case command_type::respond_to_diplomatic_message:
+		execute_respond_to_diplomatic_message(state, c.source, c.data.message.from, c.data.message.type, c.data.message.accept);
+		break;
+	case command_type::cancel_military_access:
+		execute_cancel_military_access(state, c.source, c.data.diplo_action.target);
+		break;
+	case command_type::cancel_alliance:
+		execute_cancel_alliance(state, c.source, c.data.diplo_action.target);
+		break;
+	case command_type::cancel_given_military_access:
+		execute_cancel_given_military_access(state, c.source, c.data.diplo_action.target);
+		break;
+	case command_type::declare_war:
+		execute_declare_war(state, c.source, c.data.new_war.target, c.data.new_war.primary_cb, c.data.new_war.cb_state,
+				c.data.new_war.cb_tag, c.data.new_war.cb_secondary_nation, c.data.new_war.call_attacker_allies);
+		break;
+	case command_type::add_war_goal:
+		execute_add_war_goal(state, c.source, c.data.new_war_goal.war, c.data.new_war_goal.target, c.data.new_war_goal.cb_type,
+				c.data.new_war_goal.cb_state, c.data.new_war_goal.cb_tag, c.data.new_war_goal.cb_secondary_nation);
+		break;
+	case command_type::start_peace_offer:
+		execute_start_peace_offer(state, c.source, c.data.new_offer.target, c.data.new_offer.war,
+				c.data.new_offer.is_concession);
+		break;
+	case command_type::add_peace_offer_term:
+		execute_add_to_peace_offer(state, c.source, c.data.offer_wargoal.wg);
+		break;
+	case command_type::send_peace_offer:
+		execute_send_peace_offer(state, c.source);
+		break;
+	case command_type::move_army:
+		execute_move_army(state, c.source, c.data.army_movement.a, c.data.army_movement.dest);
+		break;
+	case command_type::move_navy:
+		execute_move_navy(state, c.source, c.data.navy_movement.n, c.data.navy_movement.dest);
+		break;
+	case command_type::embark_army:
+		execute_embark_army(state, c.source, c.data.army_movement.a);
+		break;
+	case command_type::merge_armies:
+		execute_merge_armies(state, c.source, c.data.merge_army.a, c.data.merge_army.b);
+		break;
+	case command_type::merge_navies:
+		execute_merge_navies(state, c.source, c.data.merge_navy.a, c.data.merge_navy.b);
+		break;
+	case command_type::split_army:
+		execute_split_army(state, c.source, c.data.army_movement.a);
+		break;
+	case command_type::split_navy:
+		execute_split_navy(state, c.source, c.data.navy_movement.n);
+		break;
+	case command_type::delete_army:
+		execute_delete_army(state, c.source, c.data.army_movement.a);
+		break;
+	case command_type::delete_navy:
+		execute_delete_navy(state, c.source, c.data.navy_movement.n);
+		break;
+	case command_type::designate_split_regiments:
+		execute_mark_regiments_to_split(state, c.source, c.data.split_regiments.regs);
+		break;
+	case command_type::designate_split_ships:
+		execute_mark_ships_to_split(state, c.source, c.data.split_ships.ships);
+		break;
+	case command_type::naval_retreat:
+		execute_retreat_from_naval_battle(state, c.source, c.data.naval_battle.b);
+		break;
+	case command_type::land_retreat:
+		execute_retreat_from_land_battle(state, c.source, c.data.land_battle.b);
+		break;
+	case command_type::start_crisis_peace_offer:
+		execute_start_crisis_peace_offer(state, c.source, c.data.new_offer.is_concession);
+		break;
+	case command_type::invite_to_crisis:
+		execute_invite_to_crisis(state, c.source, c.data.crisis_invitation);
+		break;
+	case command_type::add_wargoal_to_crisis_offer:
+		execute_add_to_crisis_peace_offer(state, c.source, c.data.crisis_invitation);
+		break;
+	case command_type::send_crisis_peace_offer:
+		execute_send_crisis_peace_offer(state, c.source);
+		break;
+	case command_type::change_admiral:
+		execute_change_admiral(state, c.source, c.data.new_admiral.a, c.data.new_admiral.l);
+		break;
+	case command_type::change_general:
+		execute_change_general(state, c.source, c.data.new_general.a, c.data.new_general.l);
+		break;
+	case command_type::toggle_mobilization:
+		execute_toggle_mobilization(state, c.source);
+		break;
+	case command_type::give_military_access:
+		execute_give_military_access(state, c.source, c.data.diplo_action.target);
+		break;
+	case command_type::set_rally_point:
+		execute_set_rally_point(state, c.source, c.data.rally_point.location, c.data.rally_point.naval, c.data.rally_point.enable);
+		break;
+	case command_type::save_game:
+		execute_save_game(state, c.source, c.data.save_game.and_quit);
+		break;
+	case command_type::cancel_factory_building_construction:
+		execute_cancel_factory_building_construction(state, c.source, c.data.start_factory_building.location, c.data.start_factory_building.type);
+		break;
+	case command_type::disband_undermanned:
+		execute_disband_undermanned_regiments(state, c.source, c.data.army_movement.a);
+		break;
+	case command_type::even_split_army:
+		execute_evenly_split_army(state, c.source, c.data.army_movement.a);
+		break;
+	case command_type::even_split_navy:
+		execute_evenly_split_navy(state, c.source, c.data.navy_movement.n);
+		break;
 
-			// common mp commands
-		case command_type::chat_message:
-		{
-			size_t count = 0;
-			for(count = 0; count < sizeof(c.data.chat_message.body); count++)
-				if(c.data.chat_message.body[count] == '\0')
-					break;
-			std::string_view sv(c.data.chat_message.body, count);
-			execute_chat_message(state, c.source, sv, c.data.chat_message.target);
-			break;
-		}
-		case command_type::notify_player_ban:
-			execute_notify_player_ban(state, c.source, c.data.nation_pick.target);
-			break;
-		case command_type::notify_player_kick:
-			execute_notify_player_kick(state, c.source, c.data.nation_pick.target);
-			break;
-		case command_type::notify_player_joins:
-			execute_notify_player_joins(state, c.source);
-			break;
-		case command_type::notify_player_leaves:
-			execute_notify_player_leaves(state, c.source);
-			break;
-		case command_type::notify_player_picks_nation:
-			execute_notify_player_picks_nation(state, c.source, c.data.nation_pick.target);
-			break;
-		case command_type::advance_tick:
-			state.single_game_tick();
-			break;
+		// common mp commands
+	case command_type::chat_message:
+	{
+		size_t count = 0;
+		for(count = 0; count < sizeof(c.data.chat_message.body); count++)
+			if(c.data.chat_message.body[count] == '\0')
+				break;
+		std::string_view sv(c.data.chat_message.body, c.data.chat_message.body + count);
+		execute_chat_message(state, c.source, c.data.chat_message.body, c.data.chat_message.target);
+		break;
+	}
+	case command_type::notify_player_ban:
+		execute_notify_player_ban(state, c.source, c.data.nation_pick.target);
+		break;
+	case command_type::notify_player_kick:
+		execute_notify_player_kick(state, c.source, c.data.nation_pick.target);
+		break;
+	case command_type::notify_player_joins:
+		execute_notify_player_joins(state, c.source);
+		break;
+	case command_type::notify_player_leaves:
+		execute_notify_player_leaves(state, c.source);
+		break;
+	case command_type::notify_player_picks_nation:
+		execute_notify_player_picks_nation(state, c.source, c.data.nation_pick.target);
+		break;
+	case command_type::advance_tick:
+		execute_advance_tick(state, c.source, c.data.advance_tick.checksum);
+		break;
+	case command_type::update_session_info:
+		execute_update_session_info(state, c.source, c.data.update_session_info.seed, c.data.update_session_info.checksum);
+		break;
 
-			// console commands
-		case command_type::switch_nation:
-			execute_switch_nation(state, c.source, c.data.tag_target.ident);
-			break;
-		case command_type::c_change_diplo_points:
-			execute_c_change_diplo_points(state, c.source, c.data.cheat.value);
-			break;
-		case command_type::c_change_money:
-			execute_c_change_money(state, c.source, c.data.cheat.value);
-			break;
-		case command_type::c_westernize:
-			execute_c_westernize(state, c.source);
-			break;
-		case command_type::c_unwesternize:
-			execute_c_unwesternize(state, c.source);
-			break;
-		case command_type::c_change_research_points:
-			execute_c_change_research_points(state, c.source, c.data.cheat.value);
-			break;
-		case command_type::c_change_cb_progress:
-			execute_c_change_cb_progress(state, c.source, c.data.cheat.value);
-			break;
-		case command_type::c_change_infamy:
-			execute_c_change_infamy(state, c.source, c.data.cheat.value);
-			break;
-		case command_type::c_force_crisis:
-			execute_c_force_crisis(state, c.source);
-			break;
-		case command_type::c_change_national_militancy:
-			execute_c_change_national_militancy(state, c.source, c.data.cheat.value);
-			break;
-		case command_type::c_end_game:
-			execute_c_end_game(state, c.source);
-			break;
-		case command_type::c_event:
-			execute_c_event(state, c.source, c.data.cheat_int.value);
-			break;
-		case command_type::c_event_as:
-			execute_c_event_as(state, c.source, c.data.cheat_event.as, c.data.cheat_event.value);
-			break;
+		// console commands
+	case command_type::switch_nation:
+		execute_switch_nation(state, c.source, c.data.tag_target.ident);
+		break;
+	case command_type::c_change_diplo_points:
+		execute_c_change_diplo_points(state, c.source, c.data.cheat.value);
+		break;
+	case command_type::c_change_money:
+		execute_c_change_money(state, c.source, c.data.cheat.value);
+		break;
+	case command_type::c_westernize:
+		execute_c_westernize(state, c.source);
+		break;
+	case command_type::c_unwesternize:
+		execute_c_unwesternize(state, c.source);
+		break;
+	case command_type::c_change_research_points:
+		execute_c_change_research_points(state, c.source, c.data.cheat.value);
+		break;
+	case command_type::c_change_cb_progress:
+		execute_c_change_cb_progress(state, c.source, c.data.cheat.value);
+		break;
+	case command_type::c_change_infamy:
+		execute_c_change_infamy(state, c.source, c.data.cheat.value);
+		break;
+	case command_type::c_force_crisis:
+		execute_c_force_crisis(state, c.source);
+		break;
+	case command_type::c_change_national_militancy:
+		execute_c_change_national_militancy(state, c.source, c.data.cheat.value);
+		break;
+	case command_type::c_end_game:
+		execute_c_end_game(state, c.source);
+		break;
+	case command_type::c_event:
+		execute_c_event(state, c.source, c.data.cheat_int.value);
+		break;
+	case command_type::c_event_as:
+		execute_c_event_as(state, c.source, c.data.cheat_event.as, c.data.cheat_event.value);
+		break;
 	}
 }
 

--- a/src/gamestate/commands.hpp
+++ b/src/gamestate/commands.hpp
@@ -94,7 +94,7 @@ enum class command_type : uint8_t {
 	disband_undermanned = 85,
 	even_split_army = 86,
 	even_split_navy = 87,
-	
+
 	notify_player_ban = 117,
 	notify_player_kick = 118,
 	notify_player_picks_nation = 119,
@@ -102,6 +102,7 @@ enum class command_type : uint8_t {
 	notify_player_leaves = 121,
 	advance_tick = 122,
 	chat_message = 123,
+	update_session_info = 124,
 
 	// console cheats
 	switch_nation = 128,
@@ -399,6 +400,15 @@ struct nation_pick_data {
 	dcon::nation_id target;
 };
 
+struct advance_tick_data {
+	sys::checksum_key checksum;
+};
+
+struct update_session_info_data {
+	uint32_t seed;
+	sys::checksum_key checksum;
+};
+
 struct payload {
 	union dtype {
 		national_focus_data nat_focus;
@@ -451,7 +461,9 @@ struct payload {
 		rally_point_data rally_point;
 		cheat_data_int cheat_int;
 		cheat_event_data cheat_event;
+		advance_tick_data advance_tick;
 		save_game_data save_game;
+		update_session_info_data update_session_info;
 
 		dtype() { }
 	} data;
@@ -464,6 +476,8 @@ struct payload {
 void save_game(sys::state& state, dcon::nation_id source, bool and_quit);
 
 void set_rally_point(sys::state& state, dcon::nation_id source, dcon::province_id location, bool naval, bool enable);
+
+bool is_console_command(command_type t);
 
 void set_national_focus(sys::state& state, dcon::nation_id source, dcon::state_instance_id target_state, dcon::national_focus_id focus);
 bool can_set_national_focus(sys::state& state, dcon::nation_id source, dcon::state_instance_id target_state, dcon::national_focus_id focus);
@@ -520,8 +534,8 @@ void increase_relations(sys::state& state, dcon::nation_id source, dcon::nation_
 bool can_increase_relations(sys::state& state, dcon::nation_id source, dcon::nation_id target);
 
 inline budget_settings_data make_empty_budget_settings() {
-	return budget_settings_data{int8_t(-127), int8_t(-127), int8_t(-127), int8_t(-127), int8_t(-127), int8_t(-127), int8_t(-127),
-			int8_t(-127), int8_t(-127), int8_t(-127), int8_t(-127)};
+	return budget_settings_data{ int8_t(-127), int8_t(-127), int8_t(-127), int8_t(-127), int8_t(-127), int8_t(-127), int8_t(-127),
+			int8_t(-127), int8_t(-127), int8_t(-127), int8_t(-127) };
 }
 // when sending new budget settings, leaving any value as int8_t(-127) will cause it to be ignored, leaving the setting the same
 // You can use the function above to easily make an instance of the settings struct that will change no values
@@ -755,6 +769,8 @@ void notify_player_leaves(sys::state& state, dcon::nation_id source);
 bool can_notify_player_leaves(sys::state& state, dcon::nation_id source);
 void notify_player_picks_nation(sys::state& state, dcon::nation_id source, dcon::nation_id target);
 bool can_notify_player_picks_nation(sys::state& state, dcon::nation_id source, dcon::nation_id target);
+
+void update_session_info(sys::state& state, dcon::nation_id source);
 
 void switch_nation(sys::state& state, dcon::nation_id source, dcon::national_identity_id t);
 bool can_switch_nation(sys::state& state, dcon::nation_id source, dcon::national_identity_id t);

--- a/src/gamestate/serialization.cpp
+++ b/src/gamestate/serialization.cpp
@@ -782,7 +782,6 @@ void write_scenario_file(sys::state& state, native_string_view name, uint32_t co
 	scenario_header header;
 	header.count = count;
 	header.timestamp = uint64_t(std::time(nullptr));
-	header.checksum = state.get_network_checksum();
 
 	size_t scenario_space = sizeof_scenario_section(state);
 	size_t save_space = sizeof_save_section(state);
@@ -805,6 +804,11 @@ void write_scenario_file(sys::state& state, native_string_view name, uint32_t co
 	auto last_written = write_scenario_section(temp_scenario_buffer, state);
 	auto last_written_count = last_written - temp_scenario_buffer;
 	assert(size_t(last_written_count) == scenario_space);
+
+	// calculate checksum
+	checksum_key* checksum = &reinterpret_cast<scenario_header*>(temp_buffer)->checksum;
+	blake2b(checksum, sizeof(*checksum), temp_scenario_buffer, scenario_space, nullptr, 0);
+
 	buffer_position = write_compressed_section(buffer_position, temp_scenario_buffer, uint32_t(scenario_space));
 	delete[] temp_scenario_buffer;
 

--- a/src/gamestate/system_state.cpp
+++ b/src/gamestate/system_state.cpp
@@ -3384,10 +3384,23 @@ void state::single_game_tick() {
 	}
 }
 
-sys::checksum_key state::get_network_checksum() {
+sys::checksum_key state::get_save_checksum() {
 	auto buffer = std::unique_ptr<uint8_t[]>(new uint8_t[sizeof_save_section(*this)]);
-
 	dcon::load_record loaded = world.make_serialize_record_store_save();
+	std::byte* start = reinterpret_cast<std::byte*>(buffer.get());
+	world.serialize(start, loaded);
+
+	auto buffer_position = reinterpret_cast<uint8_t*>(start);
+	int32_t total_size_used = static_cast<int32_t>(buffer_position - buffer.get());
+
+	checksum_key key;
+	blake2b(&key, sizeof(key), buffer.get(), total_size_used, nullptr, 0);
+	return key;
+}
+
+sys::checksum_key state::get_scenario_checksum() {
+	auto buffer = std::unique_ptr<uint8_t[]>(new uint8_t[sizeof_scenario_section(*this)]);
+	dcon::load_record loaded = world.make_serialize_record_store_scenario();
 	std::byte* start = reinterpret_cast<std::byte*>(buffer.get());
 	world.serialize(start, loaded);
 

--- a/src/gamestate/system_state.hpp
+++ b/src/gamestate/system_state.hpp
@@ -566,7 +566,8 @@ struct alignas(64) state {
 	void single_game_tick();
 	// this function runs the internal logic of the game. It will return *only* after a quit notification is sent to it
 	void game_loop();
-	sys::checksum_key get_network_checksum();
+	sys::checksum_key get_save_checksum();
+	sys::checksum_key get_scenario_checksum();
 
 	// the following function are for interacting with the string pool
 

--- a/src/gamestate/system_state.hpp
+++ b/src/gamestate/system_state.hpp
@@ -428,6 +428,7 @@ struct alignas(64) state {
 	uint64_t scenario_time_stamp = 0;	// for identifying the scenario file
 	uint32_t scenario_counter = 0;		// as above
 	sys::checksum_key scenario_checksum;// for checksum for savefiles
+	sys::checksum_key session_host_checksum;// for checking that the client can join a session
 	native_string loaded_scenario_file;
 	native_string loaded_save_file;
 

--- a/src/gui/gui_chat_window.hpp
+++ b/src/gui/gui_chat_window.hpp
@@ -78,7 +78,8 @@ public:
 	void on_update(sys::state& state) noexcept override {
 		row_contents.clear();
 		for(auto const& c : state.ui_state.chat_messages)
-			row_contents.push_back(c);
+			if(c.source)
+				row_contents.push_back(c);
 		update(state);
 	}
 };
@@ -149,7 +150,7 @@ public:
 			});
 		}
 
-		char body[max_chat_message_len];
+		char body[max_chat_message_len + 1];
 		size_t len = s.length() >= max_chat_message_len ? max_chat_message_len : s.length();
 		memcpy(body, s.data(), len);
 		body[len] = '\0';

--- a/src/gui/gui_nation_picker.hpp
+++ b/src/gui/gui_nation_picker.hpp
@@ -463,7 +463,7 @@ public:
 		disabled = !bool(state.local_player_nation);
 		// can't start if checksum doesn't match
 		if(state.network_mode == sys::network_mode_type::client)
-			disabled = disabled || !state.session_host_checksum.is_equal(state.get_network_checksum());
+			disabled = disabled || !state.session_host_checksum.is_equal(state.get_save_checksum());
 	}
 
 	tooltip_behavior has_tooltip(sys::state& state) noexcept override {
@@ -471,7 +471,7 @@ public:
 	}
 
 	void update_tooltip(sys::state& state, int32_t x, int32_t y, text::columnar_layout& contents) noexcept override {
-		if(state.network_mode == sys::network_mode_type::client && !state.session_host_checksum.is_equal(state.get_network_checksum())) {
+		if(state.network_mode == sys::network_mode_type::client && !state.session_host_checksum.is_equal(state.get_save_checksum())) {
 			auto box = text::open_layout_box(contents, 0);
 			text::localised_format_box(state, contents, box, std::string_view("alice_play_checksum_host"));
 			text::close_layout_box(contents, box);

--- a/src/gui/gui_nation_picker.hpp
+++ b/src/gui/gui_nation_picker.hpp
@@ -88,12 +88,21 @@ class select_save_game : public button_element_base {
 public:
 	void button_action(sys::state& state) noexcept override {
 		save_item* i = retrieve< save_item*>(state, parent);
+
+		std::vector<dcon::nation_id> players;
+		for(const auto n : state.world.in_nation)
+			if(state.world.nation_get_is_player_controlled(n))
+				players.push_back(n);
+		dcon::nation_id old_local_player_nation = state.local_player_nation;
+
 		if(i->is_new_game) {
 			if(!sys::try_read_scenario_as_save_file(state, state.loaded_scenario_file)) {
 				auto msg = std::string("Scenario file ") + simple_fs::native_to_utf8(state.loaded_scenario_file) + " could not be loaded.";
 				window::emit_error_message(msg, false);
 			} else {
 				state.fill_unsaved_data();
+				if(state.network_mode == sys::network_mode_type::host)
+					command::update_session_info(state, state.local_player_nation);
 			}
 		} else {
 			if(!sys::try_read_save_file(state, i->file_name)) {
@@ -101,7 +110,17 @@ public:
 				window::emit_error_message(msg, false);
 			} else {
 				state.fill_unsaved_data();
+				if(state.network_mode == sys::network_mode_type::host)
+					command::update_session_info(state, state.local_player_nation);
 			}
+		}
+		// do not desync the local player nation upon selection of savefile
+		if(state.network_mode != sys::network_mode_type::single_player) {
+			state.local_player_nation = old_local_player_nation;
+			for(const auto n : state.world.in_nation)
+				state.world.nation_set_is_player_controlled(n, false);
+			for(const auto n : players)
+				state.world.nation_set_is_player_controlled(n, true);
 		}
 		state.game_state_updated.store(true, std::memory_order_release);
 	}
@@ -116,8 +135,7 @@ protected:
 	GLuint flag_texture_handle = 0;
 	bool visible = false;
 public:
-	void button_action(sys::state& state) noexcept override {
-	}
+	void button_action(sys::state& state) noexcept override { }
 
 
 	void on_update(sys::state& state) noexcept  override {
@@ -349,26 +367,26 @@ public:
 		}
 		auto s = retrieve<picker_sort>(state, parent);
 		switch(s) {
-			case picker_sort::name:
-				std::sort(row_contents.begin(), row_contents.end(), [&](dcon::nation_id a, dcon::nation_id b) {
-					return text::get_name_as_string(state, fatten(state.world, a)) < text::get_name_as_string(state, fatten(state.world, b));
-				});
-				break;
-			case picker_sort::mil_rank:
-				std::sort(row_contents.begin(), row_contents.end(), [&](dcon::nation_id a, dcon::nation_id b) {
-					return state.world.nation_get_military_rank(a) < state.world.nation_get_military_rank(b);
-				});
-				break;
-			case picker_sort::indust_rank:
-				std::sort(row_contents.begin(), row_contents.end(), [&](dcon::nation_id a, dcon::nation_id b) {
-					return state.world.nation_get_industrial_rank(a) < state.world.nation_get_industrial_rank(b);
-				});
-				break;
-			case picker_sort::p_rank:
-				std::sort(row_contents.begin(), row_contents.end(), [&](dcon::nation_id a, dcon::nation_id b) {
-					return state.world.nation_get_prestige_rank(a) < state.world.nation_get_prestige_rank(b);
-				});
-				break;
+		case picker_sort::name:
+			std::sort(row_contents.begin(), row_contents.end(), [&](dcon::nation_id a, dcon::nation_id b) {
+				return text::get_name_as_string(state, fatten(state.world, a)) < text::get_name_as_string(state, fatten(state.world, b));
+			});
+			break;
+		case picker_sort::mil_rank:
+			std::sort(row_contents.begin(), row_contents.end(), [&](dcon::nation_id a, dcon::nation_id b) {
+				return state.world.nation_get_military_rank(a) < state.world.nation_get_military_rank(b);
+			});
+			break;
+		case picker_sort::indust_rank:
+			std::sort(row_contents.begin(), row_contents.end(), [&](dcon::nation_id a, dcon::nation_id b) {
+				return state.world.nation_get_industrial_rank(a) < state.world.nation_get_industrial_rank(b);
+			});
+			break;
+		case picker_sort::p_rank:
+			std::sort(row_contents.begin(), row_contents.end(), [&](dcon::nation_id a, dcon::nation_id b) {
+				return state.world.nation_get_prestige_rank(a) < state.world.nation_get_prestige_rank(b);
+			});
+			break;
 		}
 		update(state);
 	}
@@ -443,6 +461,21 @@ public:
 	}
 	void on_update(sys::state& state) noexcept override {
 		disabled = !bool(state.local_player_nation);
+		// can't start if checksum doesn't match
+		if(state.network_mode == sys::network_mode_type::client)
+			disabled = disabled || !state.session_host_checksum.is_equal(state.get_network_checksum());
+	}
+
+	tooltip_behavior has_tooltip(sys::state& state) noexcept override {
+		return tooltip_behavior::variable_tooltip;
+	}
+
+	void update_tooltip(sys::state& state, int32_t x, int32_t y, text::columnar_layout& contents) noexcept override {
+		if(state.network_mode == sys::network_mode_type::client && !state.session_host_checksum.is_equal(state.get_network_checksum())) {
+			auto box = text::open_layout_box(contents, 0);
+			text::localised_format_box(state, contents, box, std::string_view("alice_play_checksum_host"));
+			text::close_layout_box(contents, box);
+		}
 	}
 };
 


### PR DESCRIPTION
- fix chat message crash when long message
- improve multiplayer handling of savefiles (on nation picker, "PLAY" button will be greyed out if checksum doesn't match)
- provide checksumming everytime a save is loaded or when a client connects so we dont enter into an invalid game state that breaks everything

rationale for having two checksums:
1. is for scenario, scenario checks for savefiles and whatnot
2. the other is for the session, meant to be to check if a client can interact with the game state of a host properly