### PR TITLE
make mainmenu command toggle mainmenu instead of triggering sigsegv

### DIFF
--- a/src/gui/gui_console.cpp
+++ b/src/gui/gui_console.cpp
@@ -545,9 +545,13 @@ void ui::console_edit::edit_box_enter(sys::state& state, std::string_view s) noe
 	}
 	switch(pstate.cmd.mode) {
 	case command_info::type::mainmenu:
-		state.ui_state.main_menu_win->is_visible() ? state.ui_state.main_menu_win->set_visible(state, false)
-			: state.ui_state.main_menu_win->set_visible(state, true);
-		state.ui_state.main_menu_win->impl_on_update(state);
+		if(!state.ui_state.main_menu) {
+			show_main_menu(state);
+		} else {
+			state.ui_state.main_menu->is_visible() ? state.ui_state.main_menu->set_visible(state, false)
+				: state.ui_state.main_menu->set_visible(state, true);
+			state.ui_state.main_menu->impl_on_update(state);
+		}
 		break;
 	case command_info::type::elecwin:
 		state.ui_state.election_window->is_visible() ? state.ui_state.election_window->set_visible(state, false)


### PR DESCRIPTION
i dont know what `state.ui_state.main_menu_win` is for. this change leaves only its declaration and initialization with `nullptr`. should maybe be removed.