### PR TITLE
Adjusts the consciousness algorithm to be consistent with Vic 2

### DIFF
--- a/src/economy/demographics.cpp
+++ b/src/economy/demographics.cpp
@@ -824,10 +824,10 @@ void update_consciousness(sys::state& state, uint32_t offset, uint32_t divisions
 		auto lx_mod = state.world.pop_get_luxury_needs_satisfaction(ids) * state.defines.con_luxury_goods;
 		auto cl_mod = cfrac * ve::select(state.world.pop_type_get_strata(types) == int32_t(culture::pop_strata::poor),
 															ve::fp_vector{state.defines.con_poor_clergy}, ve::fp_vector{state.defines.con_midrich_clergy});
-		auto lit_mod = (state.world.nation_get_plurality(owner) / 10.0f) *
+		auto lit_mod = ((state.world.nation_get_plurality(owner) / 10.0f) *
 			 (state.world.nation_get_modifier_values(owner, sys::national_mod_offsets::literacy_con_impact) + 1.0f) *
 			state.defines.con_literacy * state.world.pop_get_literacy(ids) *
-			 ve::select(state.world.province_get_is_colonial(loc), ve::fp_vector{state.defines.con_colonial_factor}, 1.0f);
+			 ve::select(state.world.province_get_is_colonial(loc), ve::fp_vector{state.defines.con_colonial_factor}, 1.0f)) / 10;
 
 		auto pmod = state.world.province_get_modifier_values(loc, sys::provincial_mod_offsets::pop_consciousness_modifier);
 		auto omod = state.world.nation_get_modifier_values(owner, sys::national_mod_offsets::global_pop_consciousness_modifier);
@@ -858,10 +858,10 @@ float get_estimated_con_change(sys::state& state, dcon::pop_id ids) {
 	float lx_mod = state.world.pop_get_luxury_needs_satisfaction(ids) * state.defines.con_luxury_goods;
 	float cl_mod = cfrac * ve::select(state.world.pop_type_get_strata(types) == int32_t(culture::pop_strata::poor),
 														state.defines.con_poor_clergy, state.defines.con_midrich_clergy);
-	float lit_mod = (state.world.nation_get_plurality(owner) / 10.0f) *
+	float lit_mod = ((state.world.nation_get_plurality(owner) / 10.0f) *
 		 (state.world.nation_get_modifier_values(owner, sys::national_mod_offsets::literacy_con_impact) + 1.0f) *
 		 state.defines.con_literacy * state.world.pop_get_literacy(ids) *
-		ve::select(state.world.province_get_is_colonial(loc), state.defines.con_colonial_factor, 1.0f);
+		ve::select(state.world.province_get_is_colonial(loc), state.defines.con_colonial_factor, 1.0f)) / 10;
 
 	float pmod = state.world.province_get_modifier_values(loc, sys::provincial_mod_offsets::pop_consciousness_modifier);
 	float omod = state.world.nation_get_modifier_values(owner, sys::national_mod_offsets::global_pop_consciousness_modifier);

--- a/src/gui/topbar_subwindows/gui_population_window.hpp
+++ b/src/gui/topbar_subwindows/gui_population_window.hpp
@@ -670,10 +670,10 @@ void describe_con(sys::state& state, text::columnar_layout& contents, dcon::pop_
 	float lx_mod = state.world.pop_get_luxury_needs_satisfaction(ids) * state.defines.con_luxury_goods;
 	float cl_mod = cfrac * (state.world.pop_type_get_strata(types) == int32_t(culture::pop_strata::poor) ?
 														state.defines.con_poor_clergy : state.defines.con_midrich_clergy);
-	float lit_mod = (state.world.nation_get_plurality(owner) / 10.0f) *
+	float lit_mod = ((state.world.nation_get_plurality(owner) / 10.0f) *
 								 (state.world.nation_get_modifier_values(owner, sys::national_mod_offsets::literacy_con_impact) + 1.0f) *
 								 state.defines.con_literacy * state.world.pop_get_literacy(ids) *
-								 (state.world.province_get_is_colonial(loc) ? state.defines.con_colonial_factor : 1.0f);
+								 (state.world.province_get_is_colonial(loc) ? state.defines.con_colonial_factor : 1.0f)) / 10;
 
 	float pmod = state.world.province_get_modifier_values(loc, sys::provincial_mod_offsets::pop_consciousness_modifier);
 	float omod = state.world.nation_get_modifier_values(owner, sys::national_mod_offsets::global_pop_consciousness_modifier);


### PR DESCRIPTION
Noticed that certain European nations were getting maxed plurality just a single decade into the game, UI and calculations seem to make consciousness gain from plurality/literacy be 10x as effective as what the UI states in Vic 2 so I adjusted it.

New adjustments
![image](https://github.com/schombert/Project-Alice/assets/18253120/9cb85369-0f93-4e76-a8c7-5090f2c02e02)

Vs Vic 2
![image](https://github.com/schombert/Project-Alice/assets/18253120/df63850f-e4aa-4015-a954-da6cc71f866d)
