### PR TITLE
Made AI avoid units when pathing (also applies to player units), of c…

### DIFF
--- a/assets/alice.csv
+++ b/assets/alice.csv
@@ -1325,8 +1325,8 @@ auto_save_0;None;;;Ninguno;;;;;;;;;x
 monthly_emigration_lab;Monthly emigration to (top 10);;;;;;;;;;;;x
 monthly_immigration_lab;Monthly immigration from (top 10);;;;;;;;;;;;x
 im_em_header;Predicted immigration/emigration for ;;;;;;;;;;;;x
-unit_moving_text;$m$ $n$/$x$/$y$ -> $prov$ ($date$);;;;;;;;;;;;x
-unit_standing_text;$m$ $n$/$x$/$y$;;;;;;;;;;;;x
+unit_moving_text;$m$ $n$/$x$/$y$ -> $prov$ ($date$) - §R$cost$§W ($attunit$/$defunit$);;;;;;;;;;;;x
+unit_standing_text;$m$ $n$/$x$/$y$ - §R$cost$§W ($attunit$/$defunit$);;;;;;;;;;;;x
 disarmed_pop;a member of a disarmed nation;;;;;;;;;;;;x
 cancel_fac_construction;Cancel factory construction;;;;;;;;;;;;x
 cancel_fac_upgrade;Cancel factory upgrade;;;;;;;;;;;;x

--- a/src/ai/ai.cpp
+++ b/src/ai/ai.cpp
@@ -4209,36 +4209,110 @@ void gather_to_battle(sys::state& state, dcon::nation_id n, dcon::province_id p)
 	}
 }
 
-float estimate_army_strength(sys::state& state, dcon::army_id a) {
+float estimate_balanced_composition_factor(sys::state& state, dcon::army_id a) {
 	auto regs = state.world.army_get_army_membership(a);
 	if(regs.begin() == regs.end())
 		return 0.0f;
-	auto last_reg = regs.end() - 1;
-	float scale = state.world.army_get_controller_from_army_control(a) ? 1.f : 0.5f;
-	return float(regs.end() - regs.begin()) * (*last_reg).get_regiment().get_org() * scale;
+	// account composition
+	// Ideal composition: 4/1/4 (1 cavalry for each 4 infantry and 1 infantry for each arty)
+	float total_str = 0.f;
+	float str_art = 0.f;
+	float str_inf = 0.f;
+	float str_cav = 0.f;
+	for(const auto reg : regs) {
+		float str = reg.get_regiment().get_strength() * reg.get_regiment().get_org();
+		auto utid = reg.get_regiment().get_type();
+		if(utid) {
+			switch(state.military_definitions.unit_base_definitions[utid].type) {
+			case military::unit_type::infantry:
+				str_inf += str;
+				break;
+			case military::unit_type::cavalry:
+				str_cav += str;
+				break;
+			case military::unit_type::support:
+			case military::unit_type::special:
+				str_art += str;
+				break;
+			}
+		}
+		total_str += str;
+	}
+	if(total_str == 0.f)
+		return 0.f;
+	//provide continous function for each military unit composition
+	//such that 4x times the infantry (we min with arty for equality reasons) and 1/4th of cavalry
+	float scale = 1.f - math::sin(std::abs(std::min(str_art / total_str, str_inf / total_str) - (4.f * str_cav / total_str)));
+	return total_str * scale;
 }
 
-float conservative_estimate_army_strength(sys::state& state, dcon::army_id a) {
-	auto regs = state.world.army_get_army_membership(a);
-	if(regs.begin() == regs.end())
-		return 0.0f;
+float estimate_army_defensive_strength(sys::state& state, dcon::army_id a) {
 	float scale = state.world.army_get_controller_from_army_control(a) ? 1.f : 0.5f;
-	return float(regs.end() - regs.begin()) * (*regs.begin()).get_regiment().get_org() * scale;
+	// account general
+	if(auto gen = state.world.army_get_general_from_army_leadership(a); gen) {
+		auto n = state.world.army_get_controller_from_army_control(a);
+		if(!n)
+			n = state.national_definitions.rebel_id;
+		auto back = state.world.leader_get_background(gen);
+		auto pers = state.world.leader_get_personality(gen);
+		float morale = state.world.nation_get_modifier_values(n, sys::national_mod_offsets::org_regain)
+			+ state.world.leader_trait_get_morale(back)
+			+ state.world.leader_trait_get_morale(pers) + 1.0f;
+		float org = state.world.nation_get_modifier_values(n, sys::national_mod_offsets::land_organisation)
+			+ state.world.leader_trait_get_organisation(back)
+			+ state.world.leader_trait_get_organisation(pers) + 1.0f;
+		float def = state.world.nation_get_modifier_values(n, sys::national_mod_offsets::land_defense_modifier)
+			+ state.world.leader_trait_get_defense(back)
+			+ state.world.leader_trait_get_defense(pers) + 1.0f;
+		scale *= def * morale * org;
+		scale *= 1.f + float(state.world.army_get_dig_in(a));
+	}
+	// terrain defensive bonus
+	float terrain_bonus = state.world.province_get_modifier_values(state.world.army_get_location_from_army_location(a), sys::provincial_mod_offsets::defense);
+	scale += terrain_bonus;
+	float defender_fort = 1.0f + 0.1f * state.world.province_get_building_level(state.world.army_get_location_from_army_location(a), economy::province_building_type::fort);
+	scale += defender_fort;
+	//
+	float strength = estimate_balanced_composition_factor(state, a);
+	return strength * scale;
 }
 
-float estimate_attack_force(sys::state& state, dcon::province_id target, dcon::nation_id by) {
+float estimate_army_offensive_strength(sys::state& state, dcon::army_id a) {
+	float scale = state.world.army_get_controller_from_army_control(a) ? 1.f : 0.5f;
+	// account general
+	if(auto gen = state.world.army_get_general_from_army_leadership(a); gen) {
+		auto n = state.world.army_get_controller_from_army_control(a);
+		if(!n)
+			n = state.national_definitions.rebel_id;
+		auto back = state.world.leader_get_background(gen);
+		auto pers = state.world.leader_get_personality(gen);
+		float morale = state.world.nation_get_modifier_values(n, sys::national_mod_offsets::org_regain)
+			+ state.world.leader_trait_get_morale(back)
+			+ state.world.leader_trait_get_morale(pers) + 1.0f;
+		float org = state.world.nation_get_modifier_values(n, sys::national_mod_offsets::land_organisation)
+			+ state.world.leader_trait_get_organisation(back)
+			+ state.world.leader_trait_get_organisation(pers) + 1.0f;
+		float atk = state.world.nation_get_modifier_values(n, sys::national_mod_offsets::land_attack_modifier)
+			+ state.world.leader_trait_get_attack(back)
+			+ state.world.leader_trait_get_attack(pers) + 1.0f;
+		scale *= atk * morale * org;
+	}
+	float strength = estimate_balanced_composition_factor(state, a);
+	return strength * scale;
+}
+
+float estimate_enemy_defensive_force(sys::state& state, dcon::province_id target, dcon::nation_id by) {
 	if(state.world.nation_get_is_at_war(by)) {
 		float strength_total = 0.f;
 		for(auto ar : state.world.in_army) {
 			if(ar.get_is_retreating() || ar.get_battle_from_army_battle_participation())
 				continue;
-
 			auto loc = ar.get_location_from_army_location();
 			auto sdist = province::sorting_distance(state, loc, target);
 			if(sdist < state.defines.alice_ai_threat_radius) {
 				auto other_nation = ar.get_controller_from_army_control();
 				if((by != other_nation) && (!other_nation || military::are_at_war(state, other_nation, by))) {
-					strength_total += estimate_army_strength(state, ar);
+					strength_total += estimate_army_defensive_strength(state, ar);
 				}
 			}
 		}
@@ -4246,12 +4320,10 @@ float estimate_attack_force(sys::state& state, dcon::province_id target, dcon::n
 	} else { // not at war -- rebel fighting
 		float strength_total = 0.f;
 		for(auto ar : state.world.province_get_army_location(target)) {
-
 			auto other_nation = ar.get_army().get_controller_from_army_control();
 			if(!other_nation) {
-				strength_total += estimate_army_strength(state, ar.get_army());
+				strength_total += estimate_army_defensive_strength(state, ar.get_army());
 			}
-
 		}
 		return state.defines.alice_ai_threat_overestimate * strength_total;
 	}
@@ -4366,7 +4438,7 @@ void assign_targets(sys::state& state, dcon::nation_id n) {
 		if(!potential_targets[i].location)
 			continue; // target has been removed as too close by some earlier iteration
 
-		auto target_attack_force = estimate_attack_force(state, potential_targets[i].location, n);
+		auto target_attack_force = estimate_enemy_defensive_force(state, potential_targets[i].location, n);
 		std::sort(ready_armies.begin(), ready_armies.end(), [&](dcon::province_id a, dcon::province_id b) {
 			auto adist = province::sorting_distance(state, a, potential_targets[i].location);
 			auto bdist = province::sorting_distance(state, b, potential_targets[i].location);
@@ -4392,7 +4464,7 @@ void assign_targets(sys::state& state, dcon::nation_id n) {
 					continue;
 				}
 
-				a_force_str += conservative_estimate_army_strength(state, ar.get_army());
+				a_force_str += estimate_army_offensive_strength(state, ar.get_army());
 			}
 		}
 
@@ -4991,7 +5063,7 @@ float estimate_rebel_strength(sys::state& state, dcon::province_id p) {
 	float v = 0.f;
 	for(auto ar : state.world.province_get_army_location(p))
 		if(ar.get_army().get_controller_from_army_rebel_control())
-			v += estimate_army_strength(state, ar.get_army());
+			v += estimate_army_defensive_strength(state, ar.get_army());
 	return v;
 }
 

--- a/src/ai/ai.hpp
+++ b/src/ai/ai.hpp
@@ -67,7 +67,7 @@ bool will_accept_peace_offer_value(sys::state& state,
 
 bool will_accept_crisis_peace_offer(sys::state& state, dcon::nation_id to, bool is_concession, bool missing_wg);
 
-float estimate_offensive_defensive_strength(sys::state& state, dcon::army_id a);
+float estimate_army_offensive_strength(sys::state& state, dcon::army_id a);
 float estimate_army_defensive_strength(sys::state& state, dcon::army_id a);
 float estimate_rebel_strength(sys::state& state, dcon::province_id p);
 

--- a/src/ai/ai.hpp
+++ b/src/ai/ai.hpp
@@ -67,7 +67,8 @@ bool will_accept_peace_offer_value(sys::state& state,
 
 bool will_accept_crisis_peace_offer(sys::state& state, dcon::nation_id to, bool is_concession, bool missing_wg);
 
-float estimate_army_strength(sys::state& state, dcon::army_id a);
+float estimate_offensive_defensive_strength(sys::state& state, dcon::army_id a);
+float estimate_army_defensive_strength(sys::state& state, dcon::army_id a);
 float estimate_rebel_strength(sys::state& state, dcon::province_id p);
 
 }

--- a/src/culture/rebels.cpp
+++ b/src/culture/rebels.cpp
@@ -786,7 +786,7 @@ void get_hunting_targets(sys::state& state, dcon::nation_id n, std::vector<dcon:
 }
 
 void sort_hunting_targets(sys::state& state, dcon::army_id ar, std::vector<dcon::province_id>& rebel_provs) {
-	auto our_str = ai::estimate_army_strength(state, ar);
+	auto our_str = ai::estimate_army_defensive_strength(state, ar);
 	auto loc = state.world.army_get_location_from_army_location(ar);
 	std::sort(rebel_provs.begin(), rebel_provs.end(), [&](dcon::province_id a, dcon::province_id b) {
 		auto aa = 0.001f * -(our_str - ai::estimate_rebel_strength(state, a));
@@ -831,8 +831,8 @@ void rebel_hunting_check(sys::state& state) {
 				std::sort(rebel_hunters.begin(), rebel_hunters.end(), [&](dcon::army_id a, dcon::army_id b) {
 					auto pa = state.world.army_get_location_from_army_location(a);
 					auto pb = state.world.army_get_location_from_army_location(b);
-					auto as = 0.001f * std::max<float>(ai::estimate_army_strength(state, a), 1.f);
-					auto bs = 0.001f * std::max<float>(ai::estimate_army_strength(state, b), 1.f);
+					auto as = 0.001f * std::max<float>(ai::estimate_army_defensive_strength(state, a), 1.f);
+					auto bs = 0.001f * std::max<float>(ai::estimate_army_defensive_strength(state, b), 1.f);
 					auto da = province::sorting_distance(state, pa, closest_prov) + as;
 					auto db = province::sorting_distance(state, pb, closest_prov) + bs;
 					if(da != db)

--- a/src/gui/gui_common_elements.hpp
+++ b/src/gui/gui_common_elements.hpp
@@ -605,9 +605,9 @@ public:
 		auto n = retrieve<dcon::nation_id>(state, parent);
 		auto recruitable = state.world.nation_get_recruitable_regiments(n);
 		auto active_regs = state.world.nation_get_active_regiments(n);
-		auto is_disarmed = state.world.nation_get_disarmed_until(n) < state.current_date;
+		auto is_disarmed = state.world.nation_get_disarmed_until(n) > state.current_date;
 		auto disarm_factor = is_disarmed ? state.defines.disarmament_army_hit : 1.f;
-		auto supply_mod = state.world.nation_get_modifier_values(n, sys::national_mod_offsets::supply_consumption) + 1.0f;
+		auto supply_mod = std::max(state.world.nation_get_modifier_values(n, sys::national_mod_offsets::supply_consumption) + 1.0f, 0.1f);
 		auto avg_land_score = state.world.nation_get_averge_land_unit_score(n);
 		auto gen_range = state.world.nation_get_leader_loyalty(n);
 		auto num_leaders = float((gen_range.end() - gen_range.begin()));

--- a/src/nations/nations.cpp
+++ b/src/nations/nations.cpp
@@ -372,13 +372,12 @@ void update_military_scores(sys::state& state) {
 	And then we add one point either per leader or per regiment, whichever is greater.
 	*/
 	state.world.execute_serial_over_nation([&, disarm = state.defines.disarmament_army_hit](auto n) {
-		float sum = 0;
 		auto recruitable = ve::to_float(state.world.nation_get_recruitable_regiments(n));
 		auto active_regs = ve::to_float(state.world.nation_get_active_regiments(n));
 		auto is_disarmed =
 				ve::apply([&](dcon::nation_id i) { return state.world.nation_get_disarmed_until(i) < state.current_date; }, n);
 		auto disarm_factor = ve::select(is_disarmed, ve::fp_vector(disarm), ve::fp_vector(1.0f));
-		auto supply_mod = state.world.nation_get_modifier_values(n, sys::national_mod_offsets::supply_consumption) + 1.0f;
+		auto supply_mod = ve::max(state.world.nation_get_modifier_values(n, sys::national_mod_offsets::supply_consumption) + 1.0f, 0.1f);
 		auto avg_land_score = state.world.nation_get_averge_land_unit_score(n);
 		auto num_leaders = ve::apply(
 				[&](dcon::nation_id i) {

--- a/src/provinces/province.cpp
+++ b/src/provinces/province.cpp
@@ -1714,8 +1714,9 @@ std::vector<dcon::province_id> make_land_path(sys::state& state, dcon::province_
 
 				if(other_prov.id.index() < state.province_definitions.first_sea_province.index()) { // is land
 					if(has_access_to_province(state, nation_as, other_prov)) {
+						float danger_factor = has_safe_access_to_province(state, nation_as, other_prov) ? 1.f : 4.f;
 						path_heap.push_back(
-								province_and_distance{nearest.distance_covered + distance, direct_distance(state, other_prov, end), other_prov});
+								province_and_distance{nearest.distance_covered + distance * danger_factor, direct_distance(state, other_prov, end) * danger_factor, other_prov});
 						std::push_heap(path_heap.begin(), path_heap.end());
 						origins_vector.set(other_prov, nearest.province);
 					} else {

--- a/src/provinces/province.cpp
+++ b/src/provinces/province.cpp
@@ -1714,7 +1714,9 @@ std::vector<dcon::province_id> make_land_path(sys::state& state, dcon::province_
 
 				if(other_prov.id.index() < state.province_definitions.first_sea_province.index()) { // is land
 					if(has_access_to_province(state, nation_as, other_prov)) {
-						float danger_factor = has_safe_access_to_province(state, nation_as, other_prov) ? 1.f : 4.f;
+						/* This will work fine for most instances, except, possibly, for allied nations or enemy ones */
+						auto armies = state.world.province_get_army_location(other_prov);
+						float danger_factor = (armies.begin() == armies.end() || (*armies.begin()).get_army().get_controller_from_army_control() == nation_as) ? 1.f : 4.f;
 						path_heap.push_back(
 								province_and_distance{nearest.distance_covered + distance * danger_factor, direct_distance(state, other_prov, end) * danger_factor, other_prov});
 						std::push_heap(path_heap.begin(), path_heap.end());


### PR DESCRIPTION
…ourse, it avoids all units EXCEPT the one they are going for (if any), for example pathing into an unit in province Zacatecas will make the AI avoid ALL other units EXCEPT the one in Zacatecas, for obvious reasons

AI will now consider generales and army composition to determine attack and defense of each unit

TESTED

With TNO
With the og savefile where the AI suicides repeatedly
With vanilla
With TGC
and with HFM

AI now doesnt die as much and is much more conservative on when doing attacks, and when they do them they do them good