### PR TITLE
Colonial power tooltip detail added

### DIFF
--- a/src/gui/gui_topbar.hpp
+++ b/src/gui/gui_topbar.hpp
@@ -129,25 +129,32 @@ public:
 	void update_tooltip(sys::state& state, int32_t x, int32_t y, text::columnar_layout& contents) noexcept override {
 		auto nation_id = retrieve<dcon::nation_id>(state, parent);
 
-		float points = 0.f;
-		state.world.for_each_technology([&](dcon::technology_id t) {
-			if(state.world.nation_get_active_technologies(nation_id, t))
-				points += float(state.world.technology_get_colonial_points(t));
-		});
-
 		text::substitution_map sub;
 		std::string value;
 		value = text::prettify(nations::free_colonial_points(state, nation_id));
 		text::add_to_substitution_map(sub, text::variable_type::value, std::string_view(value));
 		auto box = text::open_layout_box(contents, 0);
 		text::localised_format_box(state, contents, box, std::string_view("colonial_points"), sub);
+		text::add_line_break_to_layout_box(state, contents, box);
+		text::localised_format_box(state, contents, box, std::string_view("explain_colonial_points"), sub);
 		text::add_divider_to_layout_box(state, contents, box);
 		text::localised_format_box(state, contents, box, std::string_view("available_colonial_power"), sub);
 		text::add_line_break_to_layout_box(state, contents, box);
-		text::localised_format_box(state, contents, box, std::string_view("from_technology"), sub);
+		text::localised_format_box(state, contents, box, std::string_view("colonial_points_from_technology"), sub);
 		text::add_space_to_layout_box(state, contents, box);
-		text::add_to_layout_box(state, contents, box, text::format_float(points, 0), text::text_color::green);
-
+		text::add_to_layout_box(state, contents, box, text::format_float(nations::colonial_points_from_technology(state, nation_id), 0), text::text_color::green);
+		text::add_line_break_to_layout_box(state, contents, box);
+		text::localised_format_box(state, contents, box, std::string_view("colonial_points_from_naval_bases"), sub);
+		text::add_space_to_layout_box(state, contents, box);
+		text::add_to_layout_box(state, contents, box, text::format_float(nations::colonial_points_from_naval_bases(state, nation_id), 0), text::text_color::green);
+		text::add_line_break_to_layout_box(state, contents, box);
+		text::localised_format_box(state, contents, box, std::string_view("colonial_points_from_ships"), sub);
+		text::add_space_to_layout_box(state, contents, box);
+		text::add_to_layout_box(state, contents, box, text::format_float(nations::colonial_points_from_ships(state, nation_id), 0), text::text_color::green);
+		text::add_line_break_to_layout_box(state, contents, box);
+		text::localised_format_box(state, contents, box, std::string_view("used_colonial_maintenance"), sub);
+		text::add_space_to_layout_box(state, contents, box);
+		text::add_to_layout_box(state, contents, box, text::format_float(nations::used_colonial_points(state, nation_id), 0), text::text_color::red);
 		text::close_layout_box(contents, box);
 	}
 };

--- a/src/nations/nations.hpp
+++ b/src/nations/nations.hpp
@@ -286,6 +286,10 @@ float get_bank_funds(sys::state& state, dcon::nation_id n);
 float get_debt(sys::state& state, dcon::nation_id n);
 float tariff_efficiency(sys::state& state, dcon::nation_id n);
 float tax_efficiency(sys::state& state, dcon::nation_id n);
+float colonial_points_from_naval_bases(sys::state& state, dcon::nation_id n);
+float colonial_points_from_ships(sys::state& state, dcon::nation_id n);
+float colonial_points_from_technology(sys::state& state, dcon::nation_id n);
+float used_colonial_points(sys::state& state, dcon::nation_id n);
 int32_t free_colonial_points(sys::state& state, dcon::nation_id n);
 int32_t max_colonial_points(sys::state& state, dcon::nation_id n);
 


### PR DESCRIPTION
The contents of max_colonial_points() and free_colonial_points() functions have been separated into functions in the same namespace so they can be called in a way that looks intuitive for the newly added details in gui_topbar, instead of basically repeating the contents of nations.cpp there

The csv file needs to be updated with some text keys because as you have seen my computer is messing it up. It will work fine without them so I can add them later if you don't want to
explain_colonial_points;Secondary and Great Powers accumulate colonial points.
colonial_points_from_technology;From technologies:
colonial_points_from_naval_bases;From naval bases:
colonial_points_from_ships;From ships:
used_colonial_maintenance;Maintaining existing colonies: