### PR TITLE
Influence number in the outline

### DIFF
--- a/src/gui/gui_outliner_window.hpp
+++ b/src/gui/gui_outliner_window.hpp
@@ -364,8 +364,9 @@ public:
 			auto grid = std::get<dcon::gp_relationship_id>(content);
 			auto nid = state.world.gp_relationship_get_influence_target(grid);
 			auto status = state.world.gp_relationship_get_status(grid);
+			auto influence = state.world.gp_relationship_get_influence(grid);
 
-			auto full_str = text::produce_simple_string(state, state.world.nation_get_name(nid)) + " (" + text::get_influence_level_name(state, status) + ")";
+			auto full_str = text::produce_simple_string(state, state.world.nation_get_name(nid)) + " (" + text::get_influence_level_name(state, status) + ", " + text::format_float(influence, 0) + ")";
 
 			color = text::text_color::white;
 			set_text(state, full_str);


### PR DESCRIPTION
To make outliner more usual for people coming from base V2, it's relevant to include the influence points count in the outliner window.