### PR TITLE
fix decision pictures not getting shewn

### DIFF
--- a/src/parsing/nations_parsing.cpp
+++ b/src/parsing/nations_parsing.cpp
@@ -826,7 +826,6 @@ void make_decision(std::string_view name, token_generator& gen, error_handler& e
 	auto gfx = open_directory(root, NATIVE("gfx"));
 	auto pictures = open_directory(gfx, NATIVE("pictures"));
 	auto decisions = open_directory(pictures, NATIVE("decisions"));
-
 	std::string file_name = simple_fs::remove_double_backslashes(std::string("gfx\\pictures\\decisions\\") + [&]() {
 		if(peek_file(decisions, simple_fs::utf8_to_native(name) + NATIVE(".dds"))) {
 			return std::string(name) + ".tga";
@@ -834,7 +833,6 @@ void make_decision(std::string_view name, token_generator& gen, error_handler& e
 			return std::string("noimage.tga");
 		}
 	}());
-
 	if(auto it = context.gfx_context.map_of_names.find(file_name); it != context.gfx_context.map_of_names.end()) {
 		context.state.world.decision_set_image(new_decision, it->second);
 	} else {

--- a/src/parsing/parser_defs.txt
+++ b/src/parsing/parser_defs.txt
@@ -1797,7 +1797,7 @@ decision
 	news_title                              value      text                              discard
 	news_picture                              value      text                              discard
 	alert                           value      bool                              discard
-	picture                         value      text                              discard
+	picture                         value      text                              member_fn
 
 decision_list
 	#any                            extern     make_decision                     discard

--- a/src/parsing/parsers_declarations.hpp
+++ b/src/parsing/parsers_declarations.hpp
@@ -2122,6 +2122,7 @@ struct decision {
 	void allow(dcon::trigger_key value, error_handler& err, int32_t line, decision_context& context);
 	void effect(dcon::effect_key value, error_handler& err, int32_t line, decision_context& context);
 	void ai_will_do(dcon::value_modifier_key value, error_handler& err, int32_t line, decision_context& context);
+	void picture(association_type, std::string_view value, error_handler& err, int32_t line, decision_context& context);
 };
 struct decision_list {
 	void finish(scenario_building_context&) { }


### PR DESCRIPTION
so we have decision "utility_dec", so alice searches for "utility_dec" but, sike! it doesn't have a picture, so it defaults to noimage.tga,

ok so, what happens when a bunch of decisions have this image? you start to get suspicious of the behaviour, so you start investigating and, what? you find that the picture field of decisions is ignored on parsing, sus amongus

now the sussy baka is found, it is time for emergency meeting to oust the imposter, so we find, it indeed, `picture = cogs_blue`, and what do we find? cogs_blue.tga, AHA!!! so now we found the amongus crewmate imposter, we found it we are the sussiest baka ever

now after we finally realize that decision images are broken, we fix them and then the imposter is gone and the sussy baka is restored