### PR TITLE
Unit construction outliner & queue improvements

### DIFF
--- a/assets/localisation/ar-AR/alice.csv
+++ b/assets/localisation/ar-AR/alice.csv
@@ -1042,6 +1042,7 @@ alice_gp_status_regain_expiration;إذا لم نصبح في المرتبة ?Y$x$
 alice_mil_decay_description;الاضمحلال الطبيعي؟G-$x$
 alice_con_decay_description;الاضمحلال الطبيعي؟R-$x$
 x_from_y;$culture$ $x$ من $y$
+x_in_y;$x$ من $y$
 reinforce_rate;يمكن لهذا الفوج تعزيز ما يصل إلى $x$ من الجنود شهريًا.
 reinforce_rate_none;لا يمكن تعزيز هذا الفوج حاليًا.
 alice_domestic_investment_button;"الاستثمار في المشاريع الفردية أمر مهمل، استخدم شريط التمرير ""الاستثمار المحلي"" على شاشة الميزانية بدلاً من ذلك"

--- a/assets/localisation/de-DE/alice.csv
+++ b/assets/localisation/de-DE/alice.csv
@@ -1042,7 +1042,8 @@ alice_ca_cant_influence;Es ist uns derzeit nicht möglich, die Meinung anderer N
 alice_gp_status_regain_expiration;Wenn wir nicht Rang ?Y$x$?W oder höher erreichen, verlieren wir bis zum ?Y$Datum?W den Status ?YGroßmacht?W!
 alice_mil_decay_description;Natürlicher Verfall ?G-$x$
 alice_con_decay_description;Natürlicher Verfall ?R-$x$
-x_from_y;$x$ von $y$
+x_from_y;$culture$ $x$ von $y$
+x_in_y;$x$ in $y$
 reinforce_rate;Dieses Regiment kann bis zu $x$ Soldaten pro Monat verstärken.
 reinforce_rate_none;Dieses Regiment kann derzeit nicht verstärkt werden.
 alice_domestic_investment_button;Investitionen in einzelne Projekte sind veraltet. Verwenden Sie stattdessen den Schieberegler „Inländische Investitionen“ auf dem Budgetbildschirm

--- a/assets/localisation/en-US/alice.csv
+++ b/assets/localisation/en-US/alice.csv
@@ -1043,6 +1043,7 @@ alice_gp_status_regain_expiration;If we don't become rank ?Y$x$?W or higher, we 
 alice_mil_decay_description;Natural decay ?G-$x$
 alice_con_decay_description;Natural decay ?R-$x$
 x_from_y;$culture$ $x$ from $y$
+x_in_y;$x$ at $y$
 reinforce_rate;This regiment can reinforce up to $x$ soldiers per month.
 reinforce_rate_none;This regiment can't currently be reinforced.
 alice_domestic_investment_button;Investing in individual projects is ?Rdeprecated?W, use the ?Ydomestic investment?W slider on the budget screen instead

--- a/assets/localisation/es-ES/alice.csv
+++ b/assets/localisation/es-ES/alice.csv
@@ -1042,6 +1042,7 @@ alice_gp_status_regain_expiration;
 alice_mil_decay_description;
 alice_con_decay_description;
 x_from_y;
+x_in_y;
 reinforce_rate;
 reinforce_rate_none;
 alice_domestic_investment_button;

--- a/assets/localisation/it-IT/alice.csv
+++ b/assets/localisation/it-IT/alice.csv
@@ -1042,7 +1042,8 @@ alice_ca_cant_influence;Al momento non siamo in grado di aumentare o diminuire l
 alice_gp_status_regain_expiration;Se non raggiungiamo il grado ?Y$x$?W o un livello superiore, perderemo lo status di ?Ygrande potere?W entro il ?Y$data?W!
 alice_mil_decay_description;Decadimento naturale ?G-$x$
 alice_con_decay_description;Decadimento naturale ?R-$x$
-x_from_y;$x$ da $y$
+x_from_y;$culture$ $x$ da $y$
+x_in_y;$x$ a $y$
 reinforce_rate;Questo reggimento può rinforzare fino a $x$ soldati al mese.
 reinforce_rate_none;Al momento questo reggimento non può essere rinforzato.
 alice_domestic_investment_button;Investire in progetti individuali è ?Rdeprecato?W, utilizza invece il dispositivo di scorrimento ?Yinvestimento domestico?W nella schermata del budget

--- a/assets/localisation/nl-NL/alice.csv
+++ b/assets/localisation/nl-NL/alice.csv
@@ -1042,7 +1042,8 @@ alice_ca_cant_influence;We zijn momenteel niet in staat de mening van andere lan
 alice_gp_status_regain_expiration;Als we niet de rang ?Y$x$?W of hoger bereiken, verliezen we de status van ?Ygrote macht?W tegen ?Y$date?W!
 alice_mil_decay_description;Natuurlijk verval ?G-$x$
 alice_con_decay_description;Natuurlijk verval ?R-$x$
-x_from_y;$x$ van $y$
+x_from_y;$culture$ $x$ van $y$
+x_in_y;$x$ in $y$
 reinforce_rate;Dit regiment kan tot $x$ soldaten per maand versterken.
 reinforce_rate_none;Dit regiment kan momenteel niet worden versterkt.
 alice_domestic_investment_button;Investeren in individuele projecten is niet meer mogelijk. Gebruik in plaats daarvan de schuifregelaar 'Binnenlandse investeringen' op het budgetscherm

--- a/assets/localisation/pl-PL/alice.csv
+++ b/assets/localisation/pl-PL/alice.csv
@@ -1042,7 +1042,8 @@ alice_ca_cant_influence;Obecnie nie jesteśmy w stanie zwiększyć ani zmniejszy
 alice_gp_status_regain_expiration;Jeśli nie osiągniemy rangi ?Y$x$?W lub wyższej, utracimy status ?Ywielka moc?W do dnia ?Y$data?W!
 alice_mil_decay_description;Naturalny rozkład ?G-$x$
 alice_con_decay_description;Naturalny rozkład ?R-$x$
-x_from_y;$x$ z $y$
+x_from_y;$culture$ $x$ z $y$
+x_in_y;$x$ pod $y$
 reinforce_rate;Pułk ten może wzmocnić do x $ żołnierzy miesięcznie.
 reinforce_rate_none;Pułk ten nie może być obecnie wzmocniony.
 alice_domestic_investment_button;Inwestowanie w indywidualne projekty jest „przestarzałe”. Zamiast tego użyj suwaka „Inwestycje krajowe” na ekranie budżetu

--- a/assets/localisation/ru-RU/alice.csv
+++ b/assets/localisation/ru-RU/alice.csv
@@ -1034,7 +1034,8 @@ alice_ca_cant_influence;В данный момент мы не можем пов
 alice_gp_status_regain_expiration;Если мы не получим ранг ?Y$x$?W или выше, мы потеряем статус ?Ygreat power?W к ?Y$date?W!
 alice_mil_decay_description;Естественный распад ?G-$x$
 alice_con_decay_description;Естественный распад ?R-$x$
-x_from_y;$culture$ $x$ от $y$
+x_from_y;$culture$ $x$ из $y$
+x_in_y;$x$ в $y$
 reinforce_rate;Этот полк может пополнять до $x$ солдат в месяц.
 reinforce_rate_none;Этот полк в настоящее время не может быть усилен.
 alice_domestic_investment_button;Инвестирование в отдельные проекты ?Rустарело?W, вместо этого используйте ползунок ?Yвнутренние инвестиции?W на экране бюджета

--- a/assets/localisation/zh-CN/alice.csv
+++ b/assets/localisation/zh-CN/alice.csv
@@ -1041,7 +1041,8 @@ alice_ca_cant_influence;我们目前无法增加或减少其他国家的评价
 alice_gp_status_regain_expiration;如果我们不能成为第 ?Y$x$?W 名或更高排名的国家，到 ?Y$date?W，我们将失去?Y列强?W地位！
 alice_mil_decay_description;自然衰减?G-$x$
 alice_con_decay_description;自然衰减?R-$x$
-x_from_y;$x$来自$y$
+x_from_y;$culture$ $x$来自$y$
+x_in_y;$x$来自$y$
 reinforce_rate;这支军队每月能支援$x$名士兵
 reinforce_rate_none;无法增援部队
 alice_domestic_investment_button;不推荐投资单个项目，请改用预算屏幕上的国内投资滑块

--- a/src/gui/gui_outliner_window.hpp
+++ b/src/gui/gui_outliner_window.hpp
@@ -102,13 +102,13 @@ public:
 		} else if(std::holds_alternative<dcon::province_land_construction_id>(content)) {
 			auto plcid = std::get<dcon::province_land_construction_id>(content);
 			auto p = state.world.pop_get_province_from_pop_location(state.world.province_land_construction_get_pop(plcid));
-			//static_cast<ui::province_view_window*>(state.ui_state.province_window)->set_active_province(state, p);
-			//state.map_state.center_map_on_province(state, p);
+			static_cast<ui::province_view_window*>(state.ui_state.province_window)->set_active_province(state, p);
+			state.map_state.center_map_on_province(state, p);
 		} else if(std::holds_alternative<dcon::province_naval_construction_id>(content)) {
 			auto pncid = std::get<dcon::province_naval_construction_id>(content);
 			auto p = state.world.province_naval_construction_get_province(pncid);
-			//static_cast<ui::province_view_window*>(state.ui_state.province_window)->set_active_province(state, p);
-			//state.map_state.center_map_on_province(state, p);
+			static_cast<ui::province_view_window*>(state.ui_state.province_window)->set_active_province(state, p);
+			state.map_state.center_map_on_province(state, p);
 		} else if(std::holds_alternative<dcon::state_instance_id>(content)) {
 			auto siid = std::get<dcon::state_instance_id>(content);
 			auto fat_si = dcon::fatten(state.world, siid);
@@ -425,20 +425,33 @@ public:
 		} else if(std::holds_alternative<dcon::province_land_construction_id>(content)) {
 			auto plcid = std::get<dcon::province_land_construction_id>(content);
 			auto utid = state.world.province_land_construction_get_type(plcid);
-			auto name = utid ? state.military_definitions.unit_base_definitions[utid].name : dcon::text_key{};
+			auto unitname = utid ? state.military_definitions.unit_base_definitions[utid].name : dcon::text_key{};
 			float progress = economy::unit_construction_progress(state, plcid);
+			auto pop = state.world.province_land_construction_get_pop(plcid);
+			auto province = state.world.pop_get_province_from_pop_location(pop);
 
-			auto full_str = text::produce_simple_string(state, name) + " (" + text::format_percentage(progress, 0) + ")";
+			text::substitution_map sub;
+			text::add_to_substitution_map(sub, text::variable_type::x, unitname);
+			text::add_to_substitution_map(sub, text::variable_type::y, province);
+
+			std::string res = text::resolve_string_substitution(state, "x_in_y", sub);
+			auto full_str = res + " (" + text::format_percentage(progress, 0) + ")";
 
 			color = text::text_color::white;
 			set_text(state, full_str);
 		} else if(std::holds_alternative<dcon::province_naval_construction_id>(content)) {
 			auto pncid = std::get<dcon::province_naval_construction_id>(content);
 			auto utid = state.world.province_naval_construction_get_type(pncid);
-			auto name = state.military_definitions.unit_base_definitions[utid].name;
+			auto unitname = state.military_definitions.unit_base_definitions[utid].name;
 			float progress = economy::unit_construction_progress(state, pncid);
+			auto province = state.world.province_naval_construction_get_province(pncid);
 
-			auto full_str = text::produce_simple_string(state, name) + " (" + text::format_percentage(progress, 0) + ")";
+			text::substitution_map sub;
+			text::add_to_substitution_map(sub, text::variable_type::x, unitname);
+			text::add_to_substitution_map(sub, text::variable_type::y, province);
+
+			std::string res = text::resolve_string_substitution(state, "x_in_y", sub);
+			auto full_str = res + " (" + text::format_percentage(progress, 0) + ")";
 			color = text::text_color::white;
 			set_text(state, full_str);
 		} else if(std::holds_alternative<dcon::state_instance_id>(content)) {

--- a/src/gui/topbar_subwindows/military_subwindows/gui_units_window.hpp
+++ b/src/gui/topbar_subwindows/military_subwindows/gui_units_window.hpp
@@ -12,8 +12,26 @@ class military_unit_name_text : public simple_text_element_base {
 public:
 	void on_update(sys::state& state) noexcept override {
 		auto content = retrieve<military_unit_info<T>>(state, parent);
-		if(std::holds_alternative<T>(content)) {
+
+		if(std::holds_alternative<dcon::province_land_construction_id>(content)) {
+			auto c = std::get<dcon::province_land_construction_id>(content);
+			auto utid = state.world.province_land_construction_get_type(c);
+			auto unitname = utid ? state.military_definitions.unit_base_definitions[utid].name : dcon::text_key{};
+			std::string res = text::produce_simple_string(state, unitname);
+
+			set_text(state, res);
+		}
+		else if(std::holds_alternative<dcon::province_naval_construction_id>(content)) {
+			auto c = std::get<dcon::province_naval_construction_id>(content);
+			auto utid = state.world.province_naval_construction_get_type(c);
+			auto unitname = utid ? state.military_definitions.unit_base_definitions[utid].name : dcon::text_key{};
+			std::string res = text::produce_simple_string(state, unitname);
+
+			set_text(state, res);
+		}
+		else if(std::holds_alternative<T>(content)) {
 			auto fat_id = dcon::fatten(state.world, std::get<T>(content));
+			auto unit_name = std::string{ state.to_string_view(fat_id.get_name()) };
 			set_text(state, std::string{ state.to_string_view(fat_id.get_name()) });
 		}
 	}
@@ -274,6 +292,7 @@ class military_unit_entry : public listbox_row_element_base<military_unit_info<T
 	image_element_base* unit_combat_icon = nullptr;
 public:
 	std::unique_ptr<element_base> make_child(sys::state& state, std::string_view name, dcon::gui_def_id id) noexcept override {
+		auto name2 = name;
 		if(name == "military_unit_entry_bg") {
 			return make_element_by_type<mil_goto_background_button<T>>(state, id);
 		} else if(name == "unit_progress") {
@@ -296,7 +315,8 @@ public:
 			auto ptr = make_element_by_type<generic_name_text<dcon::province_id>>(state, id);
 			location_text = ptr.get();
 			return ptr;
-		} else if(name == "unit_eta") {
+		}
+		else if(name == "unit_eta") {
 			auto ptr = make_element_by_type<simple_text_element_base>(state, id);
 			eta_date_text = ptr.get();
 			return ptr;
@@ -386,9 +406,10 @@ public:
 		if(cancel_button) cancel_button->set_visible(state, is_building);
 		if(eta_date_text) eta_date_text->set_visible(state, is_building);
 		if(location_text) location_text->set_visible(state, is_building);
+
 		if(unit_building_progress) unit_building_progress->set_visible(state, is_building);
 
-		if(unit_name) unit_name->set_visible(state, !is_building);
+		if(unit_name) unit_name->set_visible(state, true);
 		if(leader_icon) leader_icon->set_visible(state, !is_building);
 		if(unit_regiments_text) unit_regiments_text->set_visible(state, !is_building);
 		if(unit_men_text) unit_men_text->set_visible(state, !is_building);


### PR DESCRIPTION
![](https://i.imgur.com/BvdxObf.png)
![](https://i.imgur.com/YOr6PlF.png)

- When constructing melee unit, display province in the outliner
- When constructing naval unit, display province in the outliner
- Clicking on melee unit construction row in the outliner, navigate to the province
- Clicking on naval unit construction row in the outliner, navigate to the province
- When constructing melee unit, display unit type name in melee view
- When constructing naval unit, display unit type name in melee view