### PR TITLE
Auto siege for units

### DIFF
--- a/assets/alice.csv
+++ b/assets/alice.csv
@@ -1656,6 +1656,7 @@ alice_political_party_trigger;Only available from 即$date_long_0$劬 to 即$date_l
 alice_political_party_no_trigger;Only available from 即$date_long_0$劬 to 即$date_long_1$劬
 alice_ai_decision;AI's chance of choosing this decision will depend on:
 alice_ctrl_group;Press 即CTRL-1劬 thru 即CTRL-9劬 to assign/unassign this unit to a control group, which you can then press 即1劬 thru 即9劬 to select
+alice_ai_controlled_unit;Enable/Disable AI control of this unit, the unit will:\n- Automatically reinforce frontlines\n- Automatically siege when it's safe to do so\n- Hunt rebels\n- Form a defensive position against nations we're likely to attack (this is at the AI's discretion, and only at peace time)\nIf you want to make this unit target a specific nation or region, first move it close to that region or nation, then turn on AI control - because the AI will override all of your commands until you turn it off again
 alice_navy_allocation_tt;With 即$curr$劬 ships, we accumulate a total supply throughput of 即$tot$劬, requiring 即$req$劬 for our fleets. A detailed summary of the consumption of each naval fleet:
 alice_navy_allocation_2;$name$: 即$value$劬 (即$perc$劬)
 alice_wg_condition_1;Does not have status quo as a defender

--- a/assets/alice.gui
+++ b/assets/alice.gui
@@ -3990,6 +3990,12 @@ guiTypes = {
 		Orientation = "CENTER_DOWN"
 	}
 
+	guiButtonType = {
+		name = "alice_enable_ai_controlled"
+		position = { 180 312 }
+		quadTextureSprite = "GFX_checkbox_default"	
+	}
+
 	windowType = {
 		name = "alice_diplomessageicon_entry_window"
 		position = { 0 0 }	

--- a/assets/alice.gui
+++ b/assets/alice.gui
@@ -3990,12 +3990,6 @@ guiTypes = {
 		Orientation = "CENTER_DOWN"
 	}
 
-	guiButtonType = {
-		name = "alice_enable_ai_controlled"
-		position = { 180 312 }
-		quadTextureSprite = "GFX_checkbox_default"	
-	}
-
 	windowType = {
 		name = "alice_diplomessageicon_entry_window"
 		position = { 0 0 }	
@@ -4020,5 +4014,16 @@ guiTypes = {
 		Orientation = "UPPER_LEFT"
 		format = centre
 		spacing = 1.0
+	}
+
+	guiButtonType = {
+		name = "alice_enable_ai_controlled"
+		position = { 180 312 }
+		quadTextureSprite = "GFX_checkbox_default"	
+	}
+	guiButtonType = {
+		name = "alice_enable_ai_controlled_multi"
+		position = { 239 4 }
+		quadTextureSprite = "GFX_checkbox_default"	
 	}
 }

--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -3681,11 +3681,13 @@ void execute_toggle_unit_ai_control(sys::state& state, dcon::nation_id source, d
 	auto owner = state.world.army_get_controller_from_army_control(a);
 	if(owner != source)
 		return;
-	auto current_state = state.world.army_get_is_rebel_hunter(a);
+	auto current_state = state.world.army_get_is_ai_controlled(a);
 	if(current_state) {
 		state.world.army_set_ai_activity(a, 0);
 		state.world.army_set_is_ai_controlled(a, false);
 	} else {
+		//turn off rebel control
+		state.world.army_set_is_rebel_hunter(a, false);
 		auto path = state.world.army_get_path(a);
 		if(path.size() > 0) {
 			state.world.army_set_ai_province(a, path.at(0));

--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -3669,6 +3669,39 @@ void execute_toggle_rebel_hunting(sys::state& state, dcon::nation_id source, dco
 	}
 }
 
+void toggle_unit_ai_control(sys::state& state, dcon::nation_id source, dcon::army_id a) {
+	payload p;
+	memset(&p, 0, sizeof(payload));
+	p.type = command_type::toggle_unit_ai_control;
+	p.source = source;
+	p.data.army_movement.a = a;
+	add_to_command_queue(state, p);
+}
+void execute_toggle_unit_ai_control(sys::state& state, dcon::nation_id source, dcon::army_id a) {
+	auto owner = state.world.army_get_controller_from_army_control(a);
+	if(owner != source)
+		return;
+	auto current_state = state.world.army_get_is_rebel_hunter(a);
+	if(current_state) {
+		state.world.army_set_ai_activity(a, 0);
+		state.world.army_set_is_ai_controlled(a, false);
+	} else {
+		auto path = state.world.army_get_path(a);
+		if(path.size() > 0) {
+			state.world.army_set_ai_province(a, path.at(0));
+		} else {
+			state.world.army_set_ai_province(a, state.world.army_get_location_from_army_location(a));
+			if(!state.world.army_get_battle_from_army_battle_participation(a)
+				&& !state.world.army_get_navy_from_army_transport(a)) {
+
+				military::send_rebel_hunter_to_next_province(state, a, state.world.army_get_location_from_army_location(a));
+			}
+		}
+		state.world.army_set_ai_activity(a, 0);
+		state.world.army_set_is_ai_controlled(a, true);
+	}
+}
+
 void toggle_select_province(sys::state& state, dcon::nation_id source, dcon::province_id prov) {
 	payload p;
 	memset(&p, 0, sizeof(payload));
@@ -4894,7 +4927,10 @@ bool can_perform_command(sys::state& state, payload& c) {
 
 	case command_type::move_capital:
 		return can_move_capital(state, c.source, c.data.generic_location.prov);
-		
+
+	case command_type::toggle_unit_ai_control:
+		return true;
+
 		// common mp commands
 	case command_type::chat_message:
 	{
@@ -5267,6 +5303,9 @@ void execute_command(sys::state& state, payload& c) {
 		break;
 	case command_type::move_capital:
 		execute_move_capital(state, c.source, c.data.generic_location.prov);
+		break;
+	case command_type::toggle_unit_ai_control:
+		execute_toggle_unit_ai_control(state, c.source, c.data.army_movement.a);
 		break;
 		
 		// common mp commands

--- a/src/gamestate/commands.hpp
+++ b/src/gamestate/commands.hpp
@@ -101,6 +101,7 @@ enum class command_type : uint8_t {
 	release_subject = 92,
 	enable_debt = 93,
 	move_capital = 94,
+	toggle_unit_ai_control = 95,
 
 	// network
 	notify_player_ban = 106,
@@ -756,6 +757,7 @@ void evenly_split_army(sys::state& state, dcon::nation_id source, dcon::army_id 
 bool can_evenly_split_army(sys::state& state, dcon::nation_id source, dcon::army_id a);
 
 void toggle_rebel_hunting(sys::state& state, dcon::nation_id source, dcon::army_id a);
+void toggle_unit_ai_control(sys::state& state, dcon::nation_id source, dcon::army_id a);
 
 void evenly_split_navy(sys::state& state, dcon::nation_id source, dcon::navy_id a);
 bool can_evenly_split_navy(sys::state& state, dcon::nation_id source, dcon::navy_id a);

--- a/src/gamestate/dcon_generated.txt
+++ b/src/gamestate/dcon_generated.txt
@@ -1714,6 +1714,11 @@ object {
 		type{ province_id }
 		tag{ save }
 	}
+	property{
+		name{ is_ai_controlled }
+		type{ bitfield }
+		tag{ save }
+	}
 }
 
 object {

--- a/src/gui/gui_unit_panel.hpp
+++ b/src/gui/gui_unit_panel.hpp
@@ -1004,10 +1004,6 @@ public:
 	}
 	void button_action(sys::state& state) noexcept override {
 		auto a = retrieve<dcon::army_id>(state, parent);
-		// Rebel control needs to be turned off
-		if(state.world.army_get_is_rebel_hunter(a)) {
-			command::toggle_rebel_hunting(state, state.local_player_nation, a);
-		}
 		command::toggle_unit_ai_control(state, state.local_player_nation, a);
 	}
 };
@@ -1935,10 +1931,6 @@ public:
 				command::toggle_unit_ai_control(state, state.local_player_nation, a);
 			} else { //some on -> turn all that are off into on, all off -> turn all on
 				if(!state.world.army_get_is_ai_controlled(a)) {
-					// Rebel control needs to be turned off
-					if(state.world.army_get_is_rebel_hunter(a)) {
-						command::toggle_rebel_hunting(state, state.local_player_nation, a);
-					}
 					command::toggle_unit_ai_control(state, state.local_player_nation, a);
 				}
 			}

--- a/src/gui/gui_unit_panel.hpp
+++ b/src/gui/gui_unit_panel.hpp
@@ -1941,6 +1941,7 @@ public:
 };
 
 class mulit_unit_selection_panel : public main_window_element_base {
+public:
 	void on_create(sys::state& state) noexcept override {
 		window_element_base::on_create(state);
 		auto ptr = make_element_by_type<multi_unit_details_ai_controlled>(state, "alice_enable_ai_controlled_multi");

--- a/src/gui/gui_unit_panel.hpp
+++ b/src/gui/gui_unit_panel.hpp
@@ -988,6 +988,29 @@ public:
 			button_element_base::render(state, x, y);
 	}
 };
+class unit_details_ai_controlled : public checkbox_button {
+public:
+	bool is_active(sys::state& state) noexcept override {
+		return state.world.army_get_is_ai_controlled(retrieve<dcon::army_id>(state, parent));
+	}
+	message_result test_mouse(sys::state& state, int32_t x, int32_t y, mouse_probe_type type) noexcept override {
+		return button_element_base::test_mouse(state, x, y, type);
+	}
+	tooltip_behavior has_tooltip(sys::state& state) noexcept override {
+		return tooltip_behavior::tooltip;
+	}
+	void update_tooltip(sys::state& state, int32_t x, int32_t y, text::columnar_layout& contents) noexcept override {
+		text::add_line(state, contents, "alice_ai_controlled_unit");
+	}
+	void button_action(sys::state& state) noexcept override {
+		auto a = retrieve<dcon::army_id>(state, parent);
+		// Rebel control needs to be turned off
+		if(state.world.army_get_is_rebel_hunter(a)) {
+			command::toggle_rebel_hunting(state, state.local_player_nation, a);
+		}
+		command::toggle_unit_ai_control(state, state.local_player_nation, a);
+	}
+};
 
 class unit_supply_bar : public progress_bar {
 public:
@@ -1121,6 +1144,13 @@ class unit_details_buttons : public window_element_base {
 private:
 	simple_text_element_base* navytransport_text = nullptr;
 public:
+	void on_create(sys::state& state) noexcept override {
+		window_element_base::on_create(state);
+
+		auto ptr = make_element_by_type<unit_details_ai_controlled>(state, "alice_enable_ai_controlled");
+		add_child_to_front(std::move(ptr));
+	}
+
 	std::unique_ptr<element_base> make_child(sys::state& state, std::string_view name, dcon::gui_def_id id) noexcept override {
 		if(name == "load_button" && std::is_same_v<T, dcon::army_id>) {
 			if constexpr(std::is_same_v<T, dcon::army_id>) {

--- a/src/gui/gui_unit_panel.hpp
+++ b/src/gui/gui_unit_panel.hpp
@@ -1923,16 +1923,22 @@ public:
 		text::add_line(state, contents, "alice_ai_controlled_unit");
 	}
 	void button_action(sys::state& state) noexcept override {
-		bool b = is_active(state);
-		for(auto a : state.selected_armies) {
-			// Rebel control needs to be turned off
-			if(state.world.army_get_is_rebel_hunter(a)) {
-				command::toggle_rebel_hunting(state, state.local_player_nation, a);
+		bool all_on = true;
+		for(auto i : state.selected_armies) {
+			if(state.world.army_get_is_ai_controlled(i) == false) {
+				all_on = false;
+				break;
 			}
-			if(b) { //all on -> turn all off
+		}
+		for(auto a : state.selected_armies) {
+			if(all_on) { //all on -> turn all off
 				command::toggle_unit_ai_control(state, state.local_player_nation, a);
 			} else { //some on -> turn all that are off into on, all off -> turn all on
-				if(state.world.army_get_is_ai_controlled(a)) {
+				if(!state.world.army_get_is_ai_controlled(a)) {
+					// Rebel control needs to be turned off
+					if(state.world.army_get_is_rebel_hunter(a)) {
+						command::toggle_rebel_hunting(state, state.local_player_nation, a);
+					}
 					command::toggle_unit_ai_control(state, state.local_player_nation, a);
 				}
 			}


### PR DESCRIPTION
Enable/Disable AI control of this unit, the unit will:
- Automatically reinforce frontlines
- Automatically siege when it's safe to do so
- Hunt rebels
- Form a defensive position against nations we're likely to attack (this is at the AI's discretion, and only at peace time)
If you want to make this unit target a specific nation or region, first move it close to that region or nation, then turn on AI control - because the AI will override all of your commands until you turn it off again