### PR TITLE
Revolt map mode

### DIFF
--- a/assets/alice.csv
+++ b/assets/alice.csv
@@ -597,6 +597,7 @@ mtt_fort_level;Fort level ;;;;;;;;;;;;x
 mtt_fort_being_built;A fort level is under construction here.;;;;;;;;;;;;x
 mtt_can_build_fort;A new fort level can be built here.;;;;;;;;;;;;x
 mtt_population_change;Monthly population change: ;;;;;;;;;;;;x
+mtt_rebels_amount;Rebels active in province: ;;;;;;;;;;;;x
 pop_size_1;In the coming month the size of this pop is expected to change by: ;;;;;;;;;;;;x
 pop_size_2;From growth: ;;;;;;;;;;;;x
 pop_size_3;From promotion and demotion: ;;;;;;;;;;;;x

--- a/assets/alice.csv
+++ b/assets/alice.csv
@@ -598,6 +598,7 @@ mtt_fort_being_built;A fort level is under construction here.;;;;;;;;;;;;x
 mtt_can_build_fort;A new fort level can be built here.;;;;;;;;;;;;x
 mtt_population_change;Monthly population change: ;;;;;;;;;;;;x
 mtt_rebels_amount;Rebels active in province: ;;;;;;;;;;;;x
+mtt_rebels_none;There are no rebels in this province.;;;;;;;;;;;;x
 pop_size_1;In the coming month the size of this pop is expected to change by: ;;;;;;;;;;;;x
 pop_size_2;From growth: ;;;;;;;;;;;;x
 pop_size_3;From promotion and demotion: ;;;;;;;;;;;;x

--- a/src/gui/map_tooltip.cpp
+++ b/src/gui/map_tooltip.cpp
@@ -77,7 +77,7 @@ void political_map_tt_box(sys::state& state, text::columnar_layout& contents, dc
 	}
 }
 
-void revolt_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon::province_id prov) {  // Done
+void militancy_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon::province_id prov) {  // Done
 	auto fat = dcon::fatten(state.world, prov);
 	country_name_box(state, contents, prov);
 
@@ -1001,7 +1001,7 @@ void growth_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon:
 	}
 }
 
-void militancy_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon::province_id prov) {
+void revolt_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon::province_id prov) {
 	auto fat = dcon::fatten(state.world, prov);
 	country_name_box(state, contents, prov);
 

--- a/src/gui/map_tooltip.cpp
+++ b/src/gui/map_tooltip.cpp
@@ -1027,17 +1027,21 @@ void militancy_map_tt_box(sys::state& state, text::columnar_layout& contents, dc
 
 		auto box = text::open_layout_box(contents);
 
-		text::localised_format_box(state, contents, box, std::string_view("mtt_rebels_amount"));
-		text::add_to_layout_box(state, contents, box, text::prettify(int64_t(total_rebels)), text::text_color::yellow);
+		if(total_rebels <= 0.f) {
+			text::localised_format_box(state, contents, box, std::string_view("mtt_rebels_none"));
+		} else {
+			text::localised_format_box(state, contents, box, std::string_view("mtt_rebels_amount"));
+			text::add_to_layout_box(state, contents, box, text::prettify(int64_t(total_rebels)), text::text_color::yellow);
 
-		for(size_t i = 0; i < rebel_factions.size(); i++) {
-			text::add_line_break_to_layout_box(state, contents, box);
-			text::add_space_to_layout_box(state, contents, box);
-			text::add_to_layout_box(state, contents, box, rebel::rebel_name(state, rebel_factions[i].first), text::text_color::yellow);
-			text::add_space_to_layout_box(state, contents, box);
-			text::add_to_layout_box(state, contents, box, std::string_view("("), text::text_color::white);
-			text::add_to_layout_box(state, contents, box, text::prettify(int64_t(rebel_factions[i].second)), text::text_color::white);
-			text::add_to_layout_box(state, contents, box, std::string_view(")"), text::text_color::white);
+			for(size_t i = 0; i < rebel_factions.size(); i++) {
+				text::add_line_break_to_layout_box(state, contents, box);
+				text::add_space_to_layout_box(state, contents, box);
+				text::add_to_layout_box(state, contents, box, rebel::rebel_name(state, rebel_factions[i].first), text::text_color::yellow);
+				text::add_space_to_layout_box(state, contents, box);
+				text::add_to_layout_box(state, contents, box, std::string_view("("), text::text_color::white);
+				text::add_to_layout_box(state, contents, box, text::prettify(int64_t(rebel_factions[i].second)), text::text_color::white);
+				text::add_to_layout_box(state, contents, box, std::string_view(")"), text::text_color::white);
+			}
 		}
 
 		text::close_layout_box(contents, box);

--- a/src/map/map_modes.cpp
+++ b/src/map/map_modes.cpp
@@ -271,19 +271,33 @@ std::vector<uint32_t> militancy_map_from(sys::state& state) {
 	uint32_t texture_size = province_size + 256 - province_size % 256;
 	std::vector<uint32_t> prov_color(texture_size * 2);
 	auto sel_nation = state.world.province_get_nation_from_province_ownership(state.map_state.get_selected_province());
-	state.world.for_each_province([&](dcon::province_id prov_id) {
-		auto nation = state.world.province_get_nation_from_province_ownership(prov_id);
-		if((sel_nation && nation == sel_nation) || !sel_nation) {
-			auto scale = 1.f / 10.f;
-			auto value = scale * (state.world.province_get_demographics(prov_id, demographics::militancy) / state.world.province_get_demographics(prov_id, demographics::total));
-			uint32_t color = ogl::color_gradient(1.f - value,
-				sys::pack_color(46, 247, 15), // green
-				sys::pack_color(247, 15, 15) // red
-			);
-			auto i = province::to_map_id(prov_id);
-			prov_color[i] = color;
-			prov_color[i + texture_size] = color;
+	std::unordered_map<uint16_t, float> rebels_in_province = {};
+	std::unordered_map<int32_t, float> continent_max_rebels = {};
+	state.world.for_each_rebel_faction([&](dcon::rebel_faction_id id) {
+		for(auto members : state.world.rebel_faction_get_pop_rebellion_membership(id)) {
+			rebels_in_province[province::to_map_id(members.get_pop().get_province_from_pop_location().id)] += members.get_pop().get_size();
 		}
+	});
+	for(auto& [p, value] : rebels_in_province) {
+		auto pid = province::from_map_id(p);
+		auto cid = dcon::fatten(state.world, pid).get_continent().id.index();
+		continent_max_rebels[cid] = std::max(continent_max_rebels[cid], value);
+	}
+	state.world.for_each_province([&](dcon::province_id prov_id) {
+		auto fat_id = dcon::fatten(state.world, prov_id);
+		auto i = province::to_map_id(prov_id);
+		auto cid = fat_id.get_continent().id.index();
+
+		uint32_t color = 0xDDDDDD;
+		if(rebels_in_province[i]) {
+			float gradient_index = (continent_max_rebels[cid] == 0.f ? 0.f : (rebels_in_province[i] / continent_max_rebels[cid]));
+			color = ogl::color_gradient(gradient_index,
+					sys::pack_color(247, 15, 15), // red
+					sys::pack_color(46, 247, 15) // green
+			);
+		}
+		prov_color[i] = color;
+		prov_color[i + texture_size] = color;
 	});
 	return prov_color;
 }

--- a/src/map/map_modes.cpp
+++ b/src/map/map_modes.cpp
@@ -397,12 +397,12 @@ std::vector<uint32_t> militancy_map_from(sys::state& state) {
 		auto fat_id = dcon::fatten(state.world, prov_id);
 		auto nation = fat_id.get_nation_from_province_ownership();
 
-		//if(nation == state.local_player_nation || state.user_settings.fow_enabled == false) {
 		if(nation) {
 			float revolt_risk = province::revolt_risk(state, prov_id) / 10;
 
-			uint32_t color = ogl::color_gradient(revolt_risk, sys::pack_color(247, 15, 15), // green
-					sys::pack_color(46, 247, 15)		// red
+			uint32_t color = ogl::color_gradient(revolt_risk,
+				sys::pack_color(247, 15, 15), // green
+				sys::pack_color(46, 247, 15) // red
 			);
 			auto i = province::to_map_id(prov_id);
 			prov_color[i] = color;

--- a/src/map/map_modes.cpp
+++ b/src/map/map_modes.cpp
@@ -266,47 +266,7 @@ std::vector<uint32_t> con_map_from(sys::state& state) {
 	});
 	return prov_color;
 }
-std::vector<uint32_t> militancy_map_from(sys::state& state) {
-	uint32_t province_size = state.world.province_size();
-	uint32_t texture_size = province_size + 256 - province_size % 256;
-	std::vector<uint32_t> prov_color(texture_size * 2);
-	auto sel_nation = state.world.province_get_nation_from_province_ownership(state.map_state.get_selected_province());
-	std::unordered_map<uint16_t, float> rebels_in_province = {};
-	std::unordered_map<int32_t, float> continent_max_rebels = {};
-	state.world.for_each_rebel_faction([&](dcon::rebel_faction_id id) {
-		auto rebellion = dcon::fatten(state.world, id);
-		if((sel_nation && sel_nation == rebellion.get_ruler_from_rebellion_within().id) || !sel_nation) {
-			for(auto members : state.world.rebel_faction_get_pop_rebellion_membership(id)) {
-				rebels_in_province[province::to_map_id(members.get_pop().get_province_from_pop_location().id)] += members.get_pop().get_size();
-			}
-		}
-	});
-	for(auto& [p, value] : rebels_in_province) {
-		auto pid = province::from_map_id(p);
-		auto cid = dcon::fatten(state.world, pid).get_continent().id.index();
-		continent_max_rebels[cid] = std::max(continent_max_rebels[cid], value);
-	}
-	state.world.for_each_province([&](dcon::province_id prov_id) {
-		auto nation = state.world.province_get_nation_from_province_ownership(prov_id);
-		if((sel_nation && nation == sel_nation) || !sel_nation) {
-			auto fat_id = dcon::fatten(state.world, prov_id);
-			auto i = province::to_map_id(prov_id);
-			auto cid = fat_id.get_continent().id.index();
 
-			uint32_t color = 0xDDDDDD; // white
-			if(rebels_in_province[i]) {
-				float gradient_index = (continent_max_rebels[cid] == 0.f ? 0.f : (rebels_in_province[i] / continent_max_rebels[cid]));
-				color = ogl::color_gradient(gradient_index,
-						sys::pack_color(247, 15, 15), // red
-						sys::pack_color(46, 247, 15) // green
-				);
-			}
-			prov_color[i] = color;
-			prov_color[i + texture_size] = color;
-		}
-	});
-	return prov_color;
-}
 std::vector<uint32_t> literacy_map_from(sys::state& state) {
 	uint32_t province_size = state.world.province_size();
 	uint32_t texture_size = province_size + 256 - province_size % 256;
@@ -419,6 +379,30 @@ std::vector<uint32_t> employment_map_from(sys::state& state) {
 			uint32_t color = ogl::color_gradient(value,
 				sys::pack_color(46, 247, 15), // green
 				sys::pack_color(247, 15, 15) // red
+			);
+			auto i = province::to_map_id(prov_id);
+			prov_color[i] = color;
+			prov_color[i + texture_size] = color;
+		}
+	});
+	return prov_color;
+}
+
+std::vector<uint32_t> militancy_map_from(sys::state& state) {
+	uint32_t province_size = state.world.province_size();
+	uint32_t texture_size = province_size + 256 - province_size % 256;
+
+	std::vector<uint32_t> prov_color(texture_size * 2);
+	state.world.for_each_province([&](dcon::province_id prov_id) {
+		auto fat_id = dcon::fatten(state.world, prov_id);
+		auto nation = fat_id.get_nation_from_province_ownership();
+
+		//if(nation == state.local_player_nation || state.user_settings.fow_enabled == false) {
+		if(nation) {
+			float revolt_risk = province::revolt_risk(state, prov_id) / 10;
+
+			uint32_t color = ogl::color_gradient(revolt_risk, sys::pack_color(247, 15, 15), // green
+					sys::pack_color(46, 247, 15)		// red
 			);
 			auto i = province::to_map_id(prov_id);
 			prov_color[i] = color;

--- a/src/map/modes/revolt.hpp
+++ b/src/map/modes/revolt.hpp
@@ -1,22 +1,41 @@
 #pragma once
 
+
 std::vector<uint32_t> revolt_map_from(sys::state& state) {
 	uint32_t province_size = state.world.province_size();
 	uint32_t texture_size = province_size + 256 - province_size % 256;
-
 	std::vector<uint32_t> prov_color(texture_size * 2);
+	auto sel_nation = state.world.province_get_nation_from_province_ownership(state.map_state.get_selected_province());
+	std::unordered_map<uint16_t, float> rebels_in_province = {};
+	std::unordered_map<int32_t, float> continent_max_rebels = {};
+	state.world.for_each_rebel_faction([&](dcon::rebel_faction_id id) {
+		auto rebellion = dcon::fatten(state.world, id);
+		if((sel_nation && sel_nation == rebellion.get_ruler_from_rebellion_within().id) || !sel_nation) {
+			for(auto members : state.world.rebel_faction_get_pop_rebellion_membership(id)) {
+				rebels_in_province[province::to_map_id(members.get_pop().get_province_from_pop_location().id)] += members.get_pop().get_size();
+			}
+		}
+	});
+	for(auto& [p, value] : rebels_in_province) {
+		auto pid = province::from_map_id(p);
+		auto cid = dcon::fatten(state.world, pid).get_continent().id.index();
+		continent_max_rebels[cid] = std::max(continent_max_rebels[cid], value);
+	}
 	state.world.for_each_province([&](dcon::province_id prov_id) {
-		auto fat_id = dcon::fatten(state.world, prov_id);
-		auto nation = fat_id.get_nation_from_province_ownership();
-
-		//if(nation == state.local_player_nation || state.user_settings.fow_enabled == false) {
-		if(nation) {
-			float revolt_risk = province::revolt_risk(state, prov_id) / 10;
-
-			uint32_t color = ogl::color_gradient(revolt_risk, sys::pack_color(247, 15, 15), // green
-					sys::pack_color(46, 247, 15)		// red
-			);
+		auto nation = state.world.province_get_nation_from_province_ownership(prov_id);
+		if((sel_nation && nation == sel_nation) || !sel_nation) {
+			auto fat_id = dcon::fatten(state.world, prov_id);
 			auto i = province::to_map_id(prov_id);
+			auto cid = fat_id.get_continent().id.index();
+
+			uint32_t color = 0xDDDDDD; // white
+			if(rebels_in_province[i]) {
+				float gradient_index = (continent_max_rebels[cid] == 0.f ? 0.f : (rebels_in_province[i] / continent_max_rebels[cid]));
+				color = ogl::color_gradient(gradient_index,
+						sys::pack_color(247, 15, 15), // red
+						sys::pack_color(46, 247, 15) // green
+				);
+			}
 			prov_color[i] = color;
 			prov_color[i + texture_size] = color;
 		}


### PR DESCRIPTION
Make revolt map mode show revolts, and militancy map show militancy
Revolt shows total population per province that are part of any rebel group
Tooltip breaks down total rebels by rebel group
