### PR TITLE
Better performance for RGO and Immigration mapmodes

### DIFF
--- a/src/map/map_modes.cpp
+++ b/src/map/map_modes.cpp
@@ -5,6 +5,7 @@
 #include "system_state.hpp"
 #include "dcon_generated.hpp"
 #include "province.hpp"
+#include "province_templates.hpp"
 #include "nations.hpp"
 #include <unordered_map>
 

--- a/src/map/modes/migration.hpp
+++ b/src/map/modes/migration.hpp
@@ -5,7 +5,6 @@ std::vector<uint32_t> migration_map_from(sys::state& state) {
 	uint32_t texture_size = province_size + 256 - province_size % 256;
 
 	std::vector<uint32_t> prov_color(texture_size * 2);
-
 	auto selected = state.map_state.selected_province;
 	auto for_nation = state.world.province_get_nation_from_province_ownership(selected);
 	if(for_nation) {
@@ -19,10 +18,9 @@ std::vector<uint32_t> migration_map_from(sys::state& state) {
 		if(mx > mn) {
 			for(auto p : state.world.nation_get_province_ownership(for_nation)) {
 				auto v = p.get_province().get_daily_net_migration();
-
 				uint32_t color = ogl::color_gradient((v - mn) / (mx - mn),
-					sys::pack_color(46, 247, 15),	// to green
-					sys::pack_color(247, 15, 15)	// from red
+					sys::pack_color(46, 247, 15), // to green
+					sys::pack_color(247, 15, 15) // from red
 				);
 				auto i = province::to_map_id(p.get_province());
 				prov_color[i] = color;
@@ -35,48 +33,39 @@ std::vector<uint32_t> migration_map_from(sys::state& state) {
 
 		if(state.ui_date != last_checked_date) {
 			last_checked_date = state.ui_date;
-
 			auto sz = state.world.nation_size();
 			if(uint32_t(nation_totals.size()) < sz) {
 				nation_totals.resize(sz);
 			}
-
-			for(uint32_t i = 0; i < sz; ++i) {
-				nation_totals[i] = 0.0f;
-			}
 			float least_neg = -1.0f;
 			float greatest_pos = 1.0f;
-			for(auto p : state.world.in_province) {
-				auto owner = p.get_nation_from_province_ownership();
-				if(owner && uint32_t(owner.id.index()) < sz) {
-					auto v = p.get_daily_net_immigration();
-					nation_totals[owner.id.index()] += v;
+			for(auto n : state.world.in_nation) {
+				nation_totals[n.id.index()] = 0.0f;
+				for(auto po : n.get_province_ownership()) {
+					nation_totals[n.id.index()] += po.get_province().get_daily_net_immigration();
 				}
-			}
-			for(uint32_t i = 0; i < sz; ++i) {
-				if(nation_totals[i] < 0.0f)
-					least_neg = std::min(nation_totals[i], least_neg);
+				if(nation_totals[n.id.index()] < 0.0f)
+					least_neg = std::min(nation_totals[n.id.index()], least_neg);
 				else
-					greatest_pos = std::max(nation_totals[i], greatest_pos);
+					greatest_pos = std::max(nation_totals[n.id.index()], greatest_pos);
 			}
-			for(uint32_t i = 0; i < sz; ++i) {
-				if(nation_totals[i] < 0.0f) {
-					nation_totals[i] = 0.5f - 0.5f * nation_totals[i] / least_neg;
-				} else if(nation_totals[i] > 0.0f) {
-					nation_totals[i] = 0.5f + 0.5f * nation_totals[i] / greatest_pos;
+			for(auto n : state.world.in_nation) {
+				if(nation_totals[n.id.index()] < 0.0f) {
+					nation_totals[n.id.index()] = 0.5f - 0.5f * nation_totals[i] / least_neg;
+				} else if(nation_totals[n.id.index()] > 0.0f) {
+					nation_totals[n.id.index()] = 0.5f + 0.5f * nation_totals[i] / greatest_pos;
 				} else {
-					nation_totals[i] = 0.5f;
+					nation_totals[n.id.index()] = 0.5f;
 				}
 			}
 		}
-		for(auto p : state.world.in_province) {
-			auto owner = p.get_nation_from_province_ownership();
-			if(owner && uint32_t(owner.id.index()) < nation_totals.size()) {
-				uint32_t color = ogl::color_gradient(nation_totals[owner.id.index()],
+		for(auto n : state.world.in_nation) {
+			for(auto po : n.get_province_ownership()) {
+				uint32_t color = ogl::color_gradient(nation_totals[n.id.index()],
 					sys::pack_color(46, 247, 15),	// to green
 					sys::pack_color(247, 15, 15)	// from red
 				);
-				auto i = province::to_map_id(p);
+				auto i = province::to_map_id(po.get_province());
 				prov_color[i] = color;
 				prov_color[i + texture_size] = color;
 			}

--- a/src/map/modes/migration.hpp
+++ b/src/map/modes/migration.hpp
@@ -51,9 +51,9 @@ std::vector<uint32_t> migration_map_from(sys::state& state) {
 			}
 			for(auto n : state.world.in_nation) {
 				if(nation_totals[n.id.index()] < 0.0f) {
-					nation_totals[n.id.index()] = 0.5f - 0.5f * nation_totals[i] / least_neg;
+					nation_totals[n.id.index()] = 0.5f - 0.5f * nation_totals[n.id.index()] / least_neg;
 				} else if(nation_totals[n.id.index()] > 0.0f) {
-					nation_totals[n.id.index()] = 0.5f + 0.5f * nation_totals[i] / greatest_pos;
+					nation_totals[n.id.index()] = 0.5f + 0.5f * nation_totals[n.id.index()] / greatest_pos;
 				} else {
 					nation_totals[n.id.index()] = 0.5f;
 				}

--- a/src/map/modes/rgo_output.hpp
+++ b/src/map/modes/rgo_output.hpp
@@ -9,13 +9,13 @@ std::vector<uint32_t> rgo_output_map_from(sys::state& state) {
 	if(selected_province) {
 		auto searched_rgo = state.world.province_get_rgo(selected_province);
 		float max_rgo_size = 0.f;
-		state.world.for_each_province([&](dcon::province_id prov_id) {
+		province::for_each_land_province(state, [&](dcon::province_id prov_id) {
 			auto prov_rgo = state.world.province_get_rgo(prov_id);
 			if(searched_rgo == prov_rgo) {
 				max_rgo_size = std::max(max_rgo_size, province::rgo_size(state, prov_id));
 			}
 		});
-		state.world.for_each_province([&](dcon::province_id prov_id) {
+		province::for_each_land_province(state, [&](dcon::province_id prov_id) {
 			auto i = province::to_map_id(prov_id);
 			auto prov_rgo = state.world.province_get_rgo(prov_id);
 			if(searched_rgo == prov_rgo) {
@@ -31,7 +31,7 @@ std::vector<uint32_t> rgo_output_map_from(sys::state& state) {
 			}
 		});
 	} else {
-		state.world.for_each_province([&](dcon::province_id prov_id) {
+		province::for_each_land_province(state, [&](dcon::province_id prov_id) {
 			auto const color = state.world.commodity_get_color(state.world.province_get_rgo(prov_id));
 			auto i = province::to_map_id(prov_id);
 			prov_color[i] = color;


### PR DESCRIPTION
- discard pops early
- reuse logic so if it changes then tt isnt that affected
- only evaluate land provinces (why would sea affect shit?)