### PR TITLE
Fix gibraltar being shown as SPA_517

### DIFF
--- a/src/parsing/provinces_parsing.cpp
+++ b/src/parsing/provinces_parsing.cpp
@@ -157,7 +157,7 @@ void make_terrain_modifier(std::string_view name, token_generator& gen, error_ha
 }
 
 void make_state_definition(std::string_view name, token_generator& gen, error_handler& err, scenario_building_context& context) {
-	auto name_id = text::find_or_add_key(context.state, name);
+	auto name_id = text::find_key(context.state, name);
 	auto state_id = context.state.world.create_state_definition();
 
 	context.map_of_state_names.insert_or_assign(std::string(name), state_id);

--- a/src/text/text.cpp
+++ b/src/text/text.cpp
@@ -686,17 +686,24 @@ std::string produce_simple_string(sys::state const& state, std::string_view txt)
 	}
 }
 
-dcon::text_sequence_id find_or_add_key(sys::state& state, std::string_view txt) {
+dcon::text_sequence_id find_key(sys::state& state, std::string_view txt) {
 	auto it = state.key_to_text_sequence.find(lowercase_str(txt));
 	if(it != state.key_to_text_sequence.end()) {
 		return it->second;
-	} else {
+	}
+	return dcon::text_sequence_id{};
+}
+
+dcon::text_sequence_id find_or_add_key(sys::state& state, std::string_view txt) {
+	auto key = text::find_key(state, txt);
+	if(!key) {
 		auto new_key = state.add_to_pool_lowercase(txt);
 		std::string local_key_copy{ state.to_string_view(new_key) };
 		// TODO: eror handler
 		parsers::error_handler err("");
 		return create_text_entry(state, local_key_copy, txt, err);
 	}
+	return key;
 }
 
 

--- a/src/text/text.hpp
+++ b/src/text/text.hpp
@@ -712,6 +712,7 @@ void load_text_data(sys::state& state, uint32_t language, parsers::error_handler
 char16_t win1250toUTF16(char in);
 std::string produce_simple_string(sys::state const& state, dcon::text_sequence_id id);
 std::string produce_simple_string(sys::state const& state, std::string_view key);
+dcon::text_sequence_id find_key(sys::state& state, std::string_view txt);
 dcon::text_sequence_id find_or_add_key(sys::state& state, std::string_view key);
 std::string date_to_string(sys::state const& state, sys::date date);
 


### PR DESCRIPTION
in get_dynamic_state_name:
`    if(!fat_id.get_definition().get_name())
        return get_name_as_string(state, fat_id.get_capital());
    return get_name_as_string(state, fat_id.get_definition());`
but state has a name, `SPA_517`, because the default `find_or_add_key` adds the key, so it "thinks" it has a name already