### PR TITLE
UI accomodations for VU fork

### DIFF
--- a/src/common_types/constants.hpp
+++ b/src/common_types/constants.hpp
@@ -173,7 +173,7 @@ enum class autosave_frequency : uint8_t {
 	daily = 3,
 };
 
-enum class commodity_group : uint8_t { military_goods = 0, raw_material_goods, industrial_goods, consumer_goods, count };
+enum class commodity_group : uint8_t { military_goods = 0, raw_material_goods, industrial_goods, consumer_goods, industrial_and_consumer_goods, count };
 
 enum class message_setting_type : uint8_t {
 	revolt = 0, // added

--- a/src/gui/gui_element_types.cpp
+++ b/src/gui/gui_element_types.cpp
@@ -1843,9 +1843,11 @@ void scrollbar::on_create(sys::state& state) noexcept {
 		auto step = base_data.data.scrollbar.get_step_size();
 		settings.scaling_factor = 1;
 		switch(step) {
-		case step_size::one:
+		case step_size::twenty_five:
 			break;
 		case step_size::two:
+			break;
+		case step_size::one:
 			break;
 		case step_size::one_tenth:
 			settings.scaling_factor = 10;
@@ -1897,7 +1899,9 @@ void scrollbar::on_create(sys::state& state) noexcept {
 				add_child_to_back(std::move(ch_res));
 
 				settings.buttons_size = settings.vertical ? left->base_data.size.y : left->base_data.size.x;
-				if(step_size::two == step)
+				if(step_size::twenty_five == step)
+					left->step_size = 25;
+				else if(step_size::two == step)
 					left->step_size = 2;
 				else
 					left->step_size = 1;
@@ -1908,7 +1912,9 @@ void scrollbar::on_create(sys::state& state) noexcept {
 				right = ch_res.get();
 				add_child_to_back(std::move(ch_res));
 
-				if(step_size::two == step)
+				if(step_size::twenty_five == step)
+					right->step_size = 25;
+				else if(step_size::two == step)
 					right->step_size = 2;
 				else
 					right->step_size = 1;

--- a/src/gui/gui_graphics.hpp
+++ b/src/gui/gui_graphics.hpp
@@ -201,11 +201,13 @@ enum class step_size : uint8_t { // 2 bits
 	two = 0x01,
 	one_tenth = 0x02,
 	one_hundredth = 0x03,
-	one_thousandth = 0x04
+	one_thousandth = 0x04,
+	// Non-vanilla
+	twenty_five = 0x40
 };
 
 struct scrollbar_data {
-	static constexpr uint8_t step_size_mask = 0x07;
+	static constexpr uint8_t step_size_mask = 0x47;
 	static constexpr uint8_t is_range_limited_mask = 0x08;
 	static constexpr uint8_t is_lockable_mask = 0x10;
 	static constexpr uint8_t is_horizontal_mask = 0x20;

--- a/src/gui/gui_topbar.hpp
+++ b/src/gui/gui_topbar.hpp
@@ -1966,7 +1966,8 @@ public:
 				if(sys::commodity_group(state.world.commodity_get_commodity_group(cid)) != sys::commodity_group::military_goods &&
 						sys::commodity_group(state.world.commodity_get_commodity_group(cid)) != sys::commodity_group::raw_material_goods &&
 						sys::commodity_group(state.world.commodity_get_commodity_group(cid)) != sys::commodity_group::industrial_goods &&
-						sys::commodity_group(state.world.commodity_get_commodity_group(cid)) != sys::commodity_group::consumer_goods)
+						sys::commodity_group(state.world.commodity_get_commodity_group(cid)) != sys::commodity_group::consumer_goods &&
+						sys::commodity_group(state.world.commodity_get_commodity_group(cid)) != sys::commodity_group::industrial_and_consumer_goods)
 					return;
 				float produced = state.world.nation_get_domestic_market_pool(state.local_player_nation, cid);
 				float consumed = state.world.nation_get_real_demand(state.local_player_nation, cid) *
@@ -2006,7 +2007,8 @@ public:
 				if(sys::commodity_group(state.world.commodity_get_commodity_group(cid)) != sys::commodity_group::military_goods &&
 						sys::commodity_group(state.world.commodity_get_commodity_group(cid)) != sys::commodity_group::raw_material_goods &&
 						sys::commodity_group(state.world.commodity_get_commodity_group(cid)) != sys::commodity_group::industrial_goods &&
-						sys::commodity_group(state.world.commodity_get_commodity_group(cid)) != sys::commodity_group::consumer_goods)
+						sys::commodity_group(state.world.commodity_get_commodity_group(cid)) != sys::commodity_group::consumer_goods &&
+						sys::commodity_group(state.world.commodity_get_commodity_group(cid)) != sys::commodity_group::industrial_and_consumer_goods)
 					return;
 				v.insert({state.world.nation_get_domestic_market_pool(state.local_player_nation, cid), cid.index()});
 			}

--- a/src/gui/topbar_subwindows/gui_production_window.hpp
+++ b/src/gui/topbar_subwindows/gui_production_window.hpp
@@ -1450,6 +1450,10 @@ public:
 			case sys::commodity_group::consumer_goods:
 				goods_cat_name->set_text(state, text::produce_simple_string(state, "consumer_goods"));
 				break;
+			// Non-vanilla
+			case sys::commodity_group::industrial_and_consumer_goods:
+				goods_cat_name->set_text(state, text::produce_simple_string(state, "industrial_and_consumer_goods"));
+				break;
 			default:
 				break;
 			}

--- a/src/gui/topbar_subwindows/gui_trade_window.hpp
+++ b/src/gui/topbar_subwindows/gui_trade_window.hpp
@@ -1140,6 +1140,9 @@ public:
 			auto ptr = make_element_by_type<trade_details_window>(state, id);
 			details_win = ptr.get();
 			return ptr;
+			// Non-vanila
+		} else if(name == "group_industrial_and_consumer_goods") {
+			return make_element_by_type<trade_commodity_group_window<sys::commodity_group::industrial_and_consumer_goods>>(state, id);
 		} else {
 			return nullptr;
 		}

--- a/src/gui/topbar_subwindows/politics_subwindows/gui_decision_window.hpp
+++ b/src/gui/topbar_subwindows/politics_subwindows/gui_decision_window.hpp
@@ -75,13 +75,16 @@ void produce_decision_substitutions(sys::state& state, text::substitution_map& m
 	text::add_to_substitution_map(m, text::variable_type::monarchtitle, state.world.government_type_get_ruler_name(state.world.nation_get_government_type(n)));
 }
 
-class decision_name : public simple_text_element_base {
+class decision_name : public multiline_text_element_base {
 public:
 	void on_update(sys::state& state) noexcept override {
 		auto id = retrieve<dcon::decision_id>(state, parent);
 		text::substitution_map m;
 		produce_decision_substitutions(state, m, state.local_player_nation);
-		set_text(state, text::resolve_string_substitution(state, state.world.decision_get_name(id), m));
+		auto contents = text::create_endless_layout(internal_layout, text::layout_parameters{ 0, 0, static_cast<int16_t>(base_data.size.x), static_cast<int16_t>(base_data.size.y), base_data.data.text.font_handle, 0, text::alignment::right, text::text_color::white, true });
+		auto box = text::open_layout_box(contents);
+		text::add_to_layout_box(state, contents, box, state.world.decision_get_name(id), m);
+		text::close_layout_box(contents, box);
 	}
 };
 

--- a/src/gui/topbar_subwindows/politics_subwindows/gui_decision_window.hpp
+++ b/src/gui/topbar_subwindows/politics_subwindows/gui_decision_window.hpp
@@ -81,7 +81,7 @@ public:
 		auto id = retrieve<dcon::decision_id>(state, parent);
 		text::substitution_map m;
 		produce_decision_substitutions(state, m, state.local_player_nation);
-		auto contents = text::create_endless_layout(internal_layout, text::layout_parameters{ 0, 0, static_cast<int16_t>(base_data.size.x), static_cast<int16_t>(base_data.size.y), base_data.data.text.font_handle, 0, text::alignment::right, text::text_color::white, true });
+		auto contents = text::create_endless_layout(internal_layout, text::layout_parameters{ 0, 0, static_cast<int16_t>(base_data.size.x), static_cast<int16_t>(base_data.size.y), base_data.data.text.font_handle, 0, text::alignment::left, text::text_color::white, true });
 		auto box = text::open_layout_box(contents);
 		text::add_to_layout_box(state, contents, box, state.world.decision_get_name(id), m);
 		text::close_layout_box(contents, box);

--- a/src/parsing/econ_parsing.cpp
+++ b/src/parsing/econ_parsing.cpp
@@ -27,6 +27,10 @@ void make_goods_group(std::string_view name, token_generator& gen, error_handler
 	} else if(name == "consumer_goods") {
 		good_group_context new_context{sys::commodity_group::consumer_goods, context};
 		parse_goods_group(gen, err, new_context);
+	// Non-vanilla
+	} else if(name == "industrial_and_consumer_goods") {
+		good_group_context new_context{ sys::commodity_group::industrial_and_consumer_goods, context };
+		parse_goods_group(gen, err, new_context);
 	} else {
 		err.accumulated_errors += "Unknown goods category " + std::string(name) + " found in " + err.file_name + "\n";
 		good_group_context new_context{sys::commodity_group::military_goods, context};

--- a/src/parsing/gui_graphics_parsers.cpp
+++ b/src/parsing/gui_graphics_parsers.cpp
@@ -632,6 +632,9 @@ void scrollbar::stepsize(association_type, std::string_view t, error_handler& er
 		target.data.scrollbar.flags |= uint8_t(ui::step_size::one_hundredth);
 	} else if(is_fixed_token_ci(t.data(), t.data() + t.length(), "0.001")) {
 		target.data.scrollbar.flags |= uint8_t(ui::step_size::one_thousandth);
+	//	Non vanilla accomodation
+	} else if(is_fixed_token_ci(t.data(), t.data() + t.length(), "25")) {
+		target.data.scrollbar.flags |= uint8_t(ui::step_size::twenty_five);
 	} else {
 		err.accumulated_errors += "tried to parse  " + std::string(t) + " as a step size on line " + std::to_string(line) +
 															" of file " + err.file_name + "\n";


### PR DESCRIPTION
- add industrial_and_consumer_goods commodity group
- respective UI accomodations for said category
- scaling factor of "25" added, using an unused bit of the scrollbar flags to not interfere with existing infrastructure
- decision names can now come in colours (HPMP outlined a red decision btw!) and a lot of mods use this colouring too!