### PR TITLE
fast get_random_float()

### DIFF
--- a/src/common_types/prng.cpp
+++ b/src/common_types/prng.cpp
@@ -52,8 +52,14 @@ float get_random_float(sys::state const& state, uint32_t value_in) {
 	r123::Philox4x32::ctr_type c = {state.current_date.value, value_in, 0, 0 };
 	r123::Philox4x32::key_type k = {state.game_seed, 0x3918CA23};
 	r123::Philox4x32::ctr_type r = rng(c, k);
-	uint32_t f = ((uint32_t)(r[1] << 8) | (0x3f << 24));
-	return *((float*)&f) * 0.5f;
+	//
+	union {
+		uint32_t u;
+		float f;
+	} pattern;
+	pattern.u = 0x3f800000;
+	pattern.u |= 0x7fffff & r[1];
+	return pattern.f - 1.0f;
 }
 
 float get_random_float(sys::state const& state, uint32_t value_in_hi, uint32_t value_in_lo) {
@@ -61,8 +67,14 @@ float get_random_float(sys::state const& state, uint32_t value_in_hi, uint32_t v
 	r123::Philox4x32::ctr_type c = {value_in_hi, value_in_lo, 0, 0 };
 	r123::Philox4x32::key_type k = {state.game_seed, 0x3918CA23};
 	r123::Philox4x32::ctr_type r = rng(c, k);
-	uint32_t f = ((uint32_t)(r[1] << 8) | (0x3f << 24));
-	return *((float*)&f) * 0.5f;
+	//
+	union {
+		uint32_t u;
+		float f;
+	} pattern;
+	pattern.u = 0x3f800000;
+	pattern.u |= 0x7fffff & r[1];
+	return pattern.f - 1.0f;
 }
 
 } // namespace rng

--- a/src/common_types/prng.cpp
+++ b/src/common_types/prng.cpp
@@ -47,4 +47,22 @@ uint32_t reduce(uint32_t value_in, uint32_t upper_bound) {
 	return uint32_t((uint64_t(value_in) * uint64_t(upper_bound)) >> 32);
 }
 
+float get_random_float(sys::state const& state, uint32_t value_in) {
+	r123::Philox4x32 rng;
+	r123::Philox4x32::ctr_type c = {state.current_date.value, value_in, 0, 0 };
+	r123::Philox4x32::key_type k = {state.game_seed, 0x3918CA23};
+	r123::Philox4x32::ctr_type r = rng(c, k);
+	auto f = float(((uint64_t(r[0]) << 32) | uint64_t(r[1])) & 0xFFFF);
+	return f / float(0xFFFF + 1);
+}
+
+float get_random_float(sys::state const& state, uint32_t value_in_hi, uint32_t value_in_lo) {
+	r123::Philox4x32 rng;
+	r123::Philox4x32::ctr_type c = {value_in_hi, value_in_lo, 0, 0 };
+	r123::Philox4x32::key_type k = {state.game_seed, 0x3918CA23};
+	r123::Philox4x32::ctr_type r = rng(c, k);
+	uint32_t f = ((uint32_t)(r[1] << 8) | (0x3f << 24));
+	return *((float*)&f) * 0.5f;
+}
+
 } // namespace rng

--- a/src/common_types/prng.cpp
+++ b/src/common_types/prng.cpp
@@ -52,8 +52,8 @@ float get_random_float(sys::state const& state, uint32_t value_in) {
 	r123::Philox4x32::ctr_type c = {state.current_date.value, value_in, 0, 0 };
 	r123::Philox4x32::key_type k = {state.game_seed, 0x3918CA23};
 	r123::Philox4x32::ctr_type r = rng(c, k);
-	auto f = float(((uint64_t(r[0]) << 32) | uint64_t(r[1])) & 0xFFFF);
-	return f / float(0xFFFF + 1);
+	uint32_t f = ((uint32_t)(r[1] << 8) | (0x3f << 24));
+	return *((float*)&f) * 0.5f;
 }
 
 float get_random_float(sys::state const& state, uint32_t value_in_hi, uint32_t value_in_lo) {


### PR DESCRIPTION
the approach the current code does is `float(x & 0xffff) / float(0xffff)`
but this is inefficient
this is a function to implement a better version of that same op