### PR TITLE
Rework loan system

### DIFF
--- a/src/economy/economy.hpp
+++ b/src/economy/economy.hpp
@@ -222,6 +222,10 @@ dcon::modifier_id get_province_immigrator_modifier(sys::state& state);
 bool can_take_loans(sys::state& state, dcon::nation_id n);
 float interest_payment(sys::state& state, dcon::nation_id n);
 float max_loan(sys::state& state, dcon::nation_id n);
+float take_loans(sys::state& state, dcon::nation_id n, float amount);
+float take_loan_from(sys::state& state, dcon::nation_id debtor, dcon::nation_id creditor, float amount);
+float repay_loans(sys::state& state, dcon::nation_id n, float amount);
+float repay_loan_from(sys::state& state, dcon::nation_id debtor, dcon::nation_id creditor, float amount);
 
 commodity_production_type get_commodity_production_type(sys::state& state, dcon::commodity_id c);
 } // namespace economy

--- a/src/gamestate/dcon_generated.txt
+++ b/src/gamestate/dcon_generated.txt
@@ -1513,7 +1513,7 @@ relationship{
 		index_storage{array}
 		multiple{2}
 	}
-	
+
 	composite_key{
 		name{province_pair}
 		index{connected_provinces}
@@ -1543,7 +1543,7 @@ relationship{
 		index_storage{array}
 		multiple{2}
 	}
-	
+
 	composite_key{
 		name{nation_adjacency_pair}
 		index{connected_nations}
@@ -1566,16 +1566,16 @@ object {
 		type{ unit_type_id }
 		tag{ save }
 	}
-	property{	
+	property{
 		name{ strength }
 		type{ float }
 		tag{ save }
 	}
-	property{	
+	property{
 		name{ pending_damage }
 		type{ float }
 	}
-	property{	
+	property{
 		name{ org }
 		type{ float }
 		tag{ save }
@@ -1602,12 +1602,12 @@ object {
 		type{ unit_type_id }
 		tag{ save }
 	}
-	property{	
+	property{
 		name{ strength }
 		type{ float }
 		tag{ save }
 	}
-	property{	
+	property{
 		name{ org }
 		type{ float }
 		tag{ save }
@@ -2173,12 +2173,12 @@ object {
 		type{vector_pool{5000}{military::reserve_regiment}}
 		tag{ save }
 	}
-	
+
 	property{
 		name{ defender_casualties }
 		type{ float }
 	}
-	
+
 	property{
 		name{ attacker_casualties }
 		type{ float }
@@ -3736,7 +3736,7 @@ relationship{
 		index_storage{array}
 		multiple{2}
 	}
-	
+
 	composite_key{
 		name{diplomatic_pair}
 		index{related_nations}
@@ -3777,7 +3777,7 @@ relationship{
 		type{many}
 		index_storage{array}
 	}
-	
+
 	composite_key{
 		name{unilateral_pair}
 		index{target}
@@ -3786,11 +3786,6 @@ relationship{
 
 	property{
 		name{ foreign_investment }
-		type{ float }
-		tag{ save }
-	}
-	property{
-		name{ owns_debt_of }
 		type{ float }
 		tag{ save }
 	}
@@ -3806,6 +3801,42 @@ relationship{
 	}
 	property{
 		name{ reparations }
+		type{ bitfield }
+		tag{ save }
+	}
+}
+
+relationship{
+	name{ loan }
+	storage_type{ compactable }
+	size{ 50000 }
+	tag{ save }
+
+	link{
+		object{nation}
+		name{debtor}
+		type{many}
+		index_storage{array}
+	}
+	link{
+		object{nation}
+		name{creditor}
+		type{many}
+		index_storage{array}
+	}
+
+	composite_key{
+		name{loan_pair}
+		index{debtor}
+		index{creditor}
+	}
+	property{
+		name{ principal }
+		type{ float }
+		tag{ save }
+	}
+	property{
+		name{ is_interest_active }
 		type{ bitfield }
 		tag{ save }
 	}

--- a/src/nations/nations.hpp
+++ b/src/nations/nations.hpp
@@ -42,7 +42,7 @@ struct global_national_state {
 	std::vector<triggered_modifier> triggered_modifiers;
 	std::vector<dcon::bitfield_type> global_flag_variables;
 	std::vector<dcon::nation_id> nations_by_rank;
-	
+
 	tagged_vector<dcon::text_sequence_id, dcon::national_flag_id> flag_variable_names;
 	tagged_vector<dcon::text_sequence_id, dcon::global_flag_id> global_flag_variable_names;
 	tagged_vector<dcon::text_sequence_id, dcon::national_variable_id> variable_names;
@@ -284,6 +284,7 @@ float leadership_points(sys::state const& state, dcon::nation_id n);
 float get_treasury(sys::state& state, dcon::nation_id n);
 float get_bank_funds(sys::state& state, dcon::nation_id n);
 float get_debt(sys::state& state, dcon::nation_id n);
+float get_available_for_loan(sys::state& state, dcon::nation_id n);
 float tariff_efficiency(sys::state& state, dcon::nation_id n);
 float tax_efficiency(sys::state& state, dcon::nation_id n);
 float colonial_points_from_naval_bases(sys::state& state, dcon::nation_id n);


### PR DESCRIPTION
Fleshes out the loan system with mechanics for tracking how much one country owes another at any given time which helps with handling bankruptcy events. This is still a WIP but I wanted to see if there was anything I needed to change or if there were any suggestions, particularly for handling things like what happens when a country loans out a pop's savings then that pop goes to withdraw its savings (basically how to handle the reserve requirement of a national bank) and how to track how much of each pop's money is currently being loaned out for the purpose of interest payments. Victoria 2 had a bug where interest payments on national bank debt never made its way to the pops' pockets which meant that that money was vanishing from the simulation so I want to make sure that bug is fixed as well.

Currently implemented is the national bank system, "shadowy financiers" or private investors which Victoria 2 had to make sure there was money available for loans if no other nations had money available to loan, functions to take/repay loans given an amount of money to cover/repay, and bankruptcy turning loan interest off but there's still some interface work to do, more extensive testing, and some sort of AI loan logic would be nice.

I'll see about getting any sort of low-hanging fruit for increased modability into this PR without bloating the scope, I think an easy one would be having a separate interest rate (and modifiers) for national vs foreign debt.