### PR TITLE
Improves the National focus section of the outliner

### DIFF
--- a/src/gui/gui_outliner_window.hpp
+++ b/src/gui/gui_outliner_window.hpp
@@ -430,8 +430,15 @@ public:
 				color = text::text_color::white;
 				set_text(state, full_str);
 			} else if(fat_nf.get_promotion_type()) {
-				auto full_str = text::produce_simple_string(state, fat_nf.get_name()) + " (" + text::get_dynamic_state_name(state, siid) + ", "  + text::format_percentage(fat_si.get_demographics(demographics::to_key(state, fat_nf.get_promotion_type())) / fat_si.get_demographics(demographics::total)) + ")";
 				color = text::text_color::white;
+				//Is the NF not optimal? Recolor it
+				if(fat_nf.get_promotion_type() == state.culture_definitions.clergy) {
+					if((fat_si.get_demographics(demographics::to_key(state, fat_nf.get_promotion_type())) / fat_si.get_demographics(demographics::total)) > state.defines.max_clergy_for_literacy) {
+						color = text::text_color::red;
+					}
+				}
+
+				auto full_str = text::format_percentage(fat_si.get_demographics(demographics::to_key(state, fat_nf.get_promotion_type())) / fat_si.get_demographics(demographics::total)) + "% " + text::produce_simple_string(state, fat_nf.get_name()) + " (" + text::get_dynamic_state_name(state, siid) + ")";
 				set_text(state, full_str);
 			} else {
 				auto full_str = text::produce_simple_string(state, fat_nf.get_name()) + " (" + text::get_dynamic_state_name(state, siid) + ")";


### PR DESCRIPTION
- Reorganized the text per line to include more relevant information; reordered as the % of demographics that is the promoted pop followed by the NF used and finally the state name
- The state having more clergymen than the _**max_clergy_for_literacy**_ will be recolored red, copying vanilla behavior in warning the player that additional promotion is unproductive for the NF
