### PR TITLE
Gaussian blur map filter

### DIFF
--- a/assets/alice.csv
+++ b/assets/alice.csv
@@ -19,6 +19,7 @@ effect_volume_label;Sound effect volume;;;Volumen de los efectos de sonido;;;;;;
 fonts_label;Classic fonts;;;Letra clasica;;;;;;;;;x
 tooltip_mode_label;Floating tooltip;;;;;;;;;;;;x
 music_player;Music player;;;Reproductor de musica;;;;;;;;;x
+gaussianblur_label;Gaussian blur;;;Desenfoque guassian;;;;;;;;;x
 map_label;Map lettering;;;Letras del mapa;;;;;;;;;x
 map_label_0;None;;;Ninguna;;;;;;;;;x
 map_label_1;Linear;;;Linear;;;;;;;;;x

--- a/assets/alice.gui
+++ b/assets/alice.gui
@@ -122,7 +122,7 @@ guiTypes = {
 			# Use classic fonts (Y/N)
 			instantTextBoxType = {
 				name = "fonts_label"
-				position = { 78 140 }
+				position = { 194 116 }
 				text = "fonts_label"
 				font = "Arial16"
 				borderSize = { 0 0}
@@ -132,13 +132,13 @@ guiTypes = {
 			}
 			guiButtonType = {
 				name = "fonts_checkbox"
-				position = { 51 139 }
+				position = { 167 115 }
 				quadTextureSprite = "GFX_checkbox_default"
 			}
 			# Fog of War (Y/N)
 			instantTextBoxType = {
 				name = "fow_label"
-				position = { 78 164 }
+				position = { 78 140 }
 				text = "fow_label"
 				font = "Arial16"
 				borderSize = { 0 0}
@@ -148,13 +148,13 @@ guiTypes = {
 			}
 			checkboxType = {
 				name = "fow_checkbox"
-				position = { 51 163 }
+				position = { 51 139 }
 				quadTextureSprite = "GFX_checkbox_default"
 			}
 			# Projection settings for the map: equirectangular, orthographic
 			instantTextBoxType = {
 				name = "projection_label"
-				position = { 58 188 }
+				position = { 58 164 }
 				font = "Arial16"
 				borderSize = { 0 0 }
 				maxsize = { 236 18 }
@@ -164,7 +164,7 @@ guiTypes = {
 			}
 			instantTextBoxType = {
 				name = "projection_value"
-				position = { 58 208 }
+				position = { 58 184 }
 				font = "Arial14"
 				borderSize = { 0 0 }
 				maxsize = { 236 18 }
@@ -173,17 +173,17 @@ guiTypes = {
 			}
 			guiButtonType = {
 				name = "projection_left"
-				position = { 51 206 }
+				position = { 51 182 }
 				quadTextureSprite = "option_prev"
 			}
 			guiButtonType = {
 				name = "projection_right"
-				position = { 269 206 }
+				position = { 269 182 }
 				quadTextureSprite = "option_next"
 			}
 			# UI scaling
 			instantTextBoxType = {
-				position = { 58 240 }
+				position = { 58 216 }
 				name = "ui_scale_label"
 				font = "Arial16"
 				borderSize = { 0 0}
@@ -193,7 +193,7 @@ guiTypes = {
 				format = centre
 			}
 			instantTextBoxType={
-				position = { 58 260 }
+				position = { 58 236 }
 				name = "ui_scale_value"
 				font = "Arial14"
 				borderSize = { 0 0}
@@ -203,17 +203,17 @@ guiTypes = {
 			}
 			guiButtonType = {
 				name = "ui_scale_left"
-				position = { 51 258 }
+				position = { 51 234 }
 				quadTextureSprite = "option_prev"
 			}
 			guiButtonType = {
 				name = "ui_scale_right"
-				position = { 269 258 }
+				position = { 269 234 }
 				quadTextureSprite = "option_next"
 			}
 			# Map label mode: none, linear, cuadratic, cubic
 			instantTextBoxType={
-				position = { 58 292 }
+				position = { 58 268 }
 				name = "map_label_label"
 				font = "Arial16"
 				borderSize = { 0 0}
@@ -223,7 +223,7 @@ guiTypes = {
 				format = centre
 			}
 			instantTextBoxType={
-				position = { 58 312 }
+				position = { 58 288 }
 				name = "map_label_value"
 				font = "Arial14"
 				borderSize = { 0 0}
@@ -233,17 +233,17 @@ guiTypes = {
 			}
 			guiButtonType = {
 				name = "map_label_left"
-				position = { 51 310 }
+				position = { 51 290 }
 				quadTextureSprite = "option_prev"
 			}
 			guiButtonType = {
 				name = "map_label_right"
-				position = { 269 310 }
+				position = { 269 290 }
 				quadTextureSprite = "option_next"
 			}
-			# Anisotropic filtering
+			# Antialiasing
 			instantTextBoxType={
-				position = { 58 344 }
+				position = { 58 320 }
 				name = "antialiasing_label"
 				font = "Arial16"
 				borderSize = { 0 0}
@@ -253,7 +253,7 @@ guiTypes = {
 				format = centre
 			}
 			instantTextBoxType={
-				position = { 58 364 }
+				position = { 58 340 }
 				name = "antialiasing_value"
 				font = "Arial14"
 				borderSize = { 0 0}
@@ -263,12 +263,42 @@ guiTypes = {
 			}
 			guiButtonType = {
 				name = "antialiasing_left"
-				position = { 51 363 }
+				position = { 51 339 }
 				quadTextureSprite = "option_prev"
 			}
 			guiButtonType = {
 				name = "antialiasing_right"
-				position = { 269 363 }
+				position = { 269 339 }
+				quadTextureSprite = "option_next"
+			}
+			# Gaussian blur
+			instantTextBoxType = {
+				position = { 58 372 }
+				name = "gaussianblur_label"
+				font = "Arial16"
+				borderSize = { 0 0}
+				maxsize = { 236 18 }
+				text = "gaussianblur_label"
+				orientation = "UPPER_LEFT"
+				format = centre
+			}
+			instantTextBoxType = {
+				position = { 58 392 }
+				name = "gaussianblur_value"
+				font = "Arial14"
+				borderSize = { 0 0}
+				maxsize = { 236 18 }
+				orientation = "UPPER_LEFT"
+				format = centre
+			}
+			guiButtonType = {
+				name = "gaussianblur_left"
+				position = { 51 391 }
+				quadTextureSprite = "option_prev"
+			}
+			guiButtonType = {
+				name = "gaussianblur_right"
+				position = { 269 391 }
 				quadTextureSprite = "option_next"
 			}
 		}

--- a/assets/shaders/msaa_f_shader.glsl
+++ b/assets/shaders/msaa_f_shader.glsl
@@ -1,6 +1,33 @@
 out vec4 out_color;
 in vec2 texcoord;
 layout (binding = 0) uniform sampler2D screen_texture;
+layout (location = 0) uniform float gaussian_radius;
+layout (location = 1) uniform vec2 screen_size;
+
+float gaussian_blur(vec2 p, float std) {
+	float r = 2.0 * std * std;
+	float t = 3.1415 * r;
+	float s = p.x * p.x + p.y * p.y;
+	return (1.0 / t) * pow(2.71, -(s / r));
+}
+
+vec4 gaussian_colour() {
+	if(gaussian_radius <= 1.0) {
+		return texture2D(screen_texture, texcoord);
+	}
+	float r = gaussian_radius;
+	float dx = 1.0 / screen_size.x;
+	float dy = 1.0 / screen_size.y;
+	vec4 col = vec4(0.0, 0.0, 0.0, 0.0);
+	vec2 p = texcoord - vec2(dx * r, dy * r);
+	for(float x = -r; x <= r; x++, p.x += dx) {
+		for(float y = -r; y <= r; y++, p.y += dy) {
+			col += texture2D(screen_texture, p) * gaussian_blur(vec2(x, y), r / 2.0);
+		}
+	}
+	return col;
+}
+
 void main() {
-	out_color = texture(screen_texture, texcoord);
+	out_color = gaussian_colour();
 }

--- a/src/gamestate/system_state.cpp
+++ b/src/gamestate/system_state.cpp
@@ -1724,6 +1724,7 @@ void state::save_user_settings() const {
 	ptr += upper_half_count;
 	US_SAVE(map_label);
 	US_SAVE(antialias_level);
+	US_SAVE(gaussianblur_level);
 #undef US_SAVE
 
 	simple_fs::write_file(settings_location, NATIVE("user_settings.dat"), &buffer[0], uint32_t(ptr - buffer));
@@ -1773,6 +1774,7 @@ void state::load_user_settings() {
 			ptr += upper_half_count;
 			US_LOAD(map_label);
 			US_LOAD(antialias_level);
+			US_LOAD(gaussianblur_level);
 #undef US_LOAD
 		} while(false);
 
@@ -1782,6 +1784,7 @@ void state::load_user_settings() {
 		user_settings.master_volume = std::clamp(user_settings.master_volume, 0.0f, 1.0f);
 		if(user_settings.antialias_level > 16)
 			user_settings.antialias_level = 0;
+		user_settings.gaussianblur_level = std::clamp(user_settings.gaussianblur_level, 1.0f, 2.0f);
 	}
 }
 

--- a/src/gamestate/system_state.hpp
+++ b/src/gamestate/system_state.hpp
@@ -360,6 +360,7 @@ struct user_settings_s {
 	bool fow_enabled = false;
 	map_label_mode map_label = map_label_mode::quadratic;
 	uint8_t antialias_level = 0;
+	float gaussianblur_level = 1.f;
 };
 
 struct global_scenario_data_s { // this struct holds miscellaneous global properties of the scenario

--- a/src/gui/gui_main_menu.cpp
+++ b/src/gui/gui_main_menu.cpp
@@ -196,6 +196,28 @@ void antialiasing_display::on_update(sys::state& state) noexcept {
 	set_text(state, "x" + std::to_string(int32_t(state.user_settings.antialias_level)));
 }
 
+void gaussianblur_left::button_action(sys::state& state) noexcept {
+	if(state.user_settings.gaussianblur_level > 1.f) {
+		state.user_settings.gaussianblur_level -= 0.125f;
+		send(state, parent, notify_setting_update{});
+	}
+}
+void gaussianblur_left::on_update(sys::state& state) noexcept {
+	disabled = (state.user_settings.gaussianblur_level == 1.f) || (state.user_settings.antialias_level == 0);
+}
+void gaussianblur_right::button_action(sys::state& state) noexcept {
+	if(state.user_settings.gaussianblur_level < 2.f) {
+		state.user_settings.gaussianblur_level += 0.125f;
+		send(state, parent, notify_setting_update{});
+	}
+}
+void gaussianblur_right::on_update(sys::state& state) noexcept {
+	disabled = (state.user_settings.gaussianblur_level >= 2.f) || (state.user_settings.antialias_level == 0);
+}
+void gaussianblur_display::on_update(sys::state& state) noexcept {
+	set_text(state, "x" + text::format_float(state.user_settings.gaussianblur_level));
+}
+
 /*
 class autosave_left : public button_element_base {
 public:

--- a/src/gui/gui_main_menu.hpp
+++ b/src/gui/gui_main_menu.hpp
@@ -115,6 +115,20 @@ class antialiasing_display : public simple_text_element_base {
 	void on_update(sys::state& state) noexcept override;
 };
 
+class gaussianblur_left : public button_element_base {
+public:
+	void button_action(sys::state& state) noexcept override;
+	void on_update(sys::state& state) noexcept override;
+};
+class gaussianblur_right : public button_element_base {
+public:
+	void button_action(sys::state& state) noexcept override;
+	void on_update(sys::state& state) noexcept override;
+};
+class gaussianblur_display : public simple_text_element_base {
+	void on_update(sys::state& state) noexcept override;
+};
+
 class music_player_left : public button_element_base {
 public:
 	void button_action(sys::state& state) noexcept override;
@@ -198,6 +212,12 @@ class graphics_menu_window : public window_element_base {
 			return make_element_by_type<antialiasing_left>(state, id);
 		} else if(name == "antialiasing_right") {
 			return make_element_by_type<antialiasing_right>(state, id);
+		} else if(name == "gaussianblur_value") {
+			return make_element_by_type<gaussianblur_display>(state, id);
+		} else if(name == "gaussianblur_left") {
+			return make_element_by_type<gaussianblur_left>(state, id);
+		} else if(name == "gaussianblur_right") {
+			return make_element_by_type<gaussianblur_right>(state, id);
 		} else {
 			return nullptr;
 		}

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -640,6 +640,9 @@ void display_data::render(sys::state& state, glm::vec2 screen_size, glm::vec2 of
 		glBindFramebuffer(GL_FRAMEBUFFER, 0);
 		// draw Screen quad
 		glUseProgram(state.open_gl.msaa_shader_program);
+		glUniform1f(0, state.user_settings.gaussianblur_level);
+		glUniform2f(1, screen_size.x, screen_size.y);
+		//
 		glActiveTexture(GL_TEXTURE0);
 		glBindTexture(GL_TEXTURE_2D, state.open_gl.msaa_texture); // use the now resolved color attachment as the quad's texture
 		glBindVertexArray(state.open_gl.msaa_vao);


### PR DESCRIPTION
Makes stuff smoother,
limited to [1, 2], in increments of 0.125 - higher than that results in pretty much not very nice results for players.

Main usage: to make stuff seem a lot smoother than it is (MSAA already does this, but Guassian Blur makes things slightly more photographic in addition to MSAA, hence why it's needed to do MSAA first)