### PR TITLE
Fix else if condition in economy AI

### DIFF
--- a/src/ai/ai.cpp
+++ b/src/ai/ai.cpp
@@ -2965,7 +2965,7 @@ void update_budget(sys::state& state) {
 			int max_social = int(100.f * poor_militancy);
 
 			// Laissez faire prioritize tax free capitalists
-			if(n.get_spending_level() < 1.0f || n.get_last_treasury() > n.get_stockpiles(economy::money)) { // losing money
+			if(n.get_spending_level() < 1.0f || n.get_last_treasury() >= n.get_stockpiles(economy::money)) { // losing money
 				if(n.get_administrative_efficiency() > 0.98f) {
 					n.set_administrative_spending(int8_t(std::max(0, n.get_administrative_spending() - 2)));
 				}
@@ -2977,7 +2977,7 @@ void update_budget(sys::state& state) {
 				n.set_poor_tax(int8_t(std::clamp(n.get_poor_tax() + 5, 0, max_poor_tax)));
 				n.set_middle_tax(int8_t(std::clamp(n.get_middle_tax() + 3, 0, max_mid_tax)));
 				n.set_rich_tax(int8_t(std::clamp(n.get_rich_tax() + 2, 0, max_rich_tax)));
-			} else if(n.get_last_treasury() > n.get_stockpiles(economy::money)) { // gaining money
+			} else if(n.get_last_treasury() < n.get_stockpiles(economy::money)) { // gaining money
 				if(n.get_administrative_efficiency() < 0.98f) {
 					n.set_administrative_spending(int8_t(std::min(100, n.get_administrative_spending() + 2)));
 				}


### PR DESCRIPTION
The laissez faire branch of the eco AI had a redundant else if condition that meant that the AI would never recognize that it was gaining money and adjust its budget accordingly. The non-LF AI didn't have this issue so I duplicated the conditions in the corresponding if-else statement.