### PR TITLE
fallthrough labels & removing destructor

### DIFF
--- a/dependencies/stb/stb_image.h
+++ b/dependencies/stb/stb_image.h
@@ -5742,10 +5742,10 @@ static int stbi__tga_get_comp(int bits_per_pixel, int is_grey, int* is_rgb16)
    switch(bits_per_pixel) {
       case 8:  return STBI_grey;
       case 16: if(is_grey) return STBI_grey_alpha;
-               // fallthrough
+	       [[fallthrough]];
       case 15: if(is_rgb16) *is_rgb16 = 1;
                return STBI_rgb;
-      case 24: // fallthrough
+      case 24: [[fallthrough]];
       case 32: return bits_per_pixel/8;
       default: return 0;
    }

--- a/src/gamestate/system_state.hpp
+++ b/src/gamestate/system_state.hpp
@@ -643,7 +643,7 @@ struct alignas(64) state {
 
 	state() : key_to_text_sequence(0, text::vector_backed_hash(text_data), text::vector_backed_eq(text_data)), incoming_commands(1024), new_n_event(1024), new_f_n_event(1024), new_p_event(1024), new_f_p_event(1024), new_requests(256), new_messages(2048), naval_battle_reports(256), land_battle_reports(256) { }
 
-	~state();
+	//~state() = default;
 
 	void save_user_settings() const;
 	void load_user_settings();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,12 +86,6 @@ extern "C" {
 #include "blake2.c"
 };
 
-namespace sys {
-state::~state() {
-	// why does this exist ? So that the destructor of the unique pointer doesn't have to be known before it is implemented
-}
-} // namespace sys
-
 // zstd
 extern "C" {
 #define XXH_NAMESPACE ZSTD_


### PR DESCRIPTION
As i understand it, the sys::state class doesnt manage its own resources. so it is not in need of a destructor declaration