### PR TITLE
Add support for COUNTRY_ADJ and RELIGION tokens in rebel names

### DIFF
--- a/src/culture/rebels.cpp
+++ b/src/culture/rebels.cpp
@@ -1247,19 +1247,25 @@ std::string rebel_name(sys::state& state, dcon::rebel_faction_id reb) {
 	text::substitution_map sub;
 
 	auto culture = state.world.rebel_faction_get_primary_culture(reb);
+	auto religion = state.world.rebel_faction_get_religion(reb);
 	auto defection_target = state.world.rebel_faction_get_defection_target(reb);
 	auto in_nation = state.world.rebel_faction_get_ruler_from_rebellion_within(reb);
 	auto rebel_adj = state.world.nation_get_adjective(in_nation);
 	auto adjective = defection_target.get_adjective();
 
 	text::add_to_substitution_map(sub, text::variable_type::country, rebel_adj);
-	
+	text::add_to_substitution_map(sub, text::variable_type::country_adj, rebel_adj);
+
 	if(culture) {
 		text::add_to_substitution_map(sub, text::variable_type::culture, culture.get_name());
 	} else {
 		text::add_to_substitution_map(sub, text::variable_type::culture, state.world.nation_get_primary_culture(in_nation).get_name());
 	}
-	
+
+	if(religion) {
+		text::add_to_substitution_map(sub, text::variable_type::religion, religion.get_name());
+	}
+
 	if(defection_target) {
 		text::add_to_substitution_map(sub, text::variable_type::indep, adjective);
 		text::add_to_substitution_map(sub, text::variable_type::union_adj, adjective);

--- a/src/text/text.cpp
+++ b/src/text/text.cpp
@@ -487,6 +487,7 @@ variable_type variable_type_from_name(std::string_view v) {
 		CT_STRING_ENUM(progress)
 		CT_STRING_ENUM(province)
 		CT_STRING_ENUM(relation)
+		CT_STRING_ENUM(religion)
 		CT_STRING_ENUM(reqlevel)
 		CT_STRING_ENUM(required)
 		CT_STRING_ENUM(resource)
@@ -1408,13 +1409,13 @@ void add_line(sys::state& state, layout_base& dest, std::string_view key, int32_
 void add_line_with_condition(sys::state& state, layout_base& dest, std::string_view key, bool condition_met, int32_t indent) {
 	auto box = text::open_layout_box(dest, indent);
 
-	
+
 	if(condition_met) {
 		text::add_to_layout_box(state, dest, box, std::string_view("\x02"), text::text_color::green);
 	} else {
 		text::add_to_layout_box(state, dest, box, std::string_view("\x01"), text::text_color::red);
 	}
-	
+
 
 	text::add_space_to_layout_box(state, dest, box);
 
@@ -1428,13 +1429,13 @@ void add_line_with_condition(sys::state& state, layout_base& dest, std::string_v
 void add_line_with_condition(sys::state& state, layout_base& dest, std::string_view key, bool condition_met, variable_type subkey, substitution value, int32_t indent) {
 	auto box = text::open_layout_box(dest, indent);
 
-	
+
 	if(condition_met) {
 		text::add_to_layout_box(state, dest, box, std::string_view("\x02"), text::text_color::green);
 	} else {
 		text::add_to_layout_box(state, dest, box, std::string_view("\x01"), text::text_color::red);
 	}
-	
+
 	text::add_space_to_layout_box(state, dest, box);
 
 	if(auto k = state.key_to_text_sequence.find(key); k != state.key_to_text_sequence.end()) {
@@ -1449,13 +1450,13 @@ void add_line_with_condition(sys::state& state, layout_base& dest, std::string_v
 void add_line_with_condition(sys::state& state, layout_base& dest, std::string_view key, bool condition_met, variable_type subkey, substitution value, variable_type subkeyb, substitution valueb, int32_t indent) {
 	auto box = text::open_layout_box(dest, indent);
 
-	
+
 	if(condition_met) {
 		text::add_to_layout_box(state, dest, box, std::string_view("\x02"), text::text_color::green);
 	} else {
 		text::add_to_layout_box(state, dest, box, std::string_view("\x01"), text::text_color::red);
 	}
-	
+
 	text::add_space_to_layout_box(state, dest, box);
 
 	if(auto k = state.key_to_text_sequence.find(key); k != state.key_to_text_sequence.end()) {

--- a/src/text/text.hpp
+++ b/src/text/text.hpp
@@ -289,6 +289,7 @@ enum class variable_type : uint16_t {
 	region,
 	rel,
 	relation,
+	religion,
 	req,
 	reqlevel,
 	required,


### PR DESCRIPTION
Re-adding support for $COUNTRY_ADJ$ as a rebel name token since that was something that Victoria 2 had then also added in support for a $RELIGION$ token since that type of rebel group is supported (although I'm not sure what the V2 token was since it was never really used).