### PR TITLE
Fix Linux build

### DIFF
--- a/src/entry_point_nix.cpp
+++ b/src/entry_point_nix.cpp
@@ -57,6 +57,13 @@ int main(int argc, char **argv) {
 
 		network::init(game_state);
 	}
+	else
+	{
+		parsers::error_handler err{ "" };
+		game_state.load_scenario_data(err);
+		if(!err.accumulated_errors.empty())
+			window::emit_error_message(err.accumulated_errors, true);
+	}
 
 	// scenario loading functions (would have to run these even when scenario is pre-built
 	game_state.load_user_settings();
@@ -66,7 +73,7 @@ int main(int argc, char **argv) {
 
 	std::thread update_thread([&]() { game_state.game_loop(); });
 
-	window::create_window(game_state, window::creation_parameters());
+	window::create_window(game_state, window::creation_parameters{1024, 780, window::window_state::maximized, game_state.user_settings.prefer_fullscreen});
 
 	game_state.quit_signaled.store(true, std::memory_order_release);
 	update_thread.join();

--- a/src/entry_point_nix.cpp
+++ b/src/entry_point_nix.cpp
@@ -57,12 +57,18 @@ int main(int argc, char **argv) {
 
 		network::init(game_state);
 	}
-	else
-	{
-		parsers::error_handler err{ "" };
-		game_state.load_scenario_data(err);
-		if(!err.accumulated_errors.empty())
-			window::emit_error_message(err.accumulated_errors, true);
+	else {
+		if(!sys::try_read_scenario_and_save_file(game_state, NATIVE("development_test_file.bin"))) {
+			// scenario making functions
+			parsers::error_handler err{ "" };
+			game_state.load_scenario_data(err);
+			if(!err.accumulated_errors.empty())
+				window::emit_error_message(err.accumulated_errors, true);
+			sys::write_scenario_file(game_state, NATIVE("development_test_file.bin"), 0);
+			game_state.loaded_scenario_file = NATIVE("development_test_file.bin");
+		} else {
+			game_state.fill_unsaved_data();
+		}
 	}
 
 	// scenario loading functions (would have to run these even when scenario is pre-built


### PR DESCRIPTION
Since the Linux version doesn't support the launcher you have to run `Alice` from the command line and by default this won't load any scenario data resulting in an error. I copy-pasted the code from the Windows file equivalent so that when running `./Alice` with no other arguments will try to run the development scenario or build it if it isn't there. This way users can at least clone the repo on Linux, build, then run the base game. I haven't cross-compiled the launcher to create scenario files so I haven't tested running with modded scenarios.

Also changed the window creation parameters for parity with the Windows version.