### PR TITLE
support spreaded diplomacy files

### DIFF
--- a/src/gamestate/system_state.cpp
+++ b/src/gamestate/system_state.cpp
@@ -2631,38 +2631,13 @@ void state::load_scenario_data(parsers::error_handler& err) {
 	}
 	// parse diplomacy history
 	{
-		auto diplomacy = open_directory(history, NATIVE("diplomacy"));
-		{
-			auto dip_file = open_file(diplomacy, NATIVE("Alliances.txt"));
+		auto diplomacy_dir = open_directory(history, NATIVE("diplomacy"));
+		for(auto dip_file : list_files(diplomacy_dir, NATIVE(".txt"))) {
 			if(dip_file) {
 				auto content = view_contents(*dip_file);
-				err.file_name = "Alliances.txt";
+				err.file_name = simple_fs::native_to_utf8(simple_fs::get_full_name(*dip_file));
 				parsers::token_generator gen(content.data, content.data + content.file_size);
-				parsers::parse_alliance_file(gen, err, context);
-			} else {
-				err.accumulated_errors += "File history/diplomacy/Alliances.txt could not be opened\n";
-			}
-		}
-		{
-			auto dip_file = open_file(diplomacy, NATIVE("PuppetStates.txt"));
-			if(dip_file) {
-				auto content = view_contents(*dip_file);
-				err.file_name = "PuppetStates.txt";
-				parsers::token_generator gen(content.data, content.data + content.file_size);
-				parsers::parse_puppets_file(gen, err, context);
-			} else {
-				err.accumulated_errors += "File history/diplomacy/PuppetStates.txt could not be opened\n";
-			}
-		}
-		{
-			auto dip_file = open_file(diplomacy, NATIVE("Unions.txt"));
-			if(dip_file) {
-				auto content = view_contents(*dip_file);
-				err.file_name = "Unions.txt";
-				parsers::token_generator gen(content.data, content.data + content.file_size);
-				parsers::parse_union_file(gen, err, context);
-			} else {
-				err.accumulated_errors += "File history/diplomacy/Unions.txt could not be opened\n";
+				parsers::parse_diplomacy_file(gen, err, context);
 			}
 		}
 	}

--- a/src/gamestate/system_state.cpp
+++ b/src/gamestate/system_state.cpp
@@ -2633,9 +2633,10 @@ void state::load_scenario_data(parsers::error_handler& err) {
 	{
 		auto diplomacy_dir = open_directory(history, NATIVE("diplomacy"));
 		for(auto dip_file : list_files(diplomacy_dir, NATIVE(".txt"))) {
-			if(dip_file) {
-				auto content = view_contents(*dip_file);
-				err.file_name = simple_fs::native_to_utf8(simple_fs::get_full_name(*dip_file));
+			auto opened_file = open_file(dip_file);
+			if(opened_file) {
+				auto content = view_contents(*opened_file);
+				err.file_name = simple_fs::native_to_utf8(simple_fs::get_full_name(*opened_file));
 				parsers::token_generator gen(content.data, content.data + content.file_size);
 				parsers::parse_diplomacy_file(gen, err, context);
 			}

--- a/src/parsing/parser_defs.txt
+++ b/src/parsing/parser_defs.txt
@@ -1929,13 +1929,9 @@ vassal_description
 	end_date                        value      date                              discard
 	start_date                      value      date                              member_fn
 
-alliance_file
+diplomacy_file
 	alliance                        extern     make_alliance                     discard
-
-union_file
 	union                           extern     make_vassal                       discard
-
-puppets_file
 	substate                        extern     make_substate                     discard
 	vassal                          extern     make_vassal                       discard
 

--- a/src/parsing/parsers_declarations.hpp
+++ b/src/parsing/parsers_declarations.hpp
@@ -2425,13 +2425,7 @@ struct vassal_description {
 	void start_date(association_type, sys::year_month_day ymd, error_handler& err, int32_t line, scenario_building_context& context);
 };
 
-struct alliance_file {
-	void finish(scenario_building_context&) { }
-};
-struct union_file {
-	void finish(scenario_building_context&) { }
-};
-struct puppets_file {
+struct diplomacy_file {
 	void finish(scenario_building_context&) { }
 };
 

--- a/tests/scenario_building.cpp
+++ b/tests/scenario_building.cpp
@@ -1179,9 +1179,10 @@ TEST_CASE("Scenario building", "[req-game-files]") {
 	{
 		auto diplomacy_dir = open_directory(history, NATIVE("diplomacy"));
 		for(auto dip_file : list_files(diplomacy_dir, NATIVE(".txt"))) {
-			if(dip_file) {
-				auto content = view_contents(*dip_file);
-				err.file_name = simple_fs::native_to_utf8(simple_fs::get_full_name(*dip_file));
+			auto opened_file = open_file(dip_file);
+			if(opened_file) {
+				auto content = view_contents(*opened_file);
+				err.file_name = simple_fs::native_to_utf8(simple_fs::get_full_name(*opened_file));
 				parsers::token_generator gen(content.data, content.data + content.file_size);
 				parsers::parse_diplomacy_file(gen, err, context);
 			}

--- a/tests/scenario_building.cpp
+++ b/tests/scenario_building.cpp
@@ -1177,38 +1177,13 @@ TEST_CASE("Scenario building", "[req-game-files]") {
 
 	// parse diplomacy history
 	{
-		auto diplomacy = open_directory(history, NATIVE("diplomacy"));
-		{
-			auto dip_file = open_file(diplomacy, NATIVE("Alliances.txt"));
-			if (dip_file) {
+		auto diplomacy_dir = open_directory(history, NATIVE("diplomacy"));
+		for(auto dip_file : list_files(diplomacy_dir, NATIVE(".txt"))) {
+			if(dip_file) {
 				auto content = view_contents(*dip_file);
-				err.file_name = "Alliances.txt";
+				err.file_name = simple_fs::native_to_utf8(simple_fs::get_full_name(*dip_file));
 				parsers::token_generator gen(content.data, content.data + content.file_size);
-				parsers::parse_alliance_file(gen, err, context);
-			} else {
-				err.accumulated_errors += "File history/diplomacy/Alliances.txt could not be opened\n";
-			}
-		}
-		{
-			auto dip_file = open_file(diplomacy, NATIVE("PuppetStates.txt"));
-			if (dip_file) {
-				auto content = view_contents(*dip_file);
-				err.file_name = "PuppetStates.txt";
-				parsers::token_generator gen(content.data, content.data + content.file_size);
-				parsers::parse_puppets_file(gen, err, context);
-			} else {
-				err.accumulated_errors += "File history/diplomacy/PuppetStates.txt could not be opened\n";
-			}
-		}
-		{
-			auto dip_file = open_file(diplomacy, NATIVE("Unions.txt"));
-			if (dip_file) {
-				auto content = view_contents(*dip_file);
-				err.file_name = "Unions.txt";
-				parsers::token_generator gen(content.data, content.data + content.file_size);
-				parsers::parse_union_file(gen, err, context);
-			} else {
-				err.accumulated_errors += "File history/diplomacy/Unions.txt could not be opened\n";
+				parsers::parse_diplomacy_file(gen, err, context);
 			}
 		}
 


### PR DESCRIPTION
supports diplomacy files like `history/diplomacy/Japan.txt` yknow, since, yknow, HFM, and HPM, yknow