### PR TITLE
Small AI fix

### DIFF
--- a/src/ai/ai.cpp
+++ b/src/ai/ai.cpp
@@ -5012,6 +5012,21 @@ void update_land_constructions(sys::state& state) {
 		if(disarm && state.current_date < disarm)
 			continue;
 
+		static std::vector<dcon::province_land_construction_id> hopeless_construction;
+		hopeless_construction.clear();
+
+		state.world.nation_for_each_province_land_construction(state.local_player_nation,
+					[&](dcon::province_land_construction_id plcid) {
+			auto fat_plc = dcon::fatten(state.world, plcid);
+			auto prov = fat_plc.get_pop().get_province_from_pop_location();
+			if(prov.get_nation_from_province_control() != n)
+				hopeless_construction.push_back(plcid);
+		});
+
+		for(auto item : hopeless_construction) {
+			state.world.delete_province_land_construction(item);
+		}			
+
 		auto constructions = state.world.nation_get_province_land_construction(n);
 		if(constructions.begin() != constructions.end())
 			continue;


### PR DESCRIPTION
AI does not build units if there is a unit in progress.
Units construction does not progress on occupied land.
So if there is a unit which they tried to build in the past on currently occupied land, they are stuck.

This PR tries to fix this oversight.