### PR TITLE
Fix pop data regeneration

### DIFF
--- a/src/economy/demographics.cpp
+++ b/src/economy/demographics.cpp
@@ -63,7 +63,7 @@ uint32_t size(sys::state const& state) {
 				 uint32_t(2) * state.world.pop_type_size() + state.world.culture_size() + state.world.religion_size();
 }
 uint32_t common_size(sys::state const& state) {
-	return count_special_keys + uint32_t(2) * state.world.pop_type_size();
+	return count_special_keys;
 }
 
 template<typename F>
@@ -110,7 +110,7 @@ void sum_over_single_nation_demographics(sys::state& state, dcon::demographics_k
 		for(auto sm : sc.get_state().get_definition().get_abstract_state_membership()) {
 			state.world.state_instance_get_demographics(location, key) += state.world.province_get_demographics(sm.get_province(), key);
 		}
-		
+
 	}
 	state.world.nation_set_demographics(n, key, 0.f);
 	for(auto sc : state.world.nation_get_state_ownership_as_nation(n)) {
@@ -140,7 +140,7 @@ void regenerate_from_pop_data(sys::state& state) {
 		auto index = base_index;
 		if constexpr(!full) {
 			if(index >= csz) {
-				index += extra_size * (state.current_date.value % extra_demo_grouping);
+				index += extra_group_size * (state.current_date.value % extra_demo_grouping);
 				if(index >= sz)
 					return;
 			}


### PR DESCRIPTION
`extra_size = sz - csz` so `if(index >= csz)`, `index += extra_size * some positive integer` will always be `>= sz` so the function returns instead of updating certain pop data like was mentioned in the comments here 001716c (although I think the cause was in a different commit).