### PR TITLE
Defines flag to allow subjects declare wars

### DIFF
--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -2152,12 +2152,13 @@ bool can_fabricate_cb(sys::state& state, dcon::nation_id source, dcon::nation_id
 		return false;
 
 	/*
-	Can't fabricate on someone you are at war with. Can't fabricate on anyone except your overlord if you are a vassal. Requires
+	Can't fabricate on someone you are at war with. Requires
 	defines:MAKE_CB_DIPLOMATIC_COST diplomatic points. Can't fabricate on your sphere members
 	*/
 
+	// Allow subjects to declare wars if can_use of CB definition allows for that as per Vanilla logic.
 	auto ol = state.world.nation_get_overlord_as_subject(source);
-	if(state.world.overlord_get_ruler(ol) && state.world.overlord_get_ruler(ol) != target)
+	if(state.defines.alice_allow_subjects_declare_wars < 1 && state.world.overlord_get_ruler(ol) && state.world.overlord_get_ruler(ol) != target)
 		return false;
 
 	if(state.world.nation_get_in_sphere_of(target) == source)

--- a/src/parsing/defines.hpp
+++ b/src/parsing/defines.hpp
@@ -690,6 +690,7 @@
 	LUA_DEFINES_LIST_ELEMENT(alice_overseas_mil, 0.1) \
 	LUA_DEFINES_LIST_ELEMENT(alice_rgo_per_size_employment, 40000.0) \
 	LUA_DEFINES_LIST_ELEMENT(alice_eval_ai_mil_everyday, 0.0) \
+	LUA_DEFINES_LIST_ELEMENT(alice_allow_subjects_declare_wars, 0.0) \
 
 // scales the needs values so that they are needs per this many pops
 // this value was arrived at by looking at farmers: 40'000 farmers produces enough grain to satisfy about 2/3


### PR DESCRIPTION
Introducing compatibility defines flag "alice_allow_subjects_declare_wars" to allow subjects declare wars and add wargoals in wars. Also rework of wrong ui logic with "has_any_usable_cb".