### PR TITLE
Effects

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -48,7 +48,10 @@ Additionally, triggers such as technology triggers no longer suffer from having 
 - `annex_to = null`: this turns all the provinces owned by the nation in scope into unowned provinces (which defeats the nation, liberates its puppets, etc).
 - `secede_province = null`: turns the province in scope into an unowned province. This is to replace some of the tricks mods did to turn provinces unowned, such as seceding them to nonexistent tags, etc
 - `random_greater_power = { ... }`: Like `any_greater_power`, but only one random great power is scoped.
-- `any_empty_neighbor_province = { ... }`: Like `random_empty_neighbor_province`, but all of the empty adjacent provinces are scoped.
+- `random_empty_neighbor_province` - selects random empty neighbor province in nation/province scope.
+- `any_empty_neighbor_province = { ... }`: Like `random_empty_neighbor_province`, but all of the empty adjacent provinces are scoped. Can be used in province or nation scope.
+- `random_neighbor_province` can be used in nation and province scope.
+- `any_neighbor_province` can be used in nation and province scope.
 - `change_terrain = terrain`: Changes the terrain of the province on scope, can be used on pop scopes too (will default to the location of the pop)
 - `religion = religion_name`: Effect can be used in a province and pops scope to change the religion of the province/pop.
 - `assimilate = yes`: Effect can be used in a pop/province/state scope to change the culture of pops in the scope to primary culture.

--- a/src/economy/economy.cpp
+++ b/src/economy/economy.cpp
@@ -887,8 +887,6 @@ float rgo_effective_size(sys::state const& state, dcon::nation_id n, dcon::provi
 	// technology-general-farm-or-mine-size-bonus + provincial-mine-or-farm-size-modifier + 1)
 	auto rgo_ownership = state.world.province_get_landowners_share(p) + state.world.province_get_capitalists_share(p);
 	auto sz = state.world.province_get_rgo_max_size_per_good(p, c) * rgo_ownership + base;
-	if(!std::isfinite(sz))
-		sz = 0;
 	auto pmod = state.world.province_get_modifier_values(p, is_mine ? sys::provincial_mod_offsets::mine_rgo_size : sys::provincial_mod_offsets::farm_rgo_size);
 	auto nmod = state.world.nation_get_modifier_values(n, is_mine ? sys::national_mod_offsets::mine_rgo_size : sys::national_mod_offsets::farm_rgo_size);
 	auto specific_pmod = state.world.nation_get_rgo_size(n, c);
@@ -1277,9 +1275,8 @@ float rgo_efficiency(sys::state & state, dcon::nation_id n, dcon::province_id p,
 			:
 			sys::national_mod_offsets::farm_rgo_eff);
 
-	float saturation = state.world.province_get_rgo_employment_per_good(p, c) / (rgo_max_employment(state, n, p, c) + 1.f);
-	if(!std::isfinite(saturation))
-		saturation = 0;
+	float saturation = state.world.province_get_rgo_employment_per_good(p, c)
+		/ (rgo_max_employment(state, n, p, c) + 1.f);
 
 	float result = base_amount
 		* main_rgo
@@ -1758,7 +1755,7 @@ void update_province_rgo_consumption(
 
 	state.world.for_each_commodity([&](dcon::commodity_id c) {
 		auto max_production = rgo_full_production_quantity(state, n, p, c);
-		if(!std::isfinite(max_production) || max_production < 0.001f) {
+		if(max_production < 0.001f) {
 			return;
 		}		
 

--- a/src/economy/economy.cpp
+++ b/src/economy/economy.cpp
@@ -887,6 +887,8 @@ float rgo_effective_size(sys::state const& state, dcon::nation_id n, dcon::provi
 	// technology-general-farm-or-mine-size-bonus + provincial-mine-or-farm-size-modifier + 1)
 	auto rgo_ownership = state.world.province_get_landowners_share(p) + state.world.province_get_capitalists_share(p);
 	auto sz = state.world.province_get_rgo_max_size_per_good(p, c) * rgo_ownership + base;
+	if(!std::isfinite(sz))
+		sz = 0;
 	auto pmod = state.world.province_get_modifier_values(p, is_mine ? sys::provincial_mod_offsets::mine_rgo_size : sys::provincial_mod_offsets::farm_rgo_size);
 	auto nmod = state.world.nation_get_modifier_values(n, is_mine ? sys::national_mod_offsets::mine_rgo_size : sys::national_mod_offsets::farm_rgo_size);
 	auto specific_pmod = state.world.nation_get_rgo_size(n, c);
@@ -1275,8 +1277,9 @@ float rgo_efficiency(sys::state & state, dcon::nation_id n, dcon::province_id p,
 			:
 			sys::national_mod_offsets::farm_rgo_eff);
 
-	float saturation = state.world.province_get_rgo_employment_per_good(p, c)
-		/ (rgo_max_employment(state, n, p, c) + 1.f);
+	float saturation = state.world.province_get_rgo_employment_per_good(p, c) / (rgo_max_employment(state, n, p, c) + 1.f);
+	if(!std::isfinite(saturation))
+		saturation = 0;
 
 	float result = base_amount
 		* main_rgo
@@ -1755,7 +1758,7 @@ void update_province_rgo_consumption(
 
 	state.world.for_each_commodity([&](dcon::commodity_id c) {
 		auto max_production = rgo_full_production_quantity(state, n, p, c);
-		if(max_production < 0.001f) {
+		if(!std::isfinite(max_production) || max_production < 0.001f) {
 			return;
 		}		
 

--- a/src/gui/gui_nation_picker.hpp
+++ b/src/gui/gui_nation_picker.hpp
@@ -445,6 +445,7 @@ public:
 		auto n = retrieve<dcon::nation_id>(state, parent);
 		if(state.network_mode == sys::network_mode_type::single_player) {
 			state.local_player_nation = n;
+			state.world.nation_set_is_player_controlled(n, true);
 			state.ui_state.nation_picker->impl_on_update(state);
 		} else {
 			command::notify_player_picks_nation(state, state.local_player_nation, n);

--- a/src/parsing/effect_parsing.cpp
+++ b/src/parsing/effect_parsing.cpp
@@ -67,7 +67,26 @@ void ef_scope_any_neighbor_province(token_generator& gen, error_handler& err, ef
 
 		context.compiled_effect[payload_size_offset] = uint16_t(context.compiled_effect.size() - payload_size_offset);
 		context.limit_position = old_limit_offset;
-	} else {
+	}
+	else if (context.main_slot == trigger::slot_contents::nation) {
+		auto old_limit_offset = context.limit_position;
+		auto old_main = context.main_slot;
+
+		context.compiled_effect.push_back(uint16_t(effect::x_neighbor_province_scope_nation | effect::scope_has_limit));
+		context.compiled_effect.push_back(uint16_t(0));
+		auto payload_size_offset = context.compiled_effect.size() - 1;
+		context.limit_position = context.compiled_effect.size();
+		context.compiled_effect.push_back(trigger::payload(dcon::trigger_key()).value);
+
+		// Change scope down to province
+		context.main_slot = trigger::slot_contents::province;
+		parse_effect_body(gen, err, context);
+
+		context.compiled_effect[payload_size_offset] = uint16_t(context.compiled_effect.size() - payload_size_offset);
+		context.limit_position = old_limit_offset;
+		context.main_slot = old_main;
+	}
+	else {
 		gen.discard_group();
 		err.accumulated_errors += "any_neighbor_province effect scope used in an incorrect scope type (" + err.file_name + ")\n";
 		return;
@@ -286,9 +305,28 @@ void ef_scope_random_neighbor_province(token_generator& gen, error_handler& err,
 
 		context.compiled_effect[payload_size_offset] = uint16_t(context.compiled_effect.size() - payload_size_offset);
 		context.limit_position = old_limit_offset;
-	} else {
+	}
+	else if(context.main_slot == trigger::slot_contents::nation) {
+		auto old_limit_offset = context.limit_position;
+		auto old_main = context.main_slot;
+
+		context.compiled_effect.push_back(uint16_t(effect::x_neighbor_province_scope_nation | effect::is_random_scope | effect::scope_has_limit));
+		context.compiled_effect.push_back(uint16_t(0));
+		auto payload_size_offset = context.compiled_effect.size() - 1;
+		context.limit_position = context.compiled_effect.size();
+		context.compiled_effect.push_back(trigger::payload(dcon::trigger_key()).value);
+
+		// Change scope down to province
+		context.main_slot = trigger::slot_contents::province;
+		parse_effect_body(gen, err, context);
+
+		context.compiled_effect[payload_size_offset] = uint16_t(context.compiled_effect.size() - payload_size_offset);
+		context.limit_position = old_limit_offset;
+		context.main_slot = old_main;
+	}
+	else {
 		gen.discard_group();
-		err.accumulated_errors += "any_neighbor_province effect scope used in an incorrect scope type (" + err.file_name + ")\n";
+		err.accumulated_errors += "random_neighbor_province effect scope used in an incorrect scope type (" + err.file_name + ")\n";
 		return;
 	}
 }
@@ -307,7 +345,26 @@ void ef_scope_any_empty_neighbor_province(token_generator& gen, error_handler& e
 
 		context.compiled_effect[payload_size_offset] = uint16_t(context.compiled_effect.size() - payload_size_offset);
 		context.limit_position = old_limit_offset;
-	} else {
+	}
+	else if(context.main_slot == trigger::slot_contents::nation) {
+		auto old_limit_offset = context.limit_position;
+		auto old_main = context.main_slot;
+
+		context.compiled_effect.push_back(uint16_t(effect::x_empty_neighbor_province_scope_nation | effect::scope_has_limit));
+		context.compiled_effect.push_back(uint16_t(0));
+		auto payload_size_offset = context.compiled_effect.size() - 1;
+		context.limit_position = context.compiled_effect.size();
+		context.compiled_effect.push_back(trigger::payload(dcon::trigger_key()).value);
+
+		// Change scope down to province
+		context.main_slot = trigger::slot_contents::province;
+		parse_effect_body(gen, err, context);
+
+		context.compiled_effect[payload_size_offset] = uint16_t(context.compiled_effect.size() - payload_size_offset);
+		context.limit_position = old_limit_offset;
+		context.main_slot = old_main;
+	}
+	else {
 		gen.discard_group();
 		err.accumulated_errors += "any_empty_neighbor_province effect scope used in an incorrect scope type(" + err.file_name + ")\n";
 		return;
@@ -328,7 +385,26 @@ void ef_scope_random_empty_neighbor_province(token_generator& gen, error_handler
 
 		context.compiled_effect[payload_size_offset] = uint16_t(context.compiled_effect.size() - payload_size_offset);
 		context.limit_position = old_limit_offset;
-	} else {
+	}
+	else if(context.main_slot == trigger::slot_contents::nation) {
+		auto old_limit_offset = context.limit_position;
+		auto old_main = context.main_slot;
+
+		context.compiled_effect.push_back(uint16_t(effect::x_empty_neighbor_province_scope_nation | effect::is_random_scope | effect::scope_has_limit));
+		context.compiled_effect.push_back(uint16_t(0));
+		auto payload_size_offset = context.compiled_effect.size() - 1;
+		context.limit_position = context.compiled_effect.size();
+		context.compiled_effect.push_back(trigger::payload(dcon::trigger_key()).value);
+
+		// Change scope down to province
+		context.main_slot = trigger::slot_contents::province;
+		parse_effect_body(gen, err, context);
+
+		context.compiled_effect[payload_size_offset] = uint16_t(context.compiled_effect.size() - payload_size_offset);
+		context.limit_position = old_limit_offset;
+		context.main_slot = old_main;
+	}
+	else {
 		gen.discard_group();
 		err.accumulated_errors += "random_empty_neighbor_province effect scope used in an incorrect scope type (" + err.file_name + ")\n";
 		return;

--- a/src/scripting/effects.hpp
+++ b/src/scripting/effects.hpp
@@ -11,4 +11,6 @@ void execute(sys::state& state, dcon::effect_key key, int32_t primary, int32_t t
 void execute(sys::state& state, uint16_t const* data, int32_t primary, int32_t this_slot, int32_t from_slot, uint32_t r_lo,
 		uint32_t r_hi);
 
+std::vector<dcon::province_id> country_get_province_adjacency(sys::state& state, dcon::nation_id nat_id);
+
 } // namespace effect

--- a/src/scripting/script_constants.hpp
+++ b/src/scripting/script_constants.hpp
@@ -473,6 +473,7 @@ EFFECT_BYTECODE_ELEMENT(0x01BD, set_culture_pop, 1) \
 #undef EFFECT_BYTECODE_ELEMENT
 
 // invalid
+/* This value must be changed if more effects are added. */
 constexpr inline uint16_t first_scope_code = 0x01BE;
 
 // scopes
@@ -545,7 +546,11 @@ constexpr inline uint16_t x_decision_country_scope_nation = first_scope_code + 0
 constexpr inline uint16_t from_bounce_scope = first_scope_code + 0x0041;
 constexpr inline uint16_t this_bounce_scope = first_scope_code + 0x0042;
 constexpr inline uint16_t random_by_modifier_scope = first_scope_code + 0x0043;
-constexpr inline uint16_t first_invalid_code = first_scope_code + 0x0044;
+constexpr inline uint16_t x_neighbor_province_scope_nation = first_scope_code + 0x0044;
+constexpr inline uint16_t x_empty_neighbor_province_scope_nation = first_scope_code + 0x0045;
+/* All scopes must be added before first_invalid_code*/
+constexpr inline uint16_t first_invalid_code = first_scope_code + 0x0046;
+
 
 inline constexpr int8_t data_sizes[] = {
 		0, // none


### PR DESCRIPTION
- `random_empty_neighbor_province` - selects random empty neighbor province in nation/province scope.
- `any_empty_neighbor_province = { ... }`: Like `random_empty_neighbor_province`, but all of the empty adjacent provinces are scoped. Can be used in province or nation scope.
- `random_neighbor_province` can be used in nation and province scope.
- `any_neighbor_province` can be used in nation and province scope.

Revamp gui scope effect tooltips