### PR TITLE
Expand incremental building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,16 @@ list(APPEND ALICE_SOURCES_LIST
 	"src/text/fonts.cpp"
 	"src/graphics/texture.cpp"
 	"src/common_types/date_interface.cpp"
+	"src/ai/ai.cpp"
+	"src/culture/culture.cpp"
+	"src/economy/economy.cpp"
+	"src/gamestate/modifiers.cpp"
+	"src/gamestate/serialization.cpp"
+	"src/military/military.cpp"
+	"src/nations/nations.cpp"
+	"src/provinces/province.cpp"
+	"src/scripting/effects.cpp"
+	"src/scripting/triggers.cpp"
 )
 
 if(WIN32)

--- a/src/ai/ai.cpp
+++ b/src/ai/ai.cpp
@@ -1,6 +1,14 @@
 #include "ai.hpp"
 #include "system_state.hpp"
+#include "demographics.hpp"
+#include "effects.hpp"
+#include "gui_effect_tooltips.hpp"
 #include "math_fns.hpp"
+#include "military.hpp"
+#include "politics.hpp"
+#include "prng.hpp"
+#include "province_templates.hpp"
+#include "triggers.hpp"
 
 namespace ai {
 
@@ -1020,7 +1028,7 @@ void update_ai_econ_construction(sys::state& state) {
 								// TODO: try to delete a factory here
 							}
 					} // END for(auto si : ordered_states) {
-				} // END if((rules & issue_rule::build_factory) == 0) 
+				} // END if((rules & issue_rule::build_factory) == 0)
 			} // END if(!desired_types.empty()) {
 		} // END  if((rules & issue_rule::expand_factory) != 0 || (rules & issue_rule::build_factory) != 0)
 
@@ -2749,7 +2757,7 @@ bool will_accept_peace_offer_value(sys::state& state,
 		if(scoreagainst_me > 50 && scoreagainst_me > -overall_po_value * 2)
 			return true;
 
-		if(overall_score < 0.0f) { // we are losing	
+		if(overall_score < 0.0f) { // we are losing
 			if(personal_score_saved > 0 && scoreagainst_me + personal_score_saved - my_po_target >= -overall_po_value)
 				return true;
 
@@ -2864,7 +2872,7 @@ bool will_accept_peace_offer(sys::state& state, dcon::nation_id n, dcon::nation_
 		if(scoreagainst_me > 50 && scoreagainst_me > -overall_po_value * 2)
 			return true;
 
-		if(overall_score < 0.0f) { // we are losing	
+		if(overall_score < 0.0f) { // we are losing
 			if(personal_score_saved > 0 && scoreagainst_me + personal_score_saved - my_po_target >= -overall_po_value)
 				return true;
 
@@ -2917,7 +2925,7 @@ void make_war_decs(sys::state& state) {
 		float best_difference = 2.0f;
 
 		//Great powers should look for non-neighbor nations to use their existing wargoals on; helpful for forcing unification/repay debts wars to happen
-		
+
 		if(nations::is_great_power(state, n)) {
 			for(auto target : state.world.in_nation) {
 				if(target == n)
@@ -3618,7 +3626,7 @@ void pickup_idle_ships(sys::state& state) {
 							n.set_arrival_time(sys::date{});
 							send_fleet_home(state, n);
 						}
-						
+
 					} else if(auto path = province::make_path_to_nearest_coast(state, owner, transported_dest); path.empty()) {
 						send_fleet_home(state, n);
 					} else {
@@ -3735,7 +3743,7 @@ void pickup_idle_ships(sys::state& state) {
 					failed_transport = false;
 				}
 			}
-			
+
 			if(transporting.begin() == transporting.end()) {
 				// all unloaded -> set to unspecified to send home later in this routine
 				state.world.navy_set_ai_activity(n, uint8_t(fleet_activity::unspecified));
@@ -4243,7 +4251,7 @@ float estimate_attack_force(sys::state& state, dcon::province_id target, dcon::n
 			if(!other_nation) {
 				strength_total += estimate_army_strength(state, ar.get_army());
 			}
-			
+
 		}
 		return state.defines.alice_ai_threat_overestimate * strength_total;
 	}

--- a/src/culture/culture.cpp
+++ b/src/culture/culture.cpp
@@ -1,9 +1,11 @@
-#include "dcon_generated.hpp"
 #include "culture.hpp"
+#include "dcon_generated.hpp"
+#include "demographics.hpp"
+#include "gui_element_base.hpp"
+#include "prng.hpp"
+#include "province_templates.hpp"
 #include "system_state.hpp"
 #include "triggers.hpp"
-#include "prng.hpp"
-#include "gui_element_base.hpp"
 
 namespace culture {
 
@@ -28,7 +30,7 @@ void clear_existing_tech_effects(sys::state& state) {
 		state.world.execute_serial_over_nation([&](auto nation_indices) {
 			state.world.nation_set_max_building_level(nation_indices, t, 0);
 		});
-		
+
 	}
 	state.world.for_each_factory_type([&](dcon::factory_type_id id) {
 		state.world.execute_serial_over_nation([&](auto nation_indices) {
@@ -692,7 +694,7 @@ flag_type get_current_flag_type(sys::state const& state, dcon::nation_id target_
 	auto gov_type = state.world.nation_get_government_type(target_nation);
 	if(!gov_type)
 		return flag_type::default_flag;
-	
+
 	auto id = state.world.national_identity_get_government_flag_type(state.world.nation_get_identity_from_identity_holder(target_nation), gov_type);
 	if(id != 0)
 		return flag_type(id - 1);

--- a/src/economy/demographics.cpp
+++ b/src/economy/demographics.cpp
@@ -2,6 +2,8 @@
 #include "dcon_generated.hpp"
 #include "system_state.hpp"
 #include "nations.hpp"
+#include "nations_templates.hpp"
+#include "ve_scalar_extensions.hpp"
 
 namespace pop_demographics {
 

--- a/src/economy/economy.cpp
+++ b/src/economy/economy.cpp
@@ -1,16 +1,25 @@
 #include "economy.hpp"
+#include "economy_templates.hpp"
+#include "demographics.hpp"
 #include "dcon_generated.hpp"
+#include "ai.hpp"
 #include "system_state.hpp"
 #include "prng.hpp"
+#include "nations_templates.hpp"
+#include "province_templates.hpp"
+#include "triggers.hpp"
 
 namespace economy {
+
+template void for_each_new_factory<std::function<void(new_factory)>>(sys::state&, dcon::state_instance_id, std::function<void(new_factory)>&&);
+template void for_each_upgraded_factory<std::function<void(upgraded_factory)>>(sys::state&, dcon::state_instance_id, std::function<void(upgraded_factory)>&&);
 
 bool can_take_loans(sys::state& state, dcon::nation_id n) {
 	if(!state.world.nation_get_is_player_controlled(n) || !state.world.nation_get_is_debt_spending(n))
 		return false;
 
 	/*
-	A country cannot borrow if it is less than define:BANKRUPTCY_EXTERNAL_LOAN_YEARS since their last bankruptcy. 
+	A country cannot borrow if it is less than define:BANKRUPTCY_EXTERNAL_LOAN_YEARS since their last bankruptcy.
 	*/
 	auto last_br = state.world.nation_get_bankrupt_until(n);
 	if(last_br && state.current_date < last_br)
@@ -21,7 +30,7 @@ bool can_take_loans(sys::state& state, dcon::nation_id n) {
 
 float interest_payment(sys::state& state, dcon::nation_id n) {
 	/*
-	Every day, a nation must pay its creditors. It must pay national-modifier-to-loan-interest x debt-amount x interest-to-debt-holder-rate / 30 
+	Every day, a nation must pay its creditors. It must pay national-modifier-to-loan-interest x debt-amount x interest-to-debt-holder-rate / 30
 	When a nation takes a loan, the interest-to-debt-holder-rate is set at nation-taking-the-loan-technology-loan-interest-modifier + define:LOAN_BASE_INTEREST, with a minimum of 0.01.
 	*/
 	auto debt = state.world.nation_get_stockpiles(n, money);
@@ -32,7 +41,7 @@ float interest_payment(sys::state& state, dcon::nation_id n) {
 }
 float max_loan(sys::state& state, dcon::nation_id n) {
 	/*
-	There is an income cap to how much may be borrowed, namely: define:MAX_LOAN_CAP_FROM_BANKS x (national-modifier-to-max-loan-amount + 1) x national-tax-base. 
+	There is an income cap to how much may be borrowed, namely: define:MAX_LOAN_CAP_FROM_BANKS x (national-modifier-to-max-loan-amount + 1) x national-tax-base.
 	*/
 	auto mod = (state.world.nation_get_modifier_values(n, sys::national_mod_offsets::max_loan_modifier) + 1.0f);
 	auto total_tax_base = state.world.nation_get_total_rich_income(n) + state.world.nation_get_total_middle_income(n) + state.world.nation_get_total_poor_income(n);
@@ -384,7 +393,7 @@ void adjust_artisan_balance(sys::state& state, dcon::nation_id n) {
 
 				auto limit = artisan_scale_limit(state, n, cid);
 				auto profit = std::max(base_artisan_profit(state, n, cid), 0.0f) * limit;
-				
+
 				total_ex_weights += w;
 				temp_weights[cid.index()] = profit * profit;
 				total_weights += profit * profit;
@@ -1147,7 +1156,7 @@ void update_national_artisan_production(sys::state& state, dcon::nation_id n) {
 
 	for(uint32_t i = 1; i < csize; ++i) {
 		dcon::commodity_id cid{ dcon::commodity_id::value_base_t(i) };
-		
+
 		if(state.world.nation_get_artisan_distribution(n, cid) > 0.0f) {
 
 			auto production = state.world.nation_get_artisan_actual_production(n, cid);
@@ -1166,7 +1175,7 @@ void update_national_artisan_production(sys::state& state, dcon::nation_id n) {
 				auto amount = min_input * production;
 				state.world.nation_set_artisan_actual_production(n, cid, amount);
 				state.world.nation_get_domestic_market_pool(n, cid) += amount;
-			} 
+			}
 		}
 	}
 }
@@ -3317,7 +3326,7 @@ float estimate_construction_spending(sys::state& state, dcon::nation_id n) {
 		auto p = po.get_province();
 		if(state.world.province_get_nation_from_province_control(p) != n)
 			continue;
-		
+
 		auto rng = state.world.province_get_province_naval_construction(p);
 		if(rng.begin() != rng.end()) {
 			auto c = *(rng.begin());
@@ -3361,7 +3370,7 @@ float estimate_construction_spending(sys::state& state, dcon::nation_id n) {
 			auto& base_cost = c.get_type().get_construction_costs();
 			auto& current_purchased = c.get_purchased_goods();
 			float construction_time = float(c.get_type().get_construction_time()) * (c.get_is_upgrade() ? 0.1f : 1.0f);
-			
+
 			for(uint32_t i = 0; i < commodity_set::set_size; ++i) {
 				if(base_cost.commodity_type[i]) {
 					if(current_purchased.commodity_amounts[i] < base_cost.commodity_amounts[i] * factory_mod * admin_cost_factor)
@@ -3410,7 +3419,7 @@ construction_status factory_upgrade(sys::state& state, dcon::factory_id f) {
 			float factory_mod = state.world.nation_get_modifier_values(st_con.get_nation(), sys::national_mod_offsets::factory_cost) + 1.0f;
 			float pop_factory_mod = std::max(0.1f, state.world.nation_get_modifier_values(st_con.get_nation(), sys::national_mod_offsets::factory_owner_cost));
 			float admin_cost_factor = (st_con.get_is_pop_project() ? pop_factory_mod : (2.0f - admin_eff)) * factory_mod;
-			
+
 
 			float total = 0.0f;
 			float purchased = 0.0f;
@@ -3426,52 +3435,6 @@ construction_status factory_upgrade(sys::state& state, dcon::factory_id f) {
 	}
 
 	return construction_status{0.0f, false};
-}
-
-template<typename F>
-void for_each_new_factory(sys::state& state, dcon::state_instance_id s, F&& func) {
-	for(auto st_con : state.world.state_instance_get_state_building_construction(s)) {
-		if(!st_con.get_is_upgrade()) {
-			float admin_eff = state.world.nation_get_administrative_efficiency(st_con.get_nation());
-			float factory_mod = state.world.nation_get_modifier_values(st_con.get_nation(), sys::national_mod_offsets::factory_cost) + 1.0f;
-			float pop_factory_mod = std::max(0.1f, state.world.nation_get_modifier_values(st_con.get_nation(), sys::national_mod_offsets::factory_owner_cost));
-			float admin_cost_factor = (st_con.get_is_pop_project() ? pop_factory_mod : (2.0f - admin_eff)) * factory_mod;
-
-			float total = 0.0f;
-			float purchased = 0.0f;
-			auto& goods = state.world.factory_type_get_construction_costs(st_con.get_type());
-
-			for(uint32_t i = 0; i < commodity_set::set_size; ++i) {
-				total += goods.commodity_amounts[i] * admin_cost_factor;
-				purchased += st_con.get_purchased_goods().commodity_amounts[i];
-			}
-
-			func(new_factory{total > 0.0f ? purchased / total : 0.0f, st_con.get_type().id});
-		}
-	}
-}
-
-template<typename F>
-void for_each_upgraded_factory(sys::state& state, dcon::state_instance_id s, F&& func) {
-	for(auto st_con : state.world.state_instance_get_state_building_construction(s)) {
-		if(st_con.get_is_upgrade()) {
-			float admin_eff = state.world.nation_get_administrative_efficiency(st_con.get_nation());
-			float factory_mod = state.world.nation_get_modifier_values(st_con.get_nation(), sys::national_mod_offsets::factory_cost) + 1.0f;
-			float pop_factory_mod = std::max(0.1f, state.world.nation_get_modifier_values(st_con.get_nation(), sys::national_mod_offsets::factory_owner_cost));
-			float admin_cost_factor = (st_con.get_is_pop_project() ? pop_factory_mod : (2.0f - admin_eff)) * factory_mod;
-
-			float total = 0.0f;
-			float purchased = 0.0f;
-			auto& goods = state.world.factory_type_get_construction_costs(st_con.get_type());
-
-			for(uint32_t i = 0; i < commodity_set::set_size; ++i) {
-				total += goods.commodity_amounts[i] * admin_cost_factor;
-				purchased += st_con.get_purchased_goods().commodity_amounts[i];
-			}
-
-			func(upgraded_factory{total > 0.0f ? purchased / total : 0.0f, st_con.get_type().id});
-		}
-	}
 }
 
 bool state_contains_constructed_factory(sys::state& state, dcon::state_instance_id s, dcon::factory_type_id ft) {
@@ -3515,7 +3478,7 @@ int32_t state_factory_count(sys::state& state, dcon::state_instance_id sid, dcon
 	for(auto p : state.world.state_instance_get_state_building_construction(sid))
 		if(p.get_is_upgrade() == false)
 			++num_factories;
-	
+
 	// For new factories: no more than defines:FACTORIES_PER_STATE existing + under construction new factories must be
 	assert(num_factories <= int32_t(state.defines.factories_per_state));
 	return num_factories;
@@ -3969,7 +3932,7 @@ void go_bankrupt(sys::state& state, dcon::nation_id n) {
 	auto& debt = state.world.nation_get_stockpiles(n, economy::money);
 
 	/*
-	 If a nation cannot pay and the amount it owes is less than define:SMALL_DEBT_LIMIT, the nation it owes money to gets an on_debtor_default_small event (with the nation defaulting in the from slot). Otherwise, the event is pulled from on_debtor_default. The nation then goes bankrupt. It receives the bad_debter modifier for define:BANKRUPCY_EXTERNAL_LOAN_YEARS years (if it goes bankrupt again within this period, creditors receive an on_debtor_default_second event). It receives the in_bankrupcy modifier for define:BANKRUPCY_DURATION days. Its prestige is reduced by a factor of define:BANKRUPCY_FACTOR, and each of its pops has their militancy increase by 2. 
+	 If a nation cannot pay and the amount it owes is less than define:SMALL_DEBT_LIMIT, the nation it owes money to gets an on_debtor_default_small event (with the nation defaulting in the from slot). Otherwise, the event is pulled from on_debtor_default. The nation then goes bankrupt. It receives the bad_debter modifier for define:BANKRUPCY_EXTERNAL_LOAN_YEARS years (if it goes bankrupt again within this period, creditors receive an on_debtor_default_second event). It receives the in_bankrupcy modifier for define:BANKRUPCY_DURATION days. Its prestige is reduced by a factor of define:BANKRUPCY_FACTOR, and each of its pops has their militancy increase by 2.
 	*/
 	auto existing_br = state.world.nation_get_bankrupt_until(n);
 	if(existing_br && state.current_date < existing_br) {

--- a/src/economy/economy.hpp
+++ b/src/economy/economy.hpp
@@ -191,17 +191,11 @@ struct new_factory {
 	float progress = 0.0f;
 	dcon::factory_type_id type;
 };
-template<typename F>
-void for_each_new_factory(sys::state& state, dcon::state_instance_id s,
-		F&& func); // calls the function repeatedly with new_factory as parameters
 
 struct upgraded_factory {
 	float progress = 0.0f;
 	dcon::factory_type_id type;
 };
-template<typename F>
-void for_each_upgraded_factory(sys::state& state, dcon::state_instance_id s,
-		F&& func); // calls the function repeatedly with new_factory as parameters
 
 bool state_contains_constructed_factory(sys::state& state, dcon::state_instance_id si, dcon::factory_type_id ft);
 bool state_contains_factory(sys::state& state, dcon::state_instance_id s, dcon::factory_type_id ft);

--- a/src/economy/economy_templates.hpp
+++ b/src/economy/economy_templates.hpp
@@ -1,0 +1,52 @@
+#pragma once
+#include "system_state.hpp"
+
+namespace economy {
+
+template<typename F>
+void for_each_new_factory(sys::state& state, dcon::state_instance_id s, F&& func) {
+	for(auto st_con : state.world.state_instance_get_state_building_construction(s)) {
+		if(!st_con.get_is_upgrade()) {
+			float admin_eff = state.world.nation_get_administrative_efficiency(st_con.get_nation());
+			float factory_mod = state.world.nation_get_modifier_values(st_con.get_nation(), sys::national_mod_offsets::factory_cost) + 1.0f;
+			float pop_factory_mod = std::max(0.1f, state.world.nation_get_modifier_values(st_con.get_nation(), sys::national_mod_offsets::factory_owner_cost));
+			float admin_cost_factor = (st_con.get_is_pop_project() ? pop_factory_mod : (2.0f - admin_eff)) * factory_mod;
+
+			float total = 0.0f;
+			float purchased = 0.0f;
+			auto& goods = state.world.factory_type_get_construction_costs(st_con.get_type());
+
+			for(uint32_t i = 0; i < commodity_set::set_size; ++i) {
+				total += goods.commodity_amounts[i] * admin_cost_factor;
+				purchased += st_con.get_purchased_goods().commodity_amounts[i];
+			}
+
+			func(new_factory{total > 0.0f ? purchased / total : 0.0f, st_con.get_type().id});
+		}
+	}
+}
+
+template<typename F>
+void for_each_upgraded_factory(sys::state& state, dcon::state_instance_id s, F&& func) {
+	for(auto st_con : state.world.state_instance_get_state_building_construction(s)) {
+		if(st_con.get_is_upgrade()) {
+			float admin_eff = state.world.nation_get_administrative_efficiency(st_con.get_nation());
+			float factory_mod = state.world.nation_get_modifier_values(st_con.get_nation(), sys::national_mod_offsets::factory_cost) + 1.0f;
+			float pop_factory_mod = std::max(0.1f, state.world.nation_get_modifier_values(st_con.get_nation(), sys::national_mod_offsets::factory_owner_cost));
+			float admin_cost_factor = (st_con.get_is_pop_project() ? pop_factory_mod : (2.0f - admin_eff)) * factory_mod;
+
+			float total = 0.0f;
+			float purchased = 0.0f;
+			auto& goods = state.world.factory_type_get_construction_costs(st_con.get_type());
+
+			for(uint32_t i = 0; i < commodity_set::set_size; ++i) {
+				total += goods.commodity_amounts[i] * admin_cost_factor;
+				purchased += st_con.get_purchased_goods().commodity_amounts[i];
+			}
+
+			func(upgraded_factory{total > 0.0f ? purchased / total : 0.0f, st_con.get_type().id});
+		}
+	}
+}
+
+} // namespace economy

--- a/src/gamestate/commands.hpp
+++ b/src/gamestate/commands.hpp
@@ -606,15 +606,19 @@ bool can_ban_embassy(sys::state& state, dcon::nation_id source, dcon::nation_id 
 
 void increase_opinion(sys::state& state, dcon::nation_id source, dcon::nation_id influence_target);
 bool can_increase_opinion(sys::state& state, dcon::nation_id source, dcon::nation_id influence_target);
+void execute_increase_opinion(sys::state& state, dcon::nation_id source, dcon::nation_id influence_target);
 
 void decrease_opinion(sys::state& state, dcon::nation_id source, dcon::nation_id influence_target, dcon::nation_id affected_gp);
 bool can_decrease_opinion(sys::state& state, dcon::nation_id source, dcon::nation_id influence_target, dcon::nation_id affected_gp);
+void execute_decrease_opinion(sys::state& state, dcon::nation_id source, dcon::nation_id influence_target, dcon::nation_id affected_gp);
 
 void add_to_sphere(sys::state& state, dcon::nation_id source, dcon::nation_id influence_target);
 bool can_add_to_sphere(sys::state& state, dcon::nation_id source, dcon::nation_id influence_target);
+void execute_add_to_sphere(sys::state& state, dcon::nation_id source, dcon::nation_id influence_target);
 
 void remove_from_sphere(sys::state& state, dcon::nation_id source, dcon::nation_id influence_target, dcon::nation_id affected_gp);
 bool can_remove_from_sphere(sys::state& state, dcon::nation_id source, dcon::nation_id influence_target, dcon::nation_id affected_gp);
+void execute_remove_from_sphere(sys::state& state, dcon::nation_id source, dcon::nation_id influence_target, dcon::nation_id affected_gp);
 
 void upgrade_colony_to_state(sys::state& state, dcon::nation_id source, dcon::state_instance_id si);
 bool can_upgrade_colony_to_state(sys::state& state, dcon::nation_id source, dcon::state_instance_id si);
@@ -630,6 +634,7 @@ bool can_finish_colonization(sys::state& state, dcon::nation_id source, dcon::pr
 
 void intervene_in_war(sys::state& state, dcon::nation_id source, dcon::war_id w, bool for_attacker);
 bool can_intervene_in_war(sys::state& state, dcon::nation_id source, dcon::war_id w, bool for_attacker);
+void execute_intervene_in_war(sys::state& state, dcon::nation_id source, dcon::war_id w, bool for_attacker);
 
 void suppress_movement(sys::state& state, dcon::nation_id source, dcon::movement_id m);
 bool can_suppress_movement(sys::state& state, dcon::nation_id source, dcon::movement_id m);
@@ -689,12 +694,14 @@ bool can_cancel_military_access(sys::state& state, dcon::nation_id source, dcon:
 
 void cancel_alliance(sys::state& state, dcon::nation_id source, dcon::nation_id target);
 bool can_cancel_alliance(sys::state& state, dcon::nation_id source, dcon::nation_id target, bool ignore_cost = false);
+void execute_cancel_alliance(sys::state& state, dcon::nation_id source, dcon::nation_id target);
 
 void cancel_given_military_access(sys::state& state, dcon::nation_id source, dcon::nation_id target); // this is for cancelling the access someone has with you
 bool can_cancel_given_military_access(sys::state& state, dcon::nation_id source, dcon::nation_id target, bool ignore_cost = false);
 
 void declare_war(sys::state& state, dcon::nation_id source, dcon::nation_id target, dcon::cb_type_id primary_cb, dcon::state_definition_id cb_state, dcon::national_identity_id cb_tag, dcon::nation_id cb_secondary_nation, bool call_attacker_allies);
 bool can_declare_war(sys::state& state, dcon::nation_id source, dcon::nation_id target, dcon::cb_type_id primary_cb, dcon::state_definition_id cb_state, dcon::national_identity_id cb_tag, dcon::nation_id cb_secondary_nation);
+void execute_declare_war(sys::state& state, dcon::nation_id source, dcon::nation_id target, dcon::cb_type_id primary_cb, dcon::state_definition_id cb_state, dcon::national_identity_id cb_tag, dcon::nation_id cb_secondary_nation, bool call_attacker_allies);
 
 void add_war_goal(sys::state& state, dcon::nation_id source, dcon::war_id w, dcon::nation_id target, dcon::cb_type_id primary_cb, dcon::state_definition_id cb_state, dcon::national_identity_id cb_tag, dcon::nation_id cb_secondary_nation);
 bool can_add_war_goal(sys::state& state, dcon::nation_id source, dcon::war_id w, dcon::nation_id target, dcon::cb_type_id primary_cb, dcon::state_definition_id cb_state, dcon::national_identity_id cb_tag, dcon::nation_id cb_secondary_nation);
@@ -785,23 +792,28 @@ flight while constructing / offering a crisis peace offer
 
 void start_peace_offer(sys::state& state, dcon::nation_id source, dcon::nation_id target, dcon::war_id war, bool is_concession);
 bool can_start_peace_offer(sys::state& state, dcon::nation_id source, dcon::nation_id target, dcon::war_id war, bool is_concession);
+void execute_start_peace_offer(sys::state& state, dcon::nation_id source, dcon::nation_id target, dcon::war_id war, bool is_concession);
 
 void add_to_peace_offer(sys::state& state, dcon::nation_id source, dcon::wargoal_id goal);
 bool can_add_to_peace_offer(sys::state& state, dcon::nation_id source, dcon::wargoal_id goal);
+void execute_add_to_peace_offer(sys::state& state, dcon::nation_id source, dcon::wargoal_id goal);
 
 void send_peace_offer(sys::state& state, dcon::nation_id source);
 bool can_send_peace_offer(sys::state& state, dcon::nation_id source);
+void execute_send_peace_offer(sys::state& state, dcon::nation_id source);
 
 // CRISIS PEACE OFFER COMMANDS
 
 void start_crisis_peace_offer(sys::state& state, dcon::nation_id source, bool is_concession);
 bool can_start_crisis_peace_offer(sys::state& state, dcon::nation_id source, bool is_concession);
+void execute_start_crisis_peace_offer(sys::state& state, dcon::nation_id source, bool is_concession);
 
 void add_to_crisis_peace_offer(sys::state& state, dcon::nation_id source, dcon::nation_id wargoal_from, dcon::nation_id target, dcon::cb_type_id primary_cb, dcon::state_definition_id cb_state, dcon::national_identity_id cb_tag, dcon::nation_id cb_secondary_nation);
 bool can_add_to_crisis_peace_offer(sys::state& state, dcon::nation_id source, dcon::nation_id wargoal_from, dcon::nation_id target, dcon::cb_type_id primary_cb, dcon::state_definition_id cb_state, dcon::national_identity_id cb_tag, dcon::nation_id cb_secondary_nation);
 
 void send_crisis_peace_offer(sys::state& state, dcon::nation_id source);
 bool can_send_crisis_peace_offer(sys::state& state, dcon::nation_id source);
+void execute_send_crisis_peace_offer(sys::state& state, dcon::nation_id source);
 
 void toggle_select_province(sys::state& state, dcon::nation_id source, dcon::province_id p);
 bool can_toggle_select_province(sys::state& state, dcon::nation_id source, dcon::province_id p);

--- a/src/gamestate/modifiers.cpp
+++ b/src/gamestate/modifiers.cpp
@@ -1,7 +1,12 @@
 #include "modifiers.hpp"
 #include "system_state.hpp"
-#include "province.hpp"
+#include "demographics.hpp"
 #include "military.hpp"
+#include "military_templates.hpp"
+#include "province.hpp"
+#include "province_templates.hpp"
+#include "triggers.hpp"
+#include "ve_scalar_extensions.hpp"
 
 namespace sys {
 

--- a/src/gamestate/serialization.cpp
+++ b/src/gamestate/serialization.cpp
@@ -7,6 +7,7 @@
 #define ZSTD_STATIC_LINKING_ONLY
 #define XXH_NAMESPACE ZSTD_
 
+#include "blake2.h"
 #include "zstd.h"
 
 namespace sys {
@@ -818,7 +819,7 @@ void write_scenario_file(sys::state& state, native_string_view name, uint32_t co
 
 	state.scenario_counter = count;
 	state.scenario_time_stamp = header.timestamp;
-	
+
 
 	// this is an upper bound, since compacting the data may require less space
 	size_t total_size =

--- a/src/gamestate/serialization.hpp
+++ b/src/gamestate/serialization.hpp
@@ -8,12 +8,12 @@
 namespace sys {
 
 template<typename T>
-size_t serialize_size(std::vector<T> const& vec) {
+inline size_t serialize_size(std::vector<T> const& vec) {
 	return sizeof(uint32_t) + sizeof(T) * vec.size();
 }
 
 template<typename T>
-uint8_t* serialize(uint8_t* ptr_in, std::vector<T> const& vec) {
+inline uint8_t* serialize(uint8_t* ptr_in, std::vector<T> const& vec) {
 	uint32_t length = uint32_t(vec.size());
 	memcpy(ptr_in, &length, sizeof(uint32_t));
 	memcpy(ptr_in + sizeof(uint32_t), vec.data(), sizeof(T) * vec.size());
@@ -21,7 +21,7 @@ uint8_t* serialize(uint8_t* ptr_in, std::vector<T> const& vec) {
 }
 
 template<typename T>
-uint8_t const* deserialize(uint8_t const* ptr_in, std::vector<T>& vec) {
+inline uint8_t const* deserialize(uint8_t const* ptr_in, std::vector<T>& vec) {
 	uint32_t length = 0;
 	memcpy(&length, ptr_in, sizeof(uint32_t));
 	vec.resize(length);
@@ -30,24 +30,24 @@ uint8_t const* deserialize(uint8_t const* ptr_in, std::vector<T>& vec) {
 }
 
 template<typename T>
-uint8_t* memcpy_serialize(uint8_t* ptr_in, T const& obj) {
+inline uint8_t* memcpy_serialize(uint8_t* ptr_in, T const& obj) {
 	memcpy(ptr_in, &obj, sizeof(T));
 	return ptr_in + sizeof(T);
 }
 
 template<typename T>
-uint8_t const* memcpy_deserialize(uint8_t const* ptr_in, T& obj) {
+inline uint8_t const* memcpy_deserialize(uint8_t const* ptr_in, T& obj) {
 	memcpy(&obj, ptr_in, sizeof(T));
 	return ptr_in + sizeof(T);
 }
 
 template<typename T, typename tag_type>
-size_t serialize_size(tagged_vector<T, tag_type> const& vec) {
+inline size_t serialize_size(tagged_vector<T, tag_type> const& vec) {
 	return sizeof(uint32_t) + sizeof(T) * vec.size();
 }
 
 template<typename T, typename tag_type>
-uint8_t* serialize(uint8_t* ptr_in, tagged_vector<T, tag_type> const& vec) {
+inline uint8_t* serialize(uint8_t* ptr_in, tagged_vector<T, tag_type> const& vec) {
 	uint32_t length = uint32_t(vec.size());
 	memcpy(ptr_in, &length, sizeof(uint32_t));
 	memcpy(ptr_in + sizeof(uint32_t), vec.data(), sizeof(T) * vec.size());
@@ -55,7 +55,7 @@ uint8_t* serialize(uint8_t* ptr_in, tagged_vector<T, tag_type> const& vec) {
 }
 
 template<typename T, typename tag_type>
-uint8_t const* deserialize(uint8_t const* ptr_in, tagged_vector<T, tag_type>& vec) {
+inline uint8_t const* deserialize(uint8_t const* ptr_in, tagged_vector<T, tag_type>& vec) {
 	uint32_t length = 0;
 	memcpy(&length, ptr_in, sizeof(uint32_t));
 	vec.resize(length);
@@ -74,7 +74,7 @@ inline uint8_t* serialize(uint8_t* ptr_in,
 				vec) {
 	return serialize(ptr_in, vec.values());
 }
-uint8_t const* deserialize(uint8_t const* ptr_in,
+inline uint8_t const* deserialize(uint8_t const* ptr_in,
 		ankerl::unordered_dense::map<dcon::text_key, dcon::text_sequence_id, text::vector_backed_hash, text::vector_backed_eq>& vec) {
 	uint32_t length = 0;
 	memcpy(&length, ptr_in, sizeof(uint32_t));
@@ -96,7 +96,7 @@ inline uint8_t* serialize(uint8_t* ptr_in,
 		ankerl::unordered_dense::map<dcon::modifier_id, dcon::gfx_object_id, sys::modifier_hash> const& vec) {
 	return serialize(ptr_in, vec.values());
 }
-uint8_t const* deserialize(uint8_t const* ptr_in,
+inline uint8_t const* deserialize(uint8_t const* ptr_in,
 		ankerl::unordered_dense::map<dcon::modifier_id, dcon::gfx_object_id, sys::modifier_hash>& vec) {
 	uint32_t length = 0;
 	memcpy(&length, ptr_in, sizeof(uint32_t));
@@ -116,7 +116,7 @@ inline size_t serialize_size(ankerl::unordered_dense::map<uint16_t, dcon::text_k
 inline uint8_t* serialize(uint8_t* ptr_in, ankerl::unordered_dense::map<uint16_t, dcon::text_key> const& vec) {
 	return serialize(ptr_in, vec.values());
 }
-uint8_t const* deserialize(uint8_t const* ptr_in, ankerl::unordered_dense::map<uint16_t, dcon::text_key>& vec) {
+inline uint8_t const* deserialize(uint8_t const* ptr_in, ankerl::unordered_dense::map<uint16_t, dcon::text_key>& vec) {
 	uint32_t length = 0;
 	memcpy(&length, ptr_in, sizeof(uint32_t));
 

--- a/src/gui/gui_common_elements.hpp
+++ b/src/gui/gui_common_elements.hpp
@@ -8,7 +8,7 @@
 #include "military.hpp"
 #include "nations.hpp"
 #include "politics.hpp"
-#include "province.hpp"
+#include "province_templates.hpp"
 #include "rebels.hpp"
 #include "system_state.hpp"
 #include "text.hpp"
@@ -716,7 +716,7 @@ public:
 	std::string get_text(sys::state& state, dcon::nation_id nation_id) noexcept override {
 		auto fat_id = dcon::fatten(state.world, nation_id);
 		auto gov_type_id = fat_id.get_government_type();
-		
+
 		auto gov_name_seq = state.world.government_type_get_name(gov_type_id);
 		return text::produce_simple_string(state, gov_name_seq);
 	}
@@ -926,7 +926,7 @@ public:
 
 	void update_tooltip(sys::state& state, int32_t x, int32_t y, text::columnar_layout& contents) noexcept override {
 		auto n = retrieve<dcon::nation_id>(state, parent);
-		
+
 		auto base = state.defines.suppression_points_gain_base;
 		auto nmod = state.world.nation_get_modifier_values(n, sys::national_mod_offsets::suppression_points_modifier) + 1.0f;
 		auto bmod = state.world.nation_get_demographics(n, demographics::to_key(state, state.culture_definitions.bureaucrat)) /
@@ -1468,7 +1468,7 @@ public:
 		}
 		float slave_pool = state.world.province_get_demographics(p, demographics::to_key(state, state.culture_definitions.slaves));
 		float labor_pool = worker_pool + slave_pool;
-		
+
 		text::add_line(state, contents, "provinceview_employment", text::variable_type::value, int64_t(std::min(rgo_max, labor_pool)));
 		text::add_line_break_to_layout(state, contents);
 		{

--- a/src/gui/gui_effect_tooltips.hpp
+++ b/src/gui/gui_effect_tooltips.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace ui {
+
+void effect_description(sys::state& state, text::layout_base& layout, dcon::effect_key k, int32_t primary_slot, int32_t this_slot,
+		int32_t from_slot, uint32_t r_lo, uint32_t r_hi);
+
+} // namespace ui

--- a/src/gui/gui_ledger_window.hpp
+++ b/src/gui/gui_ledger_window.hpp
@@ -2,6 +2,7 @@
 
 #include "gui_common_elements.hpp"
 #include "gui_element_types.hpp"
+#include "province_templates.hpp"
 
 namespace ui {
 

--- a/src/gui/gui_province_window.hpp
+++ b/src/gui/gui_province_window.hpp
@@ -11,6 +11,7 @@
 #include "system_state.hpp"
 #include "text.hpp"
 #include "gui_production_window.hpp"
+#include "province_templates.hpp"
 
 namespace ui {
 
@@ -871,7 +872,7 @@ public:
 		if(content) {
 			open_build_foreign_factory(state, state.world.province_get_state_membership(content));
 		}
-			
+
 	}
 
 	void on_update(sys::state& state) noexcept override {
@@ -1489,7 +1490,7 @@ public:
 			text::add_line_with_condition(state, contents, "col_start_1", state.world.state_definition_get_colonization_stage(sdef) <= uint8_t(1));
 			text::add_line_with_condition(state, contents, "col_start_2", state.world.nation_get_rank(state.local_player_nation) <= uint16_t(state.defines.colonial_rank), text::variable_type::x, uint16_t(state.defines.colonial_rank));
 			text::add_line_with_condition(state, contents, "col_start_3", state.crisis_colony != sdef);
-		
+
 			bool war_participant = false;
 			for(auto par : state.world.war_get_war_participant(state.crisis_war)) {
 				if(par.get_nation() == state.local_player_nation)
@@ -1515,7 +1516,7 @@ public:
 			auto num_colonizers = colonizers.end() - colonizers.begin();
 
 			text::add_line_with_condition(state, contents, "col_start_7", num_colonizers < 4);
-		
+
 			bool adjacent = [&]() {
 				for(auto p : state.world.state_definition_get_abstract_state_membership(sdef)) {
 					if(!p.get_province().get_nation_from_province_ownership()) {
@@ -1559,7 +1560,7 @@ public:
 
 			auto free_points = nations::free_colonial_points(state, state.local_player_nation);
 			auto required_points = int32_t(state.defines.colonization_interest_cost_initial + (adjacent ? state.defines.colonization_interest_cost_neighbor_modifier : 0.0f));
-			
+
 			text::add_line_with_condition(state, contents, "col_start_9", free_points > required_points, text::variable_type::x, required_points);
 		} else {
 			text::add_line(state, contents, "col_invest_title");
@@ -1644,7 +1645,7 @@ protected:
 public:
 	void on_update(sys::state& state) noexcept override {
 		auto content = retrieve<dcon::colonization_id>(state, parent);
-		
+
 		row_contents.clear();
 
 		if(!content) {
@@ -1723,7 +1724,7 @@ protected:
 
 public:
 	void on_update(sys::state& state) noexcept override {
-		
+
 		auto prov = retrieve<dcon::province_id>(state, parent);
 		auto fat_def = dcon::fatten(state.world, state.world.province_get_state_from_abstract_state_membership(prov));
 

--- a/src/gui/topbar_subwindows/gui_population_window.hpp
+++ b/src/gui/topbar_subwindows/gui_population_window.hpp
@@ -3,7 +3,7 @@
 #include "gui_element_types.hpp"
 #include "gui_graphics.hpp"
 #include "gui_common_elements.hpp"
-#include "province.hpp"
+#include "province_templates.hpp"
 #include "color.hpp"
 #include "triggers.hpp"
 #include "gui_province_window.hpp"

--- a/src/gui/topbar_subwindows/gui_production_window.hpp
+++ b/src/gui/topbar_subwindows/gui_production_window.hpp
@@ -9,6 +9,8 @@
 #include "gui_build_factory_window.hpp"
 #include "gui_project_investment_window.hpp"
 #include "gui_foreign_investment_window.hpp"
+#include "economy_templates.hpp"
+#include "province_templates.hpp"
 
 namespace ui {
 
@@ -128,7 +130,7 @@ public:
 
 		disabled = !command::can_begin_factory_building_construction(state, state.local_player_nation, sid,
 			fat.get_building_type().id, true);
-		
+
 	}
 
 	void button_shift_action(sys::state& state) noexcept override {
@@ -145,7 +147,7 @@ public:
 				}
 			}
 		}
-		
+
 	}
 
 	void button_action(sys::state& state) noexcept override {
@@ -194,7 +196,7 @@ public:
 		if(!is_not_upgrading) {
 			return;
 		}
-		
+
 		text::add_line(state, contents, "production_expand_factory_tooltip");
 
 		text::add_line_break_to_layout(state, contents);
@@ -214,7 +216,7 @@ public:
 			text::add_line_with_condition(state, contents, "factory_upgrade_condition_4", gp_condition);
 
 			text::add_line_with_condition(state, contents, "factory_upgrade_condition_5", state.world.nation_get_is_civilized(n));
-	
+
 			auto rules = state.world.nation_get_combined_issue_rules(n);
 			text::add_line_with_condition(state, contents, "factory_upgrade_condition_6",
 					(rules & issue_rule::allow_foreign_investment) != 0);
@@ -226,7 +228,7 @@ public:
 			text::add_line_with_condition(state, contents, "factory_upgrade_condition_8", (rules & issue_rule::expand_factory) != 0);
 		}
 
-		
+
 		text::add_line_with_condition(state, contents, "factory_upgrade_condition_9", is_not_upgrading);
 		text::add_line_with_condition(state, contents, "factory_upgrade_condition_10", fat.get_level() < 255);
 		text::add_line_break_to_layout(state, contents);
@@ -271,7 +273,7 @@ public:
 
 class factory_subsidise_button : public button_element_base {
 public:
-	void on_update(sys::state& state) noexcept override {	
+	void on_update(sys::state& state) noexcept override {
 		const dcon::factory_id fid = retrieve<dcon::factory_id>(state, parent);
 		const dcon::nation_id n = retrieve<dcon::nation_id>(state, parent);
 		auto rules = state.world.nation_get_combined_issue_rules(n);
@@ -537,7 +539,7 @@ class normal_factory_background : public opaque_element_base {
 
 		text::add_line(state, contents, "factory_stats_5");
 
-			
+
 		for(uint32_t i = 0; i < economy::commodity_set::set_size; ++i) {
 			if(inputs.commodity_type[i]) {
 				auto box = text::open_layout_box(contents);
@@ -1274,7 +1276,7 @@ void populate_production_states_list(sys::state& state, std::vector<dcon::state_
 				auto content = any_cast<commodity_filter_query_data>(payload);
 				count += content.filter ? 1 : 0;
 			}
-			
+
 
 			if(count > 0)
 				row_contents.push_back(fat_id.get_state());
@@ -1500,7 +1502,7 @@ class commodity_primary_worker_amount : public simple_text_element_base {
 				}
 			}
 			break;
-			
+
 		}
 
 
@@ -1544,7 +1546,7 @@ class commodity_secondary_worker_amount : public simple_text_element_base {
 			break;
 		}
 
-		
+
 		set_text(state, text::prettify(int64_t(total)));
 	}
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,13 +11,6 @@
 #include "texture.cpp"
 #include "date_interface.cpp"
 #include "serialization.cpp"
-#else
-#include "text.hpp"
-#include "fonts.hpp"
-#include "texture.hpp"
-#include "date_interface.hpp"
-#include "serialization.hpp"
-#endif
 #include "nations.cpp"
 #include "culture.cpp"
 #include "military.cpp"
@@ -26,6 +19,15 @@
 #include "triggers.cpp"
 #include "effects.cpp"
 #include "economy.cpp"
+
+#include "ai.cpp"
+#else
+#include "text.hpp"
+#include "fonts.hpp"
+#include "texture.hpp"
+#include "date_interface.hpp"
+#include "serialization.hpp"
+#endif
 #include "demographics.cpp"
 #include "bmfont.cpp"
 #include "rebels.cpp"
@@ -50,7 +52,6 @@
 #include "notifications.cpp"
 #include "map_tooltip.cpp"
 #include "unit_tooltip.cpp"
-#include "ai.cpp"
 
 #ifdef _WIN64
 // WINDOWS implementations go here

--- a/src/military/military.cpp
+++ b/src/military/military.cpp
@@ -1,11 +1,21 @@
 #include "military.hpp"
+#include "military_templates.hpp"
 #include "dcon_generated.hpp"
 #include "prng.hpp"
 #include "effects.hpp"
 #include "events.hpp"
 #include "ai.hpp"
+#include "demographics.hpp"
+#include "politics.hpp"
+#include "province_templates.hpp"
+#include "rebels.hpp"
+#include "triggers.hpp"
 
 namespace military {
+
+template auto province_is_blockaded<ve::tagged_vector<dcon::province_id>>(sys::state const&, ve::tagged_vector<dcon::province_id>);
+template auto province_is_under_siege<ve::tagged_vector<dcon::province_id>>(sys::state const&, ve::tagged_vector<dcon::province_id>);
+template auto battle_is_ongoing_in_province<ve::tagged_vector<dcon::province_id>>(sys::state const&, ve::tagged_vector<dcon::province_id>);
 
 constexpr inline float org_dam_mul = 0.18f;
 constexpr inline float str_dam_mul = 0.14f;
@@ -414,10 +424,6 @@ bool cb_instance_conditions_satisfied(sys::state& state, dcon::nation_id actor, 
 	return true;
 }
 
-template<typename T>
-auto province_is_blockaded(sys::state const& state, T ids) {
-	return state.world.province_get_is_blockaded(ids);
-}
 bool province_is_blockaded(sys::state const& state, dcon::province_id ids) {
 	return state.world.province_get_is_blockaded(ids);
 }
@@ -433,7 +439,7 @@ bool compute_blockade_status(sys::state& state, dcon::province_id p) {
 	auto port_to = state.world.province_get_port_to(p);
 	if(!port_to)
 		return false;
-	
+
 	for(auto n : state.world.province_get_navy_location(port_to)) {
 		if(n.get_navy().get_is_retreating() == false && !n.get_navy().get_battle_from_navy_battle_participation()) {
 			if(military::are_at_war(state, owner, n.get_navy().get_controller_from_navy_control()))
@@ -449,23 +455,8 @@ void update_blockade_status(sys::state& state) {
 	});
 }
 
-template<typename T>
-auto province_is_under_siege(sys::state const& state, T ids) {
-	return state.world.province_get_siege_progress(ids) > 0.0f;
-}
 bool province_is_under_siege(sys::state const& state, dcon::province_id ids) {
 	return state.world.province_get_siege_progress(ids) > 0.0f;
-}
-
-template<typename T>
-auto battle_is_ongoing_in_province(sys::state const& state, T ids) {
-	ve::apply(
-			[&](dcon::province_id p) {
-				auto battles = state.world.province_get_land_battle_location(p);
-				return battles.begin() != battles.end();
-			},
-			ids);
-	return false;
 }
 
 float recruited_pop_fraction(sys::state const& state, dcon::nation_id n) {
@@ -1079,8 +1070,8 @@ int32_t naval_supply_points_used(sys::state& state, dcon::nation_id n) {
 
 uint32_t naval_supply_from_naval_base(sys::state& state, dcon::province_id prov, dcon::nation_id nation) {
 	uint32_t supply = uint32_t(state.defines.naval_base_supply_score_base * (std::pow(2, (dcon::fatten(state.world, prov).get_building_level(economy::province_building_type::naval_base) -1))));
-	if(dcon::fatten(state.world, prov).get_building_level(economy::province_building_type::naval_base) != 0) { 
-		return supply; 
+	if(dcon::fatten(state.world, prov).get_building_level(economy::province_building_type::naval_base) != 0) {
+		return supply;
 	} else {
 		for(auto c : dcon::fatten(state.world, prov).get_core()) {
 			if(c.get_identity().get_nation_from_identity_holder().id == nation && province::has_access_to_province(state, nation, prov)) {
@@ -1893,7 +1884,7 @@ void kill_leader(sys::state& state, dcon::leader_id l) {
 	if(state.world.leader_get_nation_from_leader_loyalty(l) == state.local_player_nation) {
 		if(state.world.leader_get_army_from_army_leadership(l) || state.world.leader_get_navy_from_navy_leadership(l)) {
 			dcon::nation_id n = state.local_player_nation;
-			
+
 			auto is_admiral = state.world.leader_get_is_admiral(l);
 			auto location = is_admiral ? state.world.navy_get_location_from_navy_location(state.world.leader_get_navy_from_navy_leadership(l)) : state.world.army_get_location_from_army_location(state.world.leader_get_army_from_army_leadership(l));
 			auto name = state.world.leader_get_name(l);
@@ -4135,7 +4126,7 @@ void army_arrives_in_province(sys::state& state, dcon::army_id a, dcon::province
 				battle_in_war = par.w;
 				break;
 			}
-			
+
 		}
 
 		if(gather_to_battle) {
@@ -4427,7 +4418,7 @@ void cleanup_army(sys::state& state, dcon::army_id n) {
 		} else {
 
 		}
-		
+
 		if(should_end) {
 			bool as_attacker = state.world.land_battle_get_war_attacker_is_attacker(b);
 			end_battle(state, b, as_attacker ? battle_result::defender_won : battle_result::attacker_won);
@@ -4448,7 +4439,7 @@ void cleanup_navy(sys::state& state, dcon::navy_id n) {
 	while(em.begin() != em.end()) {
 		cleanup_army(state, (*em.begin()).get_army());
 	}
-	
+
 	auto controller = state.world.navy_get_controller_from_navy_control(n);
 	auto b = state.world.navy_get_battle_from_navy_battle_participation(n);
 
@@ -4494,7 +4485,7 @@ void end_battle(sys::state& state, dcon::land_battle_id b, battle_result result)
 
 		bool battle_attacker = (role_in_war == war_role::attacker) == state.world.land_battle_get_war_attacker_is_attacker(b);
 
-		
+
 		if(battle_attacker && result == battle_result::defender_won) {
 			if(!can_retreat_from_battle(state, b)) {
 				make_leaderless(n.get_army());
@@ -4649,7 +4640,7 @@ void end_battle(sys::state& state, dcon::land_battle_id b, battle_result result)
 						auto discard = state.land_battle_reports.try_push(rep);
 
 					}
-			
+
 		}
 	}
 
@@ -4760,7 +4751,7 @@ void end_battle(sys::state& state, dcon::naval_battle_id b, battle_result result
 				nations::adjust_prestige(state, d_nation, score / -50.0f);
 
 				// Report
-				
+
 						if(state.local_player_nation == a_nation || state.local_player_nation == d_nation) {
 							naval_battle_report rep;
 							rep.attacker_big_losses = state.world.naval_battle_get_attacker_big_ships_lost(b);
@@ -4914,7 +4905,7 @@ bool will_recieve_attrition(sys::state& state, dcon::army_id a) {
 
 	auto prov_attrition_mod = state.world.province_get_modifier_values(prov, sys::provincial_mod_offsets::attrition);
 
-	
+
 	auto ar = fatten(state.world, a);
 
 	auto army_controller = ar.get_controller_from_army_control();

--- a/src/military/military.hpp
+++ b/src/military/military.hpp
@@ -147,7 +147,7 @@ struct global_military_state {
 
 	dcon::cb_type_id crisis_colony;
 	dcon::cb_type_id crisis_liberate;
-	
+
 	dcon::unit_type_id irregular;
 	dcon::unit_type_id infantry;
 	dcon::unit_type_id artillery;
@@ -261,6 +261,8 @@ dcon::war_id find_war_between(sys::state const& state, dcon::nation_id a, dcon::
 bool has_truce_with(sys::state& state, dcon::nation_id attacker, dcon::nation_id target);
 bool can_use_cb_against(sys::state& state, dcon::nation_id from, dcon::nation_id target);
 bool leader_is_in_combat(sys::state& state, dcon::leader_id l);
+dcon::leader_id make_new_leader(sys::state& state, dcon::nation_id n, bool is_general);
+void kill_leader(sys::state& state, dcon::leader_id l);
 
 // tests whether joining the war would violate the constraint that you can't both be in a war with and
 // fighting against the same nation or fighting against them twice
@@ -271,11 +273,13 @@ bool standard_war_joining_is_possible(sys::state& state, dcon::war_id wfor, dcon
 bool joining_as_attacker_would_break_truce(sys::state& state, dcon::nation_id a, dcon::war_id w);
 bool defenders_have_non_status_quo_wargoal(sys::state const& state, dcon::war_id w);
 bool defenders_have_status_quo_wargoal(sys::state const& state, dcon::war_id w);
+bool attackers_have_status_quo_wargoal(sys::state const& state, dcon::war_id w);
 bool can_add_always_cb_to_war(sys::state& state, dcon::nation_id actor, dcon::nation_id target, dcon::cb_type_id cb, dcon::war_id w);
 bool is_attacker(sys::state& state, dcon::war_id w, dcon::nation_id n);
 bool war_goal_would_be_duplicate(sys::state& state, dcon::nation_id source, dcon::war_id w, dcon::nation_id target, dcon::cb_type_id cb_type, dcon::state_definition_id cb_state, dcon::national_identity_id cb_tag, dcon::nation_id cb_secondary_nation);
 bool state_claimed_in_war(sys::state& state, dcon::war_id w, dcon::nation_id from, dcon::nation_id target, dcon::state_definition_id cb_state);
 void set_initial_leaders(sys::state& state);
+std::string get_war_name(sys::state& state, dcon::war_id war);
 
 // war score from the perspective of the primary attacker offering a peace deal to the primary defender; -100 to 100
 float primary_warscore(sys::state& state, dcon::war_id w);
@@ -294,17 +298,9 @@ bool is_defender_wargoal(sys::state const& state, dcon::war_id w, dcon::wargoal_
 enum class war_role { none, attacker, defender };
 war_role get_role(sys::state const& state, dcon::war_id w, dcon::nation_id n);
 
-template<typename T>
-auto province_is_blockaded(sys::state const& state, T ids);
 bool province_is_blockaded(sys::state const& state, dcon::province_id ids);
-template<typename T>
-auto province_is_under_siege(sys::state const& state, T ids);
 bool province_is_under_siege(sys::state const& state, dcon::province_id ids);
-
 void update_blockade_status(sys::state& state);
-
-template<typename T>
-auto battle_is_ongoing_in_province(sys::state const& state, T ids);
 
 float recruited_pop_fraction(sys::state const& state, dcon::nation_id n);
 bool state_has_naval_base(sys::state const& state, dcon::state_instance_id di);
@@ -411,6 +407,7 @@ void advance_mobilizations(sys::state& state);
 int32_t transport_capacity(sys::state& state, dcon::navy_id n);
 int32_t free_transport_capacity(sys::state& state, dcon::navy_id n);
 bool can_embark_onto_sea_tile(sys::state& state, dcon::nation_id n, dcon::province_id p, dcon::army_id a);
+dcon::navy_id find_embark_target(sys::state& state, dcon::nation_id from, dcon::province_id p, dcon::army_id a);
 float effective_army_speed(sys::state& state, dcon::army_id a);
 float effective_navy_speed(sys::state& state, dcon::navy_id n);
 bool will_recieve_attrition(sys::state& state, dcon::navy_id a);

--- a/src/military/military_templates.hpp
+++ b/src/military/military_templates.hpp
@@ -1,0 +1,26 @@
+#pragma once
+#include "system_state.hpp"
+
+namespace military {
+
+template<typename T>
+auto province_is_blockaded(sys::state const& state, T ids) {
+	return state.world.province_get_is_blockaded(ids);
+}
+
+template<typename T>
+auto province_is_under_siege(sys::state const& state, T ids) {
+	return state.world.province_get_siege_progress(ids) > 0.0f;
+}
+
+template<typename T>
+auto battle_is_ongoing_in_province(sys::state const& state, T ids) {
+	ve::apply(
+			[&](dcon::province_id p) {
+				auto battles = state.world.province_get_land_battle_location(p);
+				return battles.begin() != battles.end();
+			},
+			ids);
+	return false;
+}
+} // namespace military

--- a/src/nations/nations.cpp
+++ b/src/nations/nations.cpp
@@ -1,4 +1,5 @@
 #include "nations.hpp"
+#include "nations_templates.hpp"
 #include "dcon_generated.hpp"
 #include "demographics.hpp"
 #include "modifiers.hpp"
@@ -10,6 +11,8 @@
 #include "events.hpp"
 #include "prng.hpp"
 #include "effects.hpp"
+#include "province_templates.hpp"
+#include "rebels.hpp"
 
 namespace nations {
 
@@ -21,6 +24,14 @@ int32_t get_level(sys::state& state, dcon::nation_id gp, dcon::nation_id target)
 }
 
 } // namespace influence
+
+template auto nation_accepts_culture<ve::tagged_vector<dcon::nation_id>, dcon::culture_id>(sys::state const&, ve::tagged_vector<dcon::nation_id>, dcon::culture_id);
+template auto primary_culture_group<ve::tagged_vector<dcon::nation_id>>(sys::state const&, ve::tagged_vector<dcon::nation_id>);
+template auto owner_of_pop<ve::tagged_vector<dcon::pop_id>>(sys::state const&, ve::tagged_vector<dcon::pop_id>);
+template auto central_blockaded_fraction<ve::tagged_vector<dcon::nation_id>>(sys::state const&, ve::tagged_vector<dcon::nation_id>);
+template auto central_reb_controlled_fraction<ve::tagged_vector<dcon::nation_id>>(sys::state const&, ve::tagged_vector<dcon::nation_id>);
+template auto central_has_crime_fraction<ve::tagged_vector<dcon::nation_id>>(sys::state const&, ve::tagged_vector<dcon::nation_id>);
+template auto occupied_provinces_fraction<ve::tagged_vector<dcon::nation_id>>(sys::state const&, ve::tagged_vector<dcon::nation_id>);
 
 int64_t get_monthly_pop_increase_of_nation(sys::state& state, dcon::nation_id n) {
 	/* TODO -
@@ -71,62 +82,9 @@ dcon::nation_id get_nth_great_power(sys::state const& state, uint16_t n) {
 	return dcon::nation_id{};
 }
 
-// returns whether a culture is on the accepted list OR is the primary culture
-template<typename T, typename U>
-auto nation_accepts_culture(sys::state const& state, T ids, U cul_ids) {
-	auto is_accepted = ve::apply(
-			[&state](dcon::nation_id n, dcon::culture_id c) {
-				if(n)
-					return state.world.nation_get_accepted_cultures(n, c);
-				else
-					return false;
-			},
-			ids, cul_ids);
-	return (state.world.nation_get_primary_culture(ids) == cul_ids) || is_accepted;
-}
-
-template<typename T>
-auto primary_culture_group(sys::state const& state, T ids) {
-	auto cultures = state.world.nation_get_primary_culture(ids);
-	return state.world.culture_get_group_from_culture_group_membership(cultures);
-}
-
 dcon::nation_id owner_of_pop(sys::state const& state, dcon::pop_id pop_ids) {
 	auto location = state.world.pop_get_province_from_pop_location(pop_ids);
 	return state.world.province_get_nation_from_province_ownership(location);
-}
-template<typename T>
-auto owner_of_pop(sys::state const& state, T pop_ids) {
-	auto location = state.world.pop_get_province_from_pop_location(pop_ids);
-	return state.world.province_get_nation_from_province_ownership(location);
-}
-
-template<typename T>
-auto central_reb_controlled_fraction(sys::state const& state, T ids) {
-	auto cpc = ve::to_float(state.world.nation_get_central_province_count(ids));
-	auto reb_count = ve::to_float(state.world.nation_get_central_rebel_controlled(ids));
-	return ve::select(cpc != 0.0f, reb_count / cpc, decltype(cpc)());
-}
-
-template<typename T>
-auto central_blockaded_fraction(sys::state const& state, T ids) {
-	auto cpc = ve::to_float(state.world.nation_get_central_ports(ids));
-	auto b_count = ve::to_float(state.world.nation_get_central_blockaded(ids));
-	return ve::select(cpc != 0.0f, b_count / cpc, decltype(cpc)());
-}
-
-template<typename T>
-auto central_has_crime_fraction(sys::state const& state, T ids) {
-	auto cpc = ve::to_float(state.world.nation_get_central_province_count(ids));
-	auto crim_count = ve::to_float(state.world.nation_get_central_crime_count(ids));
-	return ve::select(cpc != 0.0f, crim_count / cpc, decltype(cpc)());
-}
-
-template<typename T>
-auto occupied_provinces_fraction(sys::state const& state, T ids) {
-	auto cpc = ve::to_float(state.world.nation_get_owned_province_count(ids));
-	auto occ_count = ve::to_float(state.world.nation_get_occupied_count(ids));
-	return ve::select(cpc != 0.0f, occ_count / cpc, decltype(cpc)());
 }
 
 void restore_state_instances(sys::state& state) {

--- a/src/nations/nations.hpp
+++ b/src/nations/nations.hpp
@@ -42,7 +42,7 @@ struct global_national_state {
 	std::vector<triggered_modifier> triggered_modifiers;
 	std::vector<dcon::bitfield_type> global_flag_variables;
 	std::vector<dcon::nation_id> nations_by_rank;
-	
+
 	tagged_vector<dcon::text_sequence_id, dcon::national_flag_id> flag_variable_names;
 	tagged_vector<dcon::text_sequence_id, dcon::global_flag_id> global_flag_variable_names;
 	tagged_vector<dcon::text_sequence_id, dcon::national_variable_id> variable_names;
@@ -228,23 +228,7 @@ int32_t get_level(sys::state& state, dcon::nation_id gp, dcon::nation_id target)
 
 dcon::nation_id get_nth_great_power(sys::state const& state, uint16_t n);
 
-// returns whether a culture is on the accepted list OR is the primary culture
-template<typename T, typename U>
-auto nation_accepts_culture(sys::state const& state, T ids, U c);
-
-template<typename T>
-auto primary_culture_group(sys::state const& state, T ids);
 dcon::nation_id owner_of_pop(sys::state const& state, dcon::pop_id pop_ids);
-template<typename T>
-auto owner_of_pop(sys::state const& state, T pop_ids);
-template<typename T>
-auto central_reb_controlled_fraction(sys::state const& state, T ids);
-template<typename T>
-auto central_blockaded_fraction(sys::state const& state, T ids);
-template<typename T>
-auto central_has_crime_fraction(sys::state const& state, T ids);
-template<typename T>
-auto occupied_provinces_fraction(sys::state const& state, T ids);
 
 bool can_release_as_vassal(sys::state const& state, dcon::nation_id n, dcon::national_identity_id releasable);
 bool identity_has_holder(sys::state const& state, dcon::national_identity_id ident);

--- a/src/nations/nations_templates.hpp
+++ b/src/nations/nations_templates.hpp
@@ -1,0 +1,60 @@
+#pragma once
+#include "ve_scalar_extensions.hpp"
+
+namespace nations {
+
+// returns whether a culture is on the accepted list OR is the primary culture
+template<typename T, typename U>
+auto nation_accepts_culture(sys::state const& state, T ids, U cul_ids) {
+	auto is_accepted = ve::apply(
+			[&state](dcon::nation_id n, dcon::culture_id c) {
+				if(n)
+					return state.world.nation_get_accepted_cultures(n, c);
+				else
+					return false;
+			},
+			ids, cul_ids);
+	return (state.world.nation_get_primary_culture(ids) == cul_ids) || is_accepted;
+}
+
+template<typename T>
+auto primary_culture_group(sys::state const& state, T ids) {
+	auto cultures = state.world.nation_get_primary_culture(ids);
+	return state.world.culture_get_group_from_culture_group_membership(cultures);
+}
+
+template<typename T>
+auto owner_of_pop(sys::state const& state, T pop_ids) {
+	auto location = state.world.pop_get_province_from_pop_location(pop_ids);
+	return state.world.province_get_nation_from_province_ownership(location);
+}
+
+template<typename T>
+auto central_blockaded_fraction(sys::state const& state, T ids) {
+	auto cpc = ve::to_float(state.world.nation_get_central_ports(ids));
+	auto b_count = ve::to_float(state.world.nation_get_central_blockaded(ids));
+	auto ret = decltype(cpc){};
+	return ve::select(cpc != 0.0f, b_count / cpc, ret);
+}
+
+template<typename T>
+auto central_reb_controlled_fraction(sys::state const& state, T ids) {
+	auto cpc = ve::to_float(state.world.nation_get_central_province_count(ids));
+	auto reb_count = ve::to_float(state.world.nation_get_central_rebel_controlled(ids));
+	return ve::select(cpc != 0.0f, reb_count / cpc, decltype(cpc)());
+}
+
+template<typename T>
+auto central_has_crime_fraction(sys::state const& state, T ids) {
+	auto cpc = ve::to_float(state.world.nation_get_central_province_count(ids));
+	auto crim_count = ve::to_float(state.world.nation_get_central_crime_count(ids));
+	return ve::select(cpc != 0.0f, crim_count / cpc, decltype(cpc)());
+}
+
+template<typename T>
+auto occupied_provinces_fraction(sys::state const& state, T ids) {
+	auto cpc = ve::to_float(state.world.nation_get_owned_province_count(ids));
+	auto occ_count = ve::to_float(state.world.nation_get_occupied_count(ids));
+	return ve::select(cpc != 0.0f, occ_count / cpc, decltype(cpc)());
+}
+} // namespace nations

--- a/src/provinces/province.cpp
+++ b/src/provinces/province.cpp
@@ -7,8 +7,20 @@
 #include <vector>
 #include "rebels.hpp"
 #include "math_fns.hpp"
+#include "prng.hpp"
+#include "triggers.hpp"
 
 namespace province {
+
+template auto is_overseas<ve::tagged_vector<dcon::province_id>>(sys::state const&, ve::tagged_vector<dcon::province_id>);
+template void for_each_province_in_state_instance<std::function<void(dcon::province_id)>>(sys::state&, dcon::state_instance_id, std::function<void(dcon::province_id)> const&);
+
+bool is_overseas(sys::state const& state, dcon::province_id ids) {
+	auto owners = state.world.province_get_nation_from_province_ownership(ids);
+	auto owner_cap = state.world.nation_get_capital(owners);
+	return (state.world.province_get_continent(ids) != state.world.province_get_continent(owner_cap)) &&
+				 (state.world.province_get_connected_region_id(ids) != state.world.province_get_connected_region_id(owner_cap));
+}
 
 bool nations_are_adjacent(sys::state& state, dcon::nation_id a, dcon::nation_id b) {
 	auto it = state.world.get_nation_adjacency_by_nation_adjacency_pair(a, b);

--- a/src/provinces/province.cpp
+++ b/src/provinces/province.cpp
@@ -1,4 +1,5 @@
 #include "province.hpp"
+#include "province_templates.hpp"
 #include "dcon_generated.hpp"
 #include "demographics.hpp"
 #include "nations.hpp"
@@ -9,55 +10,6 @@
 
 namespace province {
 
-template<typename T>
-auto is_overseas(sys::state const& state, T ids) {
-	auto owners = state.world.province_get_nation_from_province_ownership(ids);
-	auto owner_cap = state.world.nation_get_capital(owners);
-	return (state.world.province_get_continent(ids) != state.world.province_get_continent(owner_cap)) &&
-				 (state.world.province_get_connected_region_id(ids) != state.world.province_get_connected_region_id(owner_cap));
-}
-
-bool is_overseas(sys::state const& state, dcon::province_id ids) {
-	auto owners = state.world.province_get_nation_from_province_ownership(ids);
-	auto owner_cap = state.world.nation_get_capital(owners);
-	return (state.world.province_get_continent(ids) != state.world.province_get_continent(owner_cap)) &&
-				 (state.world.province_get_connected_region_id(ids) != state.world.province_get_connected_region_id(owner_cap));
-}
-
-template<typename F>
-void for_each_land_province(sys::state& state, F const& func) {
-	int32_t last = state.province_definitions.first_sea_province.index();
-	for(int32_t i = 0; i < last; ++i) {
-		dcon::province_id pid{dcon::province_id::value_base_t(i)};
-		func(pid);
-	}
-}
-
-template<typename F>
-void ve_for_each_land_province(sys::state& state, F const& func) {
-	int32_t last = state.province_definitions.first_sea_province.index();
-	ve::execute_serial<dcon::province_id>(uint32_t(last), func);
-}
-
-template<typename F>
-void for_each_sea_province(sys::state& state, F const& func) {
-	int32_t first = state.province_definitions.first_sea_province.index();
-	for(int32_t i = first; i < int32_t(state.world.province_size()); ++i) {
-		dcon::province_id pid{dcon::province_id::value_base_t(i)};
-		func(pid);
-	}
-}
-
-template<typename F>
-void for_each_province_in_state_instance(sys::state& state, dcon::state_instance_id s, F const& func) {
-	auto d = state.world.state_instance_get_definition(s);
-	auto o = state.world.state_instance_get_nation_from_state_ownership(s);
-	for(auto p : state.world.state_definition_get_abstract_state_membership(d)) {
-		if(p.get_province().get_nation_from_province_ownership() == o) {
-			func(p.get_province().id);
-		}
-	}
-}
 bool nations_are_adjacent(sys::state& state, dcon::nation_id a, dcon::nation_id b) {
 	auto it = state.world.get_nation_adjacency_by_nation_adjacency_pair(a, b);
 	return bool(it);
@@ -432,7 +384,7 @@ bool can_build_naval_base(sys::state& state, dcon::province_id id, dcon::nation_
 		return false;
 
 	auto si = state.world.province_get_state_membership(id);
-	
+
 	int32_t current_lvl = state.world.province_get_building_level(id, economy::province_building_type::naval_base);
 	int32_t max_local_lvl = state.world.nation_get_max_building_level(n, economy::province_building_type::naval_base);
 	int32_t min_build = int32_t(state.world.province_get_modifier_values(id, sys::provincial_mod_offsets::min_build_naval_base));
@@ -1919,7 +1871,7 @@ std::vector<dcon::province_id> make_naval_path(sys::state& state, dcon::province
 							nearest.province.index() >= state.province_definitions.first_sea_province.index())) {
 
 
-				
+
 				if((bits & province::border::coastal_bit) == 0) { // doesn't cross coast -- i.e. is sea province
 					if(other_prov == end) {
 						fill_path_result(nearest.province);

--- a/src/provinces/province.hpp
+++ b/src/provinces/province.hpp
@@ -31,15 +31,6 @@ struct global_provincial_state {
 	dcon::modifier_id oceania;
 };
 
-template<typename F>
-void for_each_land_province(sys::state& state, F const& func);
-template<typename F>
-void for_each_sea_province(sys::state& state, F const& func);
-template<typename F>
-void for_each_province_in_state_instance(sys::state& state, dcon::state_instance_id s, F const& func);
-template<typename F>
-void ve_for_each_land_province(sys::state& state, F const& func);
-
 bool nations_are_adjacent(sys::state& state, dcon::nation_id a, dcon::nation_id b);
 void update_connected_regions(sys::state& state);
 void update_cached_values(sys::state& state);
@@ -47,8 +38,6 @@ void update_blockaded_cache(sys::state& state);
 void restore_unsaved_values(sys::state& state);
 void restore_distances(sys::state& state);
 
-template<typename T>
-auto is_overseas(sys::state const& state, T ids);
 bool is_overseas(sys::state const& state, dcon::province_id ids);
 bool can_integrate_colony(sys::state& state, dcon::state_instance_id id);
 dcon::province_id get_connected_province(sys::state& state, dcon::province_adjacency_id adj, dcon::province_id curr);

--- a/src/provinces/province_templates.hpp
+++ b/src/provinces/province_templates.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "system_state.hpp"
+
+namespace province {
+template<typename F>
+void for_each_land_province(sys::state& state, F const& func);
+template<typename F>
+void for_each_sea_province(sys::state& state, F const& func);
+template<typename F>
+void for_each_province_in_state_instance(sys::state& state, dcon::state_instance_id s, F const& func);
+template<typename F>
+void ve_for_each_land_province(sys::state& state, F const& func);
+template<typename T>
+auto is_overseas(sys::state const& state, T ids);
+
+template<typename T>
+auto is_overseas(sys::state const& state, T ids) {
+	auto owners = state.world.province_get_nation_from_province_ownership(ids);
+	auto owner_cap = state.world.nation_get_capital(owners);
+	return (state.world.province_get_continent(ids) != state.world.province_get_continent(owner_cap)) &&
+				 (state.world.province_get_connected_region_id(ids) != state.world.province_get_connected_region_id(owner_cap));
+}
+
+template<typename F>
+void for_each_land_province(sys::state& state, F const& func) {
+	int32_t last = state.province_definitions.first_sea_province.index();
+	for(int32_t i = 0; i < last; ++i) {
+		dcon::province_id pid{dcon::province_id::value_base_t(i)};
+		func(pid);
+	}
+}
+
+template<typename F>
+void ve_for_each_land_province(sys::state& state, F const& func) {
+	int32_t last = state.province_definitions.first_sea_province.index();
+	ve::execute_serial<dcon::province_id>(uint32_t(last), func);
+}
+
+template<typename F>
+void for_each_sea_province(sys::state& state, F const& func) {
+	int32_t first = state.province_definitions.first_sea_province.index();
+	for(int32_t i = first; i < int32_t(state.world.province_size()); ++i) {
+		dcon::province_id pid{dcon::province_id::value_base_t(i)};
+		func(pid);
+	}
+}
+
+template<typename F>
+void for_each_province_in_state_instance(sys::state& state, dcon::state_instance_id s, F const& func) {
+	auto d = state.world.state_instance_get_definition(s);
+	auto o = state.world.state_instance_get_nation_from_state_ownership(s);
+	for(auto p : state.world.state_definition_get_abstract_state_membership(d)) {
+		if(p.get_province().get_nation_from_province_ownership() == o) {
+			func(p.get_province().id);
+		}
+	}
+}
+}

--- a/src/provinces/province_templates.hpp
+++ b/src/provinces/province_templates.hpp
@@ -1,18 +1,7 @@
 #pragma once
-
 #include "system_state.hpp"
 
 namespace province {
-template<typename F>
-void for_each_land_province(sys::state& state, F const& func);
-template<typename F>
-void for_each_sea_province(sys::state& state, F const& func);
-template<typename F>
-void for_each_province_in_state_instance(sys::state& state, dcon::state_instance_id s, F const& func);
-template<typename F>
-void ve_for_each_land_province(sys::state& state, F const& func);
-template<typename T>
-auto is_overseas(sys::state const& state, T ids);
 
 template<typename T>
 auto is_overseas(sys::state const& state, T ids) {
@@ -56,4 +45,4 @@ void for_each_province_in_state_instance(sys::state& state, dcon::state_instance
 		}
 	}
 }
-}
+} // namespace province

--- a/src/scripting/effects.cpp
+++ b/src/scripting/effects.cpp
@@ -1,6 +1,12 @@
 #include "effects.hpp"
 #include "system_state.hpp"
 #include "ai.hpp"
+#include "demographics.hpp"
+#include "politics.hpp"
+#include "prng.hpp"
+#include "province_templates.hpp"
+#include "rebels.hpp"
+#include "triggers.hpp"
 
 namespace effect {
 
@@ -1702,7 +1708,7 @@ uint32_t ef_life_rating_state(EFFECT_PARAMTERS) {
 			p,
 			uint8_t(std::clamp(int32_t(ws.world.province_get_life_rating(p)) + trigger::payload(tval[1]).signed_value, 0, 255)));
 	});
-	
+
 	return 0;
 }
 uint32_t ef_religion(EFFECT_PARAMTERS) {
@@ -3791,7 +3797,7 @@ uint32_t ef_call_allies(EFFECT_PARAMTERS) {
 				}
 			}
 		}
-		
+
 	}
 
 	return 0;

--- a/src/scripting/events.cpp
+++ b/src/scripting/events.cpp
@@ -1,5 +1,6 @@
 #include "events.hpp"
 #include "system_state.hpp"
+#include "triggers.hpp"
 
 namespace event {
 

--- a/src/scripting/triggers.cpp
+++ b/src/scripting/triggers.cpp
@@ -1,5 +1,10 @@
 #include "triggers.hpp"
 #include "system_state.hpp"
+#include "demographics.hpp"
+#include "military_templates.hpp"
+#include "nations_templates.hpp"
+#include "prng.hpp"
+#include "province_templates.hpp"
 #include "ve_scalar_extensions.hpp"
 
 namespace trigger {

--- a/src/scripting/triggers.hpp
+++ b/src/scripting/triggers.hpp
@@ -6,6 +6,9 @@
 
 namespace trigger {
 
+float read_float_from_payload(uint16_t const* data);
+int32_t read_int32_t_from_payload(uint16_t const* data);
+
 inline int32_t to_generic(dcon::province_id v) {
 	return v.index();
 }
@@ -82,35 +85,35 @@ inline ve::partial_contiguous_tags<int32_t> to_generic(ve::partial_contiguous_ta
 	return ve::partial_contiguous_tags<int32_t>(v.value, v.subcount);
 }
 
-dcon::province_id to_prov(int32_t v) {
+inline dcon::province_id to_prov(int32_t v) {
 	return dcon::province_id(dcon::province_id::value_base_t(v));
 }
-ve::tagged_vector<dcon::province_id> to_prov(ve::tagged_vector<int32_t> v) {
+inline ve::tagged_vector<dcon::province_id> to_prov(ve::tagged_vector<int32_t> v) {
 	return ve::tagged_vector<dcon::province_id>(v, std::true_type{});
 }
-ve::contiguous_tags<dcon::province_id> to_prov(ve::contiguous_tags<int32_t> v) {
+inline ve::contiguous_tags<dcon::province_id> to_prov(ve::contiguous_tags<int32_t> v) {
 	return ve::contiguous_tags<dcon::province_id>(v.value);
 }
-ve::unaligned_contiguous_tags<dcon::province_id> to_prov(ve::unaligned_contiguous_tags<int32_t> v) {
+inline ve::unaligned_contiguous_tags<dcon::province_id> to_prov(ve::unaligned_contiguous_tags<int32_t> v) {
 	return ve::unaligned_contiguous_tags<dcon::province_id>(v.value);
 }
-ve::partial_contiguous_tags<dcon::province_id> to_prov(ve::partial_contiguous_tags<int32_t> v) {
+inline ve::partial_contiguous_tags<dcon::province_id> to_prov(ve::partial_contiguous_tags<int32_t> v) {
 	return ve::partial_contiguous_tags<dcon::province_id>(v.value, v.subcount);
 }
 
-dcon::nation_id to_nation(int32_t v) {
+inline dcon::nation_id to_nation(int32_t v) {
 	return dcon::nation_id(dcon::nation_id::value_base_t(v));
 }
-ve::tagged_vector<dcon::nation_id> to_nation(ve::tagged_vector<int32_t> v) {
+inline ve::tagged_vector<dcon::nation_id> to_nation(ve::tagged_vector<int32_t> v) {
 	return ve::tagged_vector<dcon::nation_id>(v, std::true_type{});
 }
-ve::contiguous_tags<dcon::nation_id> to_nation(ve::contiguous_tags<int32_t> v) {
+inline ve::contiguous_tags<dcon::nation_id> to_nation(ve::contiguous_tags<int32_t> v) {
 	return ve::contiguous_tags<dcon::nation_id>(v.value);
 }
-ve::unaligned_contiguous_tags<dcon::nation_id> to_nation(ve::unaligned_contiguous_tags<int32_t> v) {
+inline ve::unaligned_contiguous_tags<dcon::nation_id> to_nation(ve::unaligned_contiguous_tags<int32_t> v) {
 	return ve::unaligned_contiguous_tags<dcon::nation_id>(v.value);
 }
-ve::partial_contiguous_tags<dcon::nation_id> to_nation(ve::partial_contiguous_tags<int32_t> v) {
+inline ve::partial_contiguous_tags<dcon::nation_id> to_nation(ve::partial_contiguous_tags<int32_t> v) {
 	return ve::partial_contiguous_tags<dcon::nation_id>(v.value, v.subcount);
 }
 


### PR DESCRIPTION
Moves a few high traffic files so they can be (re)built incrementally. Most of the changes are adding `#include`s but the one big thing to note is that template functions require some attention when used across translation units. I've structured the files so that template functions are defined in a separate .hpp file since they have to be defined across all translation units they're included in, and they also require that any template be explicitly instantiated somewhere with a `template [return type] function<explicit template type>();` declaration somewhere. I've put those in the original .cpp files of the functions.

Note that if you want to use a lambda function as a template argument that you'll have to instantiate a template with `std::function<void([lambda argument type(s)])>` as a template argument.

Also you might want to consider adding an incremental target to CI (or maybe switching the Unix one so it builds the incremental target) so that both builds are covered.

[Proof that incremental builds](https://github.com/OptimizedForDensity/Project-Alice/actions/runs/7536130547/job/20513100446)