### PR TITLE
Implement `rgo_distribution` for province history.

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -376,3 +376,21 @@ Now you can define ruler names for a specific nation with a specific government 
 RUS_absolute_monarchy;The Russian Empire
 RUS_absolute_monarchy_ruler;Tsar
 ```
+
+## Definitions for multiple goods produced by local RGO
+
+As RGO can produce a whole distribution of goods, you can define your own distribution for specific provinces:
+
+Example (`history\provinces` files):
+```
+rgo_distribution = {
+	entry = {
+        trade_good = silk
+        max_employment = 100000
+	}
+    entry = {
+        trade_good = opium
+        max_employment = 100000
+	}
+}
+```

--- a/src/economy/economy.cpp
+++ b/src/economy/economy.cpp
@@ -799,6 +799,10 @@ void initialize(sys::state& state) {
 
 
 	province::for_each_land_province(state, [&](dcon::province_id p) {
+		if(state.world.province_get_rgo_was_set_during_scenario_creation(p)) {
+			return;
+		}
+
 		auto fp = fatten(state.world, p);
 
 		dcon::modifier_id climate = fp.get_climate();
@@ -854,7 +858,7 @@ void initialize(sys::state& state) {
 			true_distribution[c.index()] /= total;
 		});
 
-		// distribution of rgo land per good
+		// distribution of rgo land per good		
 		state.world.for_each_commodity([&](dcon::commodity_id c) {
 			auto fc = fatten(state.world, c);
 			state.world.province_get_rgo_max_size_per_good(fp, c) +=

--- a/src/gamestate/dcon_generated.txt
+++ b/src/gamestate/dcon_generated.txt
@@ -1511,6 +1511,11 @@ object {
 		type{ float }
 	}
 	property{
+		name{ rgo_was_set_during_scenario_creation }
+		type{ bitfield }
+		tag{ scenario, save }
+	}
+	property{
 		name{ rgo_max_size_per_good }
 		type{ array{commodity_id}{float} }
 		tag{ save }

--- a/src/gamestate/dcon_generated.txt
+++ b/src/gamestate/dcon_generated.txt
@@ -1513,7 +1513,6 @@ object {
 	property{
 		name{ rgo_was_set_during_scenario_creation }
 		type{ bitfield }
-		tag{ scenario, save }
 	}
 	property{
 		name{ rgo_max_size_per_good }

--- a/src/gamestate/system_state.cpp
+++ b/src/gamestate/system_state.cpp
@@ -2505,6 +2505,8 @@ void state::load_scenario_data(parsers::error_handler& err, sys::year_month_day 
 		}
 	});
 
+	world.province_resize_rgo_max_size_per_good(world.commodity_size());
+
 	// load province history files
 	auto history = open_directory(root, NATIVE("history"));
 	{
@@ -3021,7 +3023,6 @@ void state::load_scenario_data(parsers::error_handler& err, sys::year_month_day 
 	world.state_instance_resize_demographics(demographics::size(*this));
 
 	world.province_resize_demographics(demographics::size(*this));
-	world.province_resize_rgo_max_size_per_good(world.commodity_size());
 	world.province_resize_rgo_profit_per_good(world.commodity_size());
 	world.province_resize_rgo_actual_production_per_good(world.commodity_size());
 	world.province_resize_rgo_employment_per_good(world.commodity_size());

--- a/src/parsing/parser_defs.txt
+++ b/src/parsing/parser_defs.txt
@@ -565,6 +565,13 @@ pv_state_building
 	building          value          text               member_fn
 	upgrade           value          none               discard
 
+province_rgo_ext_desc
+	trade_good        value          text               member_fn
+	max_employment    value          int                member_fn
+
+province_rgo_ext
+	entry             group          province_rgo_ext_desc  member_fn
+
 province_history_file
 	life_rating       value          uint               member_fn
 	colony            value          uint               member_fn
@@ -582,6 +589,7 @@ province_history_file
 	is_slave          value          bool               member_fn
 	set_province_flag value          none               discard
 	clr_province_flag value          none               discard
+	rgo_distribution  group          province_rgo_ext   member_fn
 	#any              value          uint               member_fn
 	#any              extern         enter_dated_block  discard
 

--- a/src/parsing/parsers_declarations.hpp
+++ b/src/parsing/parsers_declarations.hpp
@@ -1477,6 +1477,19 @@ struct pv_state_building {
 	void finish(province_file_context&) { }
 };
 
+struct province_rgo_ext_desc {
+	dcon::commodity_id trade_good_id;
+	float max_employment_value;
+	void max_employment(association_type, uint32_t value, error_handler& err, int32_t line, province_file_context& context);
+	void trade_good(association_type, std::string_view text, error_handler& err, int32_t line, province_file_context& context);
+	void finish(province_file_context&);
+};
+
+struct province_rgo_ext {
+	void entry(province_rgo_ext_desc const& value, error_handler& err, int32_t line, province_file_context& context);
+	void finish(province_file_context&) { }
+};
+
 struct province_history_file {
 	void life_rating(association_type, uint32_t value, error_handler& err, int32_t line, province_file_context& context);
 	void colony(association_type, uint32_t value, error_handler& err, int32_t line, province_file_context& context);
@@ -1489,8 +1502,8 @@ struct province_history_file {
 	void party_loyalty(pv_party_loyalty const& value, error_handler& err, int32_t line, province_file_context& context);
 	void state_building(pv_state_building const& value, error_handler& err, int32_t line, province_file_context& context);
 	void is_slave(association_type, bool value, error_handler& err, int32_t line, province_file_context& context);
-	void any_value(std::string_view name, association_type, uint32_t value, error_handler& err, int32_t line,
-			province_file_context& context);
+	void rgo_distribution(province_rgo_ext const& value, error_handler& err, int32_t line, province_file_context& context);
+	void any_value(std::string_view name, association_type, uint32_t value, error_handler& err, int32_t line, province_file_context& context);
 	void finish(province_file_context&) { }
 };
 

--- a/src/parsing/provinces_parsing.cpp
+++ b/src/parsing/provinces_parsing.cpp
@@ -300,6 +300,10 @@ void province_history_file::trade_goods(association_type, std::string_view text,
 	}
 }
 
+void province_history_file::rgo_distribution(province_rgo_ext const& value, error_handler& err, int32_t line, province_file_context& context) {
+	return;
+}
+
 void province_history_file::owner(association_type, uint32_t value, error_handler& err, int32_t line,
 		province_file_context& context) {
 	if(auto it = context.outer_context.map_of_ident_names.find(value); it != context.outer_context.map_of_ident_names.end()) {
@@ -385,6 +389,32 @@ void province_history_file::any_value(std::string_view name, association_type, u
 		}
 	}
 	err.accumulated_errors += "unknown province history key " + std::string(name) + " (" + err.file_name + " line " + std::to_string(line) + ")\n";//err.unhandled_association_key();
+}
+
+void province_rgo_ext_desc::max_employment(association_type, uint32_t value, error_handler& err, int32_t line, province_file_context& context) {
+	max_employment_value = float(value);
+}
+
+void province_rgo_ext_desc::trade_good(association_type, std::string_view text, error_handler& err, int32_t line, province_file_context& context) {
+	if(auto it = context.outer_context.map_of_commodity_names.find(std::string(text));
+			it != context.outer_context.map_of_commodity_names.end()) {
+		trade_good_id = it->second;
+	} else {
+		err.accumulated_errors +=
+			std::string(text) + " is not a valid commodity name (" + err.file_name + " line " + std::to_string(line) + ")\n";
+	}
+}
+
+void province_rgo_ext_desc::finish(province_file_context& context) {
+	
+};
+
+void province_rgo_ext::entry(province_rgo_ext_desc const& value, error_handler& err, int32_t line, province_file_context& context) {
+	if(value.trade_good_id) {
+		auto p = context.id;
+		context.outer_context.state.world.province_set_rgo_max_size_per_good(p, value.trade_good_id, value.max_employment_value / economy::rgo_per_size_employment);
+		context.outer_context.state.world.province_set_rgo_was_set_during_scenario_creation(p, 1);
+	}
 }
 
 void make_pop_province_list(std::string_view name, token_generator& gen, error_handler& err, scenario_building_context& context) {


### PR DESCRIPTION
Syntax is 
```
rgo_distribution = {
	entry = {
		trade_good = silk
		max_employment = 100000
	}
	entry = {
		trade_good = opium
		max_employment = 100000
	}
}
```
It overwrites values which would be otherwise generated by a game.