### PR TITLE
Truncate whitespace from player names (used on GUI mostly)

### DIFF
--- a/src/common_types/container_types.hpp
+++ b/src/common_types/container_types.hpp
@@ -291,7 +291,12 @@ struct player_name {
 	char data[48] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
 	std::string_view to_string_view() noexcept {
-		return std::string_view{ reinterpret_cast<const char*>(&data[0]), sizeof(data) };
+		for(int32_t i = sizeof(data) - 1; i >= 0; i--) {
+			if(data[i] != ' ') {
+				return std::string_view{ reinterpret_cast<const char*>(&data[0]), uint32_t(i) };
+			}
+		}
+		return "???";
 	}
 };
 static_assert(sizeof(player_name) == sizeof(player_name::data));


### PR DESCRIPTION
[will most likely not work after unicode transition - but this will do for now]