### PR TITLE
Fix incorrect AI CB fabrication target

### DIFF
--- a/src/ai/ai.cpp
+++ b/src/ai/ai.cpp
@@ -2030,7 +2030,7 @@ void update_cb_fabrication(sys::state& state) {
 					auto t = possible_targets[rng::reduce(uint32_t(rng::get_random(state, uint32_t(n.id.index())) >> 2), uint32_t(possible_targets.size()))];
 					auto cb = pick_fabrication_type(state, n, t);
 					if(cb) {
-						n.set_constructing_cb_target(n.get_ai_rival());
+						n.set_constructing_cb_target(t);
 						n.set_constructing_cb_type(cb);
 					}
 				}


### PR DESCRIPTION
Fixing what looks like a copy-paste error where the AI only fabricates CBs against its rival. `n.get_ai_rival()` also could be invalid here anyways since it's in the else branch of the `if(n.get_ai_rival() && ,,,)` check.