### PR TITLE
Nationalism AI; changes for encouraging more nationalism to successfully suceed

### DIFF
--- a/src/ai/ai.cpp
+++ b/src/ai/ai.cpp
@@ -8,6 +8,11 @@ float estimate_strength(sys::state& state, dcon::nation_id n) {
 	float value = state.world.nation_get_military_score(n);
 	for(auto subj : state.world.nation_get_overlord_as_ruler(n))
 		value += subj.get_subject().get_military_score();
+	//Leaders currently make minor nations (especially spherelings) seem much more powerful than they are, so it's getting axed here
+	auto gen_range = state.world.nation_get_leader_loyalty(n);
+	auto num_leaders = float((gen_range.end() - gen_range.begin()));
+	value -= num_leaders;
+
 	return value;
 }
 
@@ -166,8 +171,12 @@ void prune_alliances(sys::state& state) {
 		if(!n.get_is_player_controlled() && !n.get_ai_is_threatened() && !(n.get_overlord_as_subject().get_ruler())) {
 			prune_targets.clear();
 			for(auto dr : n.get_diplomatic_relation()) {
+				auto other = dr.get_related_nations(0) != n ? dr.get_related_nations(0) : dr.get_related_nations(1);
+				if(military::can_use_cb_against(state, n, other)) {
+					prune_targets.push_back(other);
+					continue;
+				}
 				if(dr.get_are_allied()) {
-					auto other = dr.get_related_nations(0) != n ? dr.get_related_nations(0) : dr.get_related_nations(1);
 					if(other.get_in_sphere_of() != n) {
 						prune_targets.push_back(other);
 					}
@@ -269,6 +278,11 @@ bool ai_will_accept_alliance(sys::state& state, dcon::nation_id target, dcon::na
 	// Otherwise we may consider alliances only iff they are close to our continent or we are adjacent
 	if(!ai_is_close_enough(state, target, from))
 		return false;
+
+	//We'd rather want to kill them rather than ally
+	if(military::can_use_cb_against(state, from, target)) {
+		return false;
+	}
 
 	// And also if they're powerful enough to be considered for an alliance
 	auto target_score = estimate_strength(state, target);
@@ -385,10 +399,10 @@ void initialize_ai_tech_weights(sys::state& state) {
 	for(auto t : state.world.in_technology) {
 		float base = 1000.0f;
 		if(state.culture_definitions.tech_folders[t.get_folder_index()].category == culture::tech_category::army)
-			base *= 1.5f;
+			base *= 3.0f;
 
 		if(t.get_increase_building(economy::province_building_type::naval_base))
-			base *= 1.1f;
+			base *= 9.0f;
 		else if(state.culture_definitions.tech_folders[t.get_folder_index()].category == culture::tech_category::navy)
 			base *= 0.9f;
 
@@ -396,19 +410,19 @@ void initialize_ai_tech_weights(sys::state& state) {
 		auto& vals = mod.get_national_values();
 		for(uint32_t i = 0; i < sys::national_modifier_definition::modifier_definition_size; ++i) {
 			if(vals.offsets[i] == sys::national_mod_offsets::research_points) {
-				base *= 3.0f;
+				base *= 6.0f;
 			} else if(vals.offsets[i] == sys::national_mod_offsets::research_points_modifier) {
-				base *= 3.0f;
+				base *= 6.0f;
 			} else if(vals.offsets[i] == sys::national_mod_offsets::education_efficiency) {
-				base *= 2.0f;
+				base *= 3.0f;
 			} else if(vals.offsets[i] == sys::national_mod_offsets::education_efficiency_modifier) {
-				base *= 2.0f;
+				base *= 3.0f;
 			} else if(vals.offsets[i] == sys::national_mod_offsets::pop_growth) {
-				base *= 1.6f;
+				base *= 9.0f;
 			} else if(vals.offsets[i] == sys::national_mod_offsets::max_national_focus) {
-				base *= 1.7f;
+				base *= 9.0f;
 			} else if(vals.offsets[i] == sys::national_mod_offsets::colonial_life_rating) {
-				base *= 1.6f;
+				base *= 15.0f;
 			} else if(vals.offsets[i] == sys::national_mod_offsets::rgo_output) {
 				base *= 1.2f;
 			} else if(vals.offsets[i] == sys::national_mod_offsets::factory_output) {
@@ -467,14 +481,51 @@ void update_influence_priorities(sys::state& state) {
 				}
 			}
 
-			if(t.get_primary_culture().get_group_from_culture_group_membership() == state.world.nation_get_primary_culture(n.nation).get_group_from_culture_group_membership()) {
-				weight += 4.0f;
-			} else if(t.get_in_sphere_of()) {
-				weight /= 3.0f;
+			//We probably don't want to fight a forever lasting sphere war, let's find some other uncontested nations
+			if(t.get_in_sphere_of()) {
+				weight /= 4.0f;
+			}
+
+			//Prioritize primary culture before culture groups; should ensure Prussia spheres all of the NGF first before trying to contest Austria
+			if(t.get_primary_culture() == state.world.nation_get_primary_culture(n.nation)) {
+				weight += 1.0f;
+				weight *= 4000.0f;
+			}
+
+			else if(t.get_primary_culture().get_group_from_culture_group_membership() == state.world.nation_get_primary_culture(n.nation).get_group_from_culture_group_membership()) {
+				weight *= 100.0f;
+			}
+			//Focus on gaining influence against nations we have active wargoals against
+			if(military::can_use_cb_against(state, n.nation, t) && t.get_in_sphere_of() != n.nation && t.get_in_sphere_of()) {
+				weight += 1.0f;
+				weight *= 1000.0f;
+			}
+			//If it doesn't neighbor us or a friendly sphere and isn't coastal, please don't sphere it, we don't want sphere gore
+			bool is_reachable = false;
+			for(auto adj : state.world.nation_get_nation_adjacency(t)) {
+				auto casted_adj = adj.get_connected_nations(0) != t ? adj.get_connected_nations(0) : adj.get_connected_nations(1);
+				if(casted_adj == n.nation) {
+					is_reachable = true;
+					break;
+				}
+				if(casted_adj.get_in_sphere_of() == n.nation) {
+					is_reachable = true;
+					break;
+				}
+			};
+
+			//Is coastal? Technically reachable
+			if(state.world.nation_get_central_ports(t) > 0) {
+				is_reachable = true;
 			}
 
 			if(state.world.get_nation_adjacency_by_nation_adjacency_pair(n.nation, t.id)) {
 				weight *= 3.0f;
+				is_reachable = true;
+			}
+
+			if(!is_reachable) {
+				weight *= 0.0f;
 			}
 
 			targets.push_back(weighted_nation{ t.id, weight });
@@ -532,6 +583,9 @@ void perform_influence_actions(sys::state& state) {
 				command::execute_remove_from_sphere(state, gprl.get_great_power(), gprl.get_influence_target(), gprl.get_influence_target().get_in_sphere_of());
 			} else if(state.defines.addtosphere_influence_cost <= gprl.get_influence() && !current_sphere && clevel == nations::influence::level_friendly) {
 				command::execute_add_to_sphere(state, gprl.get_great_power(), gprl.get_influence_target());
+			//De-sphere countries we have wargoals against
+			} else if(military::can_use_cb_against(state, gprl.get_great_power(), gprl.get_influence_target()) && state.defines.removefromsphere_influence_cost <= gprl.get_influence() && current_sphere && clevel == nations::influence::level_friendly) {
+				command::execute_remove_from_sphere(state, gprl.get_great_power(), gprl.get_influence_target(), gprl.get_influence_target().get_in_sphere_of());
 			}
 		}
 	}
@@ -1833,11 +1887,23 @@ bool will_accept_crisis_peace_offer(sys::state& state, dcon::nation_id to, dcon:
 
 void update_war_intervention(sys::state& state) {
 	for(auto& gp : state.great_nations) {
-		if(state.world.nation_get_is_player_controlled(gp.nation) == false && state.world.nation_get_is_at_war(gp.nation) == false) {
+		if(state.world.nation_get_is_player_controlled(gp.nation) == false){
 			bool as_attacker = false;
 			dcon::war_id intervention_target;
 			[&]() {
 				for(auto w : state.world.in_war) {
+					//GPs will try to intervene in wars to protect smaller nations in the same cultural union
+					if(command::can_intervene_in_war(state, gp.nation, w, false)) {
+						for(auto par : w.get_war_participant()) {
+							if(!par.get_is_attacker()
+								&& state.world.nation_get_primary_culture(gp.nation).get_group_from_culture_group_membership() == state.world.nation_get_primary_culture(par.get_nation()).get_group_from_culture_group_membership()
+								&& !nations::is_great_power(state, par.get_nation())
+							){
+								intervention_target = w;
+								return;
+							}
+						}
+					}
 					if(w.get_is_great()) {
 						if(command::can_intervene_in_war(state, gp.nation, w, false)) {
 							for(auto par : w.get_war_participant()) {
@@ -1945,7 +2011,6 @@ void update_cb_fabrication(sys::state& state) {
 				continue;
 			if(n.get_constructing_cb_type())
 				continue;
-
 			auto ol = n.get_overlord_as_subject().get_ruler().id;
 			if(n.get_ai_rival()
 				&& n.get_ai_rival().get_in_sphere_of() != n
@@ -2735,6 +2800,14 @@ bool will_accept_peace_offer(sys::state& state, dcon::nation_id n, dcon::nation_
 		if(war_duration < 365) {
 			return false;
 		}
+		//The country is ruined and it's been a bit into the war, we'll recover later
+		if(state.world.nation_get_war_exhaustion(n) > 80) {
+			return true;
+		}
+		//Stalemated war, peace out
+		if(war_duration > (365 * 6) && (overall_score <= 10 && overall_score >= -10)) {
+			return true;
+		}
 		float willingness_factor = float(war_duration - 365) * 10.0f / 365.0f;
 		if(overall_score >= 0) {
 			if(concession && ((overall_score * 2 - overall_po_value - willingness_factor) < 0))
@@ -2762,6 +2835,9 @@ bool will_accept_peace_offer(sys::state& state, dcon::nation_id n, dcon::nation_
 		if(overall_score < 0.0f) { // we are losing
 			if(my_side_against_target - scoreagainst_me <= overall_po_value + personal_score_saved)
 				return true;
+			if(state.world.nation_get_war_exhaustion(n) > 80) {
+				return true;
+			}
 		} else {
 			if(my_side_against_target <= overall_po_value)
 				return true;
@@ -2772,13 +2848,20 @@ bool will_accept_peace_offer(sys::state& state, dcon::nation_id n, dcon::nation_
 			return false;
 
 		auto scoreagainst_me = military::directed_warscore(state, w, from, n);
-
+		auto war_duration = state.current_date.value - state.world.war_get_start_date(w).value;
 		if(scoreagainst_me > 50 && scoreagainst_me > -overall_po_value * 2)
 			return true;
+		//Stalemated war, peace out
+		if(war_duration > (365 * 6) && (scoreagainst_me <= 10 && scoreagainst_me >= -10)) {
+			return true;
+		}
 
 		if(overall_score < 0.0f) { // we are losing	
 			if(personal_score_saved > 0 && scoreagainst_me + personal_score_saved - my_po_target >= -overall_po_value)
 				return true;
+			if(state.world.nation_get_war_exhaustion(n) > 80) {
+				return true;
+			}
 
 		} else { // we are winning
 			if(my_po_target > 0 && my_po_target >= overall_po_value)
@@ -2826,7 +2909,52 @@ void make_war_decs(sys::state& state) {
 			return;
 
 		auto base_strength = estimate_strength(state, n);
-		float best_difference = 2.f;
+		float best_difference = 2.0f;
+
+		//Great powers should look for non-neighbor nations to use their existing wargoals on; helpful for forcing unification/repay debts wars to happen
+		
+		if(nations::is_great_power(state, n)) {
+			for(auto target : state.world.in_nation) {
+				if(target == n)
+					continue;
+				if(nations::are_allied(state, n, target))
+					continue;
+				if(target.get_in_sphere_of() == n)
+					continue;
+				if(state.world.nation_get_in_sphere_of(target) == n)
+					continue;
+				if(military::has_truce_with(state, n, target))
+					continue;
+				if(!military::can_use_cb_against(state, n, target))
+					continue;
+				//If it neighbors one of our spheres and we can pathfind to each other's capitals, we don't need naval supremacy to reach this nation
+				//Generally here to help Prussia realize it doesn't need a navy to attack Denmark
+				for(auto adj : state.world.nation_get_nation_adjacency(target)) {
+					auto other = adj.get_connected_nations(0) != n ? adj.get_connected_nations(0) : adj.get_connected_nations(1);
+					auto neighbor = other;
+					if(neighbor.get_in_sphere_of() == n){
+						auto path = province::make_safe_land_path(state, state.world.nation_get_capital(n), state.world.nation_get_capital(neighbor), n);
+						if(path.empty()) {
+							continue;
+						}
+						auto str_difference = base_strength + estimate_additional_offensive_strength(state, n, target) - estimate_defensive_strength(state, target);
+						if(str_difference > best_difference) {
+							best_difference = str_difference;
+							targets.set(n, target.id);
+							break;
+						}
+					}
+				}
+				if(!state.world.get_nation_adjacency_by_nation_adjacency_pair(n, target) && !naval_supremacy(state, n, target))
+					continue;
+				auto str_difference = base_strength + estimate_additional_offensive_strength(state, n, target) - estimate_defensive_strength(state, target);
+				if(str_difference > best_difference) {
+					best_difference = str_difference;
+					targets.set(n, target.id);
+				}
+			}
+		}
+
 		for(auto adj : state.world.nation_get_nation_adjacency(n)) {
 			auto other = adj.get_connected_nations(0) != n ? adj.get_connected_nations(0) : adj.get_connected_nations(1);
 			auto real_target = other.get_overlord_as_subject().get_ruler() ? other.get_overlord_as_subject().get_ruler() : other;

--- a/src/culture/rebels.cpp
+++ b/src/culture/rebels.cpp
@@ -272,7 +272,6 @@ void update_pop_movement_membership(sys::state& state) {
 					}
 				}
 			});
-
 			if(max_option) {
 				if(auto m = get_movement_by_position(state, owner, max_option); m) {
 					add_pop_to_movement(state, p, m);
@@ -377,9 +376,23 @@ bool pop_is_compatible_with_rebel_faction(sys::state& state, dcon::pop_id p, dco
 	here. Instead I will go with: pop is not an accepted culture and either its primary culture is associated with that identity
 	*or* there is no core in the province associated with its primary identity.
 	*/
+	auto type = fatten(state.world, state.world.rebel_faction_get_type(t));
 	auto fac = fatten(state.world, t);
 	auto pop = fatten(state.world, p);
-
+	if(type.get_independence() != 0 || type.get_defection() != 0) {
+		if(type.get_independence() == uint8_t(culture::rebel_independence::pan_nationalist) ||
+				type.get_defection() == uint8_t(culture::rebel_defection::pan_nationalist)) {
+			if(pop.get_is_primary_or_accepted_culture())
+				return true;
+		} else {
+			if(pop.get_is_primary_or_accepted_culture())
+				return false;
+		}
+		for(auto core : pop.get_province_from_pop_location().get_core()) {
+			if(core.get_identity().get_primary_culture() == pop.get_culture())
+				return true;
+		}
+	}
 	if(fac.get_primary_culture() && fac.get_primary_culture() != pop.get_culture())
 		return false;
 	if(fac.get_religion() && fac.get_religion() != pop.get_religion())
@@ -389,17 +402,6 @@ bool pop_is_compatible_with_rebel_faction(sys::state& state, dcon::pop_id p, dco
 		return false;
 	if(fac.get_type().get_ideology() && fac.get_type().get_ideology_restriction() && fac.get_type().get_ideology() != pop.get_dominant_ideology())
 		return false;
-	if(fac.get_defection_target()) {
-		if(pop.get_is_primary_or_accepted_culture())
-			return false;
-		if(pop.get_culture() == fac.get_defection_target().get_primary_culture())
-			return true;
-		for(auto core : pop.get_province_from_pop_location().get_core()) {
-			if(core.get_identity().get_primary_culture() == pop.get_culture())
-				return false;
-		}
-		return true;
-	}
 	return true;
 }
 
@@ -407,8 +409,6 @@ bool pop_is_compatible_with_rebel_type(sys::state& state, dcon::pop_id p, dcon::
 	auto fac = fatten(state.world, t);
 	auto pop = fatten(state.world, p);
 
-	if(fac.get_ideology() && fac.get_ideology() != pop.get_dominant_ideology())
-		return false;
 	if(fac.get_independence() != 0 || fac.get_defection() != 0) {
 		if(fac.get_independence() == uint8_t(culture::rebel_independence::pan_nationalist) ||
 				fac.get_defection() == uint8_t(culture::rebel_defection::pan_nationalist)) {
@@ -422,6 +422,15 @@ bool pop_is_compatible_with_rebel_type(sys::state& state, dcon::pop_id p, dcon::
 			if(core.get_identity().get_primary_culture() == pop.get_culture())
 				return true;
 		}
+		return false;
+	}
+	//Discriminated pops focus on independence rather than political issues
+	else {
+		if(!pop.get_is_primary_or_accepted_culture()) {
+			return false;
+		}
+	}
+	if(fac.get_ideology() && fac.get_ideology() != pop.get_dominant_ideology()) {
 		return false;
 	}
 	return true;
@@ -705,7 +714,6 @@ void delete_faction(sys::state& state, dcon::rebel_faction_id reb) {
 
 void update_factions(sys::state& state) {
 	update_pop_rebel_membership(state);
-
 	// IMPORTANT: we count down here so that we can delete as we go, compacting from the end
 	for(auto last = state.world.rebel_faction_size(); last-- > 0;) {
 		dcon::rebel_faction_id m{dcon::rebel_faction_id::value_base_t(last)};
@@ -862,7 +870,7 @@ void rebel_hunting_check(sys::state& state) {
 	}
 }
 
-inline constexpr float rebel_size_reduction = 0.25f;
+inline constexpr float rebel_size_reduction = 1.0f;
 
 void rebel_risings_check(sys::state& state) {
 	static std::vector<dcon::army_id> new_armies;
@@ -1165,6 +1173,11 @@ void execute_rebel_victories(sys::state& state) {
 			}
 			if(auto iid = state.world.rebel_faction_get_type(reb).get_ideology(); iid) {
 				politics::force_nation_ideology(state, within, iid);
+			}
+
+			//The pops won, reset their militancy to avoid death spiraling
+			for(auto members : state.world.rebel_faction_get_pop_rebellion_membership(reb)) {
+				members.get_pop().set_militancy(0.0f);
 			}
 
 			/*


### PR DESCRIPTION
Big list of changes
- Rebel AI can now properly form pan nationalist factions, although nationalists still appear to be broken, this should drastically increase the chance of an Italy appearing alongside the occasional Gutter crown for the germans
- Nations will try to unally and desphere countries they have wargoals against; stops certain situations like USA sphering mexico causing them to not be able to manifest a destiny
- Modified some tech weights, effective outcome should be a much higher focus on national focus techs, culture and army
- Redid the sphere AI; now tries to not sphere countries they don't have a neighboring sphere or a coastal state to access. Countries will now hyperfocus on sphering countries within their culture union
- AI will now intervene in wars even if they're already in a war if it means they can protect a non-GP culture union; this could use some military strength checks, but this is mainly to ensure the USA will keep Texas safe from the Mexicans and not be pseudo locked out from manifest destiny
- Wars that extend for > 6 years and have minor amounts of war score will now be peaced out easily; stops forever stalemate wars particularly with Europeans doing "cut down to size" wars against asian countries. 
- Countries with very high war exhaustion will peace out after 1 year in war; countries locked in rebel death spiral will try to escape the situation, especially when the aggressor cannot occupy the lands because of rebels
- GPs will now look globally to figure out where they can use their wargoals; helps Prussia decide in attacking Denmark and would allow for other free wargoals to be used like 'pay debts' and 'cut down to size'
- Undid the rebel size reduction, rebels winning a revolution will now negate militancy; this should help nations not ener a permanent death spiral just because the population is permanently unhappy

