### PR TITLE
Add ability to name wars based on belligerents

### DIFF
--- a/src/gui/topbar_subwindows/gui_diplomacy_window.hpp
+++ b/src/gui/topbar_subwindows/gui_diplomacy_window.hpp
@@ -14,7 +14,7 @@
 #include "gui_crisis_window.hpp"
 
 namespace military {
-void populate_war_text_subsitutions(sys::state&, dcon::war_id, text::substitution_map&);
+std::string get_war_name(sys::state&, dcon::war_id);
 }
 
 namespace ui {
@@ -1646,9 +1646,7 @@ public:
 class war_name_text : public simple_text_element_base {
 	void on_update(sys::state& state) noexcept override {
 		auto w = retrieve<dcon::war_id>(state, parent);
-		text::substitution_map sub;
-		military::populate_war_text_subsitutions(state, w, sub);
-		auto s = text::resolve_string_substitution(state, state.world.war_get_name(w), sub);
+		auto s = military::get_war_name(state, w);
 		set_text(state, s);
 	}
 };


### PR DESCRIPTION
A casus belli gives a war its name, usually something like `WAR_CONQUEST_ANY_NAME` which looks up a localization string `NORMAL_WAR_CONQUEST_ANY_NAME`, but Victoria 2 also had a feature where you can specify a localization string `NORMAL_WAR_CONQUEST_ANY_NAME_ABC_DEF` which, if there was a war where the primary attacker had the tag `ABC` and the primary defender had the tag `DEF`, would give that specific war the name specified in the localization file for that combination of tags, otherwise it would default to the usual war name if there wasn't any. Mods like HPM used this for wars like the Oriental Crisis and European intervention against Egypt for example.

This feature has been implemented, although the code isn't the prettiest since it needs to look up the raw localization tag instead of using the `dcon::text_sequence_id` which is stored for the war, however this approach doesn't require storing any additional data. Iterating over the entire text sequence map to look up a key given a value isn't efficient, however the war name is only generated for certain UI functions so performance shouldn't be an issue. I'm open to feedback if there's a nicer way to do this.

Here's a snapshot from a test game with this PR.

![Screenshot](https://github.com/schombert/Project-Alice/assets/105244635/966f8a24-fa84-4590-b9be-eb43851254e9)
