### PR TITLE
Add support for a religion map mode

### DIFF
--- a/assets/alice.csv
+++ b/assets/alice.csv
@@ -27,6 +27,7 @@ map_label_1;Linear;;;Linear;;;;;;;;;x
 map_label_2;Quadratic;;;Cuadratica;;;;;;;;;x
 map_label_3;Cubic;;;Cubica;;;;;;;;;x
 antialiasing_label;Antialiasing;;;Antialiasing;;;;;;;;;x
+mapmode_24;Religion Mapmode;;;;;;;;;;;;x
 lg_min_mapmode_8;Low admin
 lg_min_mapmode_19;Uncivilized
 lg_min_mapmode_7;Uncolonized
@@ -552,6 +553,7 @@ mtt_name;$state$ ($name$ - );;;;;;;;;;;;x
 mtt_core_entry;$$faction$ - $name$;;;;;;;;;;;;x
 mtt_state_entry; - $state$ \n $continentname$;;;;;;;;;;;;x
 mtt_culture_majorities;The cultures in §Y$PROV$§W are:;;;;;;;;;;;;x
+mtt_religion_majorities;The religions in §Y$PROV$§W are:;;;;;;;;;;;;x
 pop_size_1;In the coming month the size of this pop is expected to change by: ;;;;;;;;;;;;x
 pop_size_2;From growth: ;;;;;;;;;;;;x
 pop_size_3;From promotion and demotion: ;;;;;;;;;;;;x

--- a/src/gui/gui_map_legend.hpp
+++ b/src/gui/gui_map_legend.hpp
@@ -48,6 +48,8 @@ class map_legend_title : public simple_text_element_base {
 			return "mapmode_15";
 		case map_mode::mode::terrain:
 			return "mapmode_1";
+		case map_mode::mode::religion:
+			return "mapmode_24";
 		default:
 			return "???";
 		}

--- a/src/gui/gui_minimap.hpp
+++ b/src/gui/gui_minimap.hpp
@@ -102,6 +102,9 @@ public:
 		case map_mode::mode::terrain:
 			text::localised_format_box(state, contents, box, std::string_view("mapmode_1"));
 			break;
+		case map_mode::mode::religion:
+			text::localised_format_box(state, contents, box, std::string_view("mapmode_24"));
+			break;
 		}
 		text::close_layout_box(contents, box);
 	}

--- a/src/gui/map_tooltip.cpp
+++ b/src/gui/map_tooltip.cpp
@@ -7,7 +7,7 @@ void country_name_box(sys::state& state, text::columnar_layout& contents, dcon::
 	auto fat = dcon::fatten(state.world, prov);
 	auto owner = fat.get_nation_from_province_ownership();
 	auto box = text::open_layout_box(contents);
-	
+
 	if(owner) {
 		text::add_to_layout_box(state, contents, box, fat.get_name());
 		text::add_to_layout_box(state, contents, box, std::string_view{ " (" });
@@ -44,7 +44,7 @@ void political_map_tt_box(sys::state& state, text::columnar_layout& contents, dc
 	//text::close_layout_box(contents, box);
 }
 
-void revolt_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon::province_id prov) {  // Done 
+void revolt_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon::province_id prov) {  // Done
 	auto fat = dcon::fatten(state.world, prov);
 	country_name_box(state, contents, prov);
 
@@ -60,7 +60,7 @@ void revolt_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon:
 			text::add_line(state, contents, state.culture_definitions.crimes[fat.get_crime()].name);
 			ui::modifier_description(state, contents, state.culture_definitions.crimes[fat.get_crime()].modifier);
 		}
-		
+
 	}
 }
 
@@ -128,7 +128,7 @@ void diplomatic_map_tt_box(sys::state& state, text::columnar_layout& contents, d
 	}
 }
 
-void region_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon::province_id prov) {  // Done 
+void region_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon::province_id prov) {  // Done
 	auto fat = dcon::fatten(state.world, prov);
 	country_name_box(state, contents, prov);
 
@@ -209,7 +209,7 @@ void colonial_map_tt_box(sys::state& state, text::columnar_layout& contents, dco
 	}
 }
 
-void admin_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon::province_id prov) {   // Done 
+void admin_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon::province_id prov) {   // Done
 	auto fat = dcon::fatten(state.world, prov);
 	country_name_box(state, contents, prov);
 
@@ -326,7 +326,7 @@ void nationality_map_tt_box(sys::state& state, text::columnar_layout& contents, 
 	}
 }
 
-void sphere_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon::province_id prov) {  // Done 
+void sphere_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon::province_id prov) {  // Done
 	auto fat = dcon::fatten(state.world, prov);
 	country_name_box(state, contents, prov);
 
@@ -452,7 +452,7 @@ void partyloyalty_map_tt_box(sys::state& state, text::columnar_layout& contents,
 	}
 }
 
-void rank_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon::province_id prov) {    //  Done 
+void rank_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon::province_id prov) {    //  Done
 	auto fat = dcon::fatten(state.world, prov);
 	country_name_box(state, contents, prov);
 
@@ -486,7 +486,7 @@ void rank_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon::p
 void migration_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon::province_id prov) {   // TODO - Needs Migration Map
 	auto fat = dcon::fatten(state.world, prov);
 	auto owner = fat.get_nation_from_province_ownership();
-	
+
 	if(owner) {
 		{
 			auto box = text::open_layout_box(contents);
@@ -591,7 +591,7 @@ void migration_map_tt_box(sys::state& state, text::columnar_layout& contents, dc
 	}
 }
 
-void civilsationlevel_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon::province_id prov) {    //Done 
+void civilsationlevel_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon::province_id prov) {    //Done
 	auto fat = dcon::fatten(state.world, prov);
 	country_name_box(state, contents, prov);
 
@@ -653,7 +653,7 @@ void civilsationlevel_map_tt_box(sys::state& state, text::columnar_layout& conte
 	}
 }
 
-void relation_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon::province_id prov) {    //Done 
+void relation_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon::province_id prov) {    //Done
 	auto fat = dcon::fatten(state.world, prov);
 	country_name_box(state, contents, prov);
 
@@ -696,7 +696,7 @@ void crisis_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon:
 	}
 }
 
-void naval_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon::province_id prov) {   // Done 
+void naval_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon::province_id prov) {   // Done
 	auto fat = dcon::fatten(state.world, prov);
 	country_name_box(state, contents, prov);
 
@@ -733,6 +733,37 @@ void naval_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon::
 		if(province::is_overseas(state, prov)) {
 			text::add_line_break_to_layout_box(state, contents, box);
 			text::localised_format_box(state, contents, box, std::string_view("naval_base_overseas_limit"));
+		}
+
+		text::close_layout_box(contents, box);
+	}
+}
+
+void religion_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon::province_id prov) { // Done
+	auto fat = dcon::fatten(state.world, prov);
+	country_name_box(state, contents, prov);
+
+	if(prov.value < state.province_definitions.first_sea_province.value) {
+		auto box = text::open_layout_box(contents);
+
+		text::localised_single_sub_box(state, contents, box, std::string_view("mtt_religion_majorities"), text::variable_type::prov, prov);
+
+		std::vector<dcon::religion_fat_id> religions;
+		for(auto pop : fat.get_pop_location()) {
+			if(std::find(religions.begin(), religions.end(), pop.get_pop().get_religion()) == religions.end()) {
+				religions.push_back(pop.get_pop().get_religion());
+			}
+		}
+		std::sort(religions.begin(), religions.end(), [&](auto a, auto b) {return fat.get_demographics(demographics::to_key(state, a.id)) > fat.get_demographics(demographics::to_key(state, b.id)); });
+		//for(size_t i = religions.size(); i > 0; i--) {
+		for(size_t i = 0; i < religions.size(); i++) {
+			text::add_line_break_to_layout_box(state, contents, box);
+			text::add_space_to_layout_box(state, contents, box);
+			text::add_to_layout_box(state, contents, box, religions[i].get_name(), text::text_color::yellow);
+			text::add_space_to_layout_box(state, contents, box);
+			text::add_to_layout_box(state, contents, box, std::string_view("("), text::text_color::white);
+			text::add_to_layout_box(state, contents, box, text::format_percentage(fat.get_demographics(demographics::to_key(state, religions[i].id)) / fat.get_demographics(demographics::total)), text::text_color::white);
+			text::add_to_layout_box(state, contents, box, std::string_view(")"), text::text_color::white);
 		}
 
 		text::close_layout_box(contents, box);
@@ -809,6 +840,9 @@ void populate_map_tooltip(sys::state& state, text::columnar_layout& contents, dc
 			break;
 		case map_mode::mode::naval:
 			naval_map_tt_box(state, contents, prov);
+			break;
+		case map_mode::mode::religion:
+			religion_map_tt_box(state, contents, prov);
 			break;
 		default:
 			break;

--- a/src/map/map_modes.cpp
+++ b/src/map/map_modes.cpp
@@ -29,6 +29,7 @@
 #include "modes/crisis.hpp"
 #include "modes/colonial.hpp"
 #include "modes/rgo_output.hpp"
+#include "modes/religion.hpp"
 
 #include "gui_element_types.hpp"
 
@@ -36,7 +37,7 @@ std::vector<uint32_t> select_states_map_from(sys::state& state) {
 	uint32_t province_size = state.world.province_size();
 	uint32_t texture_size = province_size + 256 - province_size % 256;
 	std::vector<uint32_t> prov_color(texture_size * 2, 0);
-	
+
 	assert(state.state_selection.has_value());
 	if(state.state_selection) {
 		for(const auto s : state.state_selection->selectable_states) {
@@ -44,7 +45,7 @@ std::vector<uint32_t> select_states_map_from(sys::state& state) {
 
 			for(const auto m : state.world.state_definition_get_abstract_state_membership_as_state(s)) {
 				auto p = m.get_province();
-				
+
 				auto i = province::to_map_id(p.id);
 
 				prov_color[i] = color;
@@ -61,7 +62,7 @@ void set_map_mode(sys::state& state, mode mode) {
 	std::vector<uint32_t> prov_color;
 
 
-	
+
 	switch(mode) {
 		case map_mode::mode::migration:
 		case map_mode::mode::population:
@@ -201,6 +202,9 @@ void set_map_mode(sys::state& state, mode mode) {
 	case mode::rgo_output:
 		// TODO
 		prov_color = rgo_output_map_from(state);
+		break;
+	case mode::religion:
+		prov_color = religion_map_from(state);
 		break;
 	default:
 		return;

--- a/src/map/map_modes.hpp
+++ b/src/map/map_modes.hpp
@@ -27,7 +27,8 @@ enum class mode : uint8_t {
 	relation = 0x14,
 	crisis = 0x15,
 	naval = 0x16,
-	state_select = 0x17
+	state_select = 0x17,
+	religion = 0x18
 };
 
 const uint8_t PROV_COLOR_LAYERS = 2;

--- a/src/map/modes/religion.hpp
+++ b/src/map/modes/religion.hpp
@@ -1,0 +1,97 @@
+#pragma once
+
+std::vector<uint32_t> get_religion_global_color(sys::state& state) {
+	uint32_t province_size = state.world.province_size() + 1;
+	uint32_t texture_size = province_size + 256 - province_size % 256;
+
+	std::vector<uint32_t> prov_color(texture_size * 2);
+	state.world.for_each_province([&](dcon::province_id prov_id) {
+		auto id = province::to_map_id(prov_id);
+		float total_pops = state.world.province_get_demographics(prov_id, demographics::total);
+
+		dcon::religion_id primary_religion, secondary_religion;
+		float primary_religion_percent = 0.f, secondary_religion_percent = 0.f;
+
+		state.world.for_each_religion([&](dcon::religion_id religion_id) {
+			auto demo_key = demographics::to_key(state, religion_id);
+			auto volume = state.world.province_get_demographics(prov_id, demo_key);
+			float percent = volume / total_pops;
+
+			if(percent > primary_religion_percent) {
+				secondary_religion = primary_religion;
+				secondary_religion_percent = primary_religion_percent;
+				primary_religion = religion_id;
+				primary_religion_percent = percent;
+			} else if(percent > secondary_religion_percent) {
+				secondary_religion = religion_id;
+				secondary_religion_percent = percent;
+			}
+		});
+
+		dcon::religion_fat_id fat_primary_religion = dcon::fatten(state.world, primary_religion);
+
+		uint32_t primary_religion_color = fat_primary_religion.get_color();
+		uint32_t secondary_religion_color = 0xFFAAAAAA; // This color won't be reached
+
+		if(bool(secondary_religion)) {
+			dcon::religion_fat_id fat_secondary_religion = dcon::fatten(state.world, secondary_religion);
+			secondary_religion_color = fat_secondary_religion.get_color();
+		}
+
+		if(secondary_religion_percent >= .35) {
+			prov_color[id] = primary_religion_color;
+			prov_color[id + texture_size] = secondary_religion_color;
+		} else {
+			prov_color[id] = primary_religion_color;
+			prov_color[id + texture_size] = primary_religion_color;
+		}
+	});
+
+	return prov_color;
+}
+
+std::vector<uint32_t> get_religion_diaspora_color(sys::state& state) {
+	auto fat_selected_id = dcon::fatten(state.world, state.map_state.get_selected_province());
+	auto religion_id = fat_selected_id.get_dominant_religion();
+	auto religion_key = demographics::to_key(state, religion_id.id);
+
+	uint32_t province_size = state.world.province_size() + 1;
+	uint32_t texture_size = province_size + 256 - province_size % 256;
+
+	std::vector<uint32_t> prov_color(texture_size * 2);
+
+	if(bool(religion_id)) {
+		uint32_t full_color = religion_id.get_color();
+		uint32_t empty_color = 0xDDDDDD;
+		// Make the other end of the gradient dark if the color is bright and vice versa.
+		// This should make it easier to see religions that would otherwise be problematic.
+		if((full_color & 0xFF) + (full_color >> 8 & 0xFF) + (full_color >> 16 & 0xFF) > 140 * 3) {
+			empty_color = 0x222222;
+		}
+
+		state.world.for_each_province([&](dcon::province_id prov_id) {
+			auto i = province::to_map_id(prov_id);
+			auto fat_id = dcon::fatten(state.world, prov_id);
+			auto total_pop = state.world.province_get_demographics(prov_id, demographics::total);
+			auto religion_pop = state.world.province_get_demographics(prov_id, religion_key);
+			auto ratio = religion_pop / total_pop;
+
+			auto color = ogl::color_gradient(ratio, full_color, empty_color);
+
+			prov_color[i] = color;
+			prov_color[i + texture_size] = color;
+		});
+	}
+	return prov_color;
+}
+
+std::vector<uint32_t> religion_map_from(sys::state& state) {
+	std::vector<uint32_t> prov_color;
+	if(state.map_state.get_selected_province()) {
+		prov_color = get_religion_diaspora_color(state);
+	} else {
+		prov_color = get_religion_global_color(state);
+	}
+
+	return prov_color;
+}


### PR DESCRIPTION
Adds mod support for a religion map mode (`mapmode_24`) that works in the same way as the cultural map mode although it *does not* actually add the button to activate the map mode into PA. The GUI needs modified to add a button for it by adding a block of code like this to `interface/menubar.gui`. Note that this code specifically reuses the naval map mode icon and it is out of place so further UI tweaking would be needed but the feature is there for UI mods.

```
guiButtonType = {
	name = "mapmode_24"
	position = { x = -62 y = -136 }
	quadTextureSprite ="GFX_mapmode_naval"
	Orientation = "LOWER_RIGHT"
	clicksound = click
}
```

Pictures

![Screenshot1](https://github.com/schombert/Project-Alice/assets/105244635/4b6028a3-be1d-478d-88be-dcb2d05e7da0)

![Screenshot2](https://github.com/schombert/Project-Alice/assets/105244635/7d8d237c-9693-413b-b5da-722a3462b801)

![Screenshot3](https://github.com/schombert/Project-Alice/assets/105244635/6206ba3d-830b-4ecf-b16a-68da06593baf)
