### PR TITLE
add slot(1,2,3,4) to support gfm dynamic dominion flags

### DIFF
--- a/src/culture/culture.hpp
+++ b/src/culture/culture.hpp
@@ -78,6 +78,10 @@ enum class flag_type : uint8_t {
 	agrarism,
 	national_syndicalist,
 	theocratic,
+	slot1,
+	slot2,
+	slot3,
+	slot4,
 	count
 };
 

--- a/src/ogl/texture.cpp
+++ b/src/ogl/texture.cpp
@@ -527,6 +527,18 @@ GLuint get_flag_handle(sys::state& state, dcon::national_identity_id nat_id, cul
 		case culture::flag_type::theocratic:
 			file_str += NATIVE("_theocratic");
 			break;
+		case culture::flag_type::slot1:
+			file_str += NATIVE("_slot1");
+			break;
+		case culture::flag_type::slot2:
+			file_str += NATIVE("_slot2");
+			break;
+		case culture::flag_type::slot3:
+			file_str += NATIVE("_slot3");
+			break;
+		case culture::flag_type::slot4:
+			file_str += NATIVE("_slot4");
+			break;
 		}
 		file_str += NATIVE(".tga");
 


### PR DESCRIPTION
doesn't cost anything to add, plus it's just 4 slots, and allows me to not have to fiddle with `goverments.txt`