### PR TITLE
Fix incorrect budget slider constraint

### DIFF
--- a/src/economy/economy.cpp
+++ b/src/economy/economy.cpp
@@ -3916,7 +3916,7 @@ void bound_budget_settings(sys::state& state, dcon::nation_id n) {
 			max_spend = 100;
 		max_spend = std::max(min_spend, max_spend);
 
-		auto& v = state.world.nation_get_social_spending(n);
+		auto& v = state.world.nation_get_domestic_investment_spending(n);
 		v = int8_t(std::clamp(std::clamp(int32_t(v), min_spend, max_spend), 0, 100));
 	}
 }


### PR DESCRIPTION
Bounding the social spending slider instead of the domestic investment one.