### PR TITLE
Economy balance tweaks

### DIFF
--- a/src/economy/economy.cpp
+++ b/src/economy/economy.cpp
@@ -995,6 +995,7 @@ void rebalance_needs_weights(sys::state& state, dcon::market_id n) {
 	auto zone = state.world.market_get_zone_from_local_market(n);
 	auto nation = state.world.state_instance_get_nation_from_state_ownership(zone);
 
+	/*
 	{
 		float total_weights = 0.f;
 		uint32_t count = 0;
@@ -1028,7 +1029,6 @@ void rebalance_needs_weights(sys::state& state, dcon::market_id n) {
 				}
 				auto& w = state.world.market_get_life_needs_weights(n, c);
 				w = ideal_weighting * state.defines.alice_need_drift_speed + w * (1.0f - state.defines.alice_need_drift_speed);
-				w = 1.f;
 
 				assert(std::isfinite(w));
 				assert(w <= count + 0.01f);
@@ -1070,7 +1070,6 @@ void rebalance_needs_weights(sys::state& state, dcon::market_id n) {
 				}
 				auto& w = state.world.market_get_everyday_needs_weights(n, c);
 				w = ideal_weighting * state.defines.alice_need_drift_speed + w * (1.0f - state.defines.alice_need_drift_speed);
-				w = 1.f;
 
 				assert(std::isfinite(w));
 				assert(w <= count + 0.01f);
@@ -1112,13 +1111,26 @@ void rebalance_needs_weights(sys::state& state, dcon::market_id n) {
 				}
 				auto& w = state.world.market_get_luxury_needs_weights(n, c);
 				w = ideal_weighting * state.defines.alice_need_drift_speed + w * (1.0f - state.defines.alice_need_drift_speed);
-				w = 1.f;
 
 				assert(std::isfinite(w));
 				assert(w <= count + 0.01f);
 			}
 		});
 	}
+
+	*/
+
+	state.world.for_each_commodity([&](dcon::commodity_id c) {
+		if(valid_luxury_need(state, nation, c)) {
+			state.world.market_set_luxury_needs_weights(n, c, 1.f);
+		}
+		if(valid_everyday_need(state, nation, c)) {
+			state.world.market_set_everyday_needs_weights(n, c, 1.f);
+		}
+		if(valid_life_need(state, nation, c)) {
+			state.world.market_set_life_needs_weights(n, c, 1.f);
+		}
+	});
 }
 
 

--- a/src/economy/economy.cpp
+++ b/src/economy/economy.cpp
@@ -24,7 +24,7 @@ template<typename T>
 ve::fp_vector ve_artisan_min_wage(sys::state& state, T markets) {
 	auto life = state.world.market_get_life_needs_costs(markets, state.culture_definitions.artisans);
 	auto everyday = state.world.market_get_everyday_needs_costs(markets, state.culture_definitions.artisans);
-	return (life + everyday) * 1.1f;
+	return life * 1.5f;
 }
 template<typename T>
 ve::fp_vector ve_farmer_min_wage(sys::state& state, T markets, ve::fp_vector min_wage_factor) {

--- a/src/economy/economy.cpp
+++ b/src/economy/economy.cpp
@@ -1028,6 +1028,7 @@ void rebalance_needs_weights(sys::state& state, dcon::market_id n) {
 				}
 				auto& w = state.world.market_get_life_needs_weights(n, c);
 				w = ideal_weighting * state.defines.alice_need_drift_speed + w * (1.0f - state.defines.alice_need_drift_speed);
+				w = 1.f;
 
 				assert(std::isfinite(w));
 				assert(w <= count + 0.01f);
@@ -1069,6 +1070,7 @@ void rebalance_needs_weights(sys::state& state, dcon::market_id n) {
 				}
 				auto& w = state.world.market_get_everyday_needs_weights(n, c);
 				w = ideal_weighting * state.defines.alice_need_drift_speed + w * (1.0f - state.defines.alice_need_drift_speed);
+				w = 1.f;
 
 				assert(std::isfinite(w));
 				assert(w <= count + 0.01f);
@@ -1110,6 +1112,7 @@ void rebalance_needs_weights(sys::state& state, dcon::market_id n) {
 				}
 				auto& w = state.world.market_get_luxury_needs_weights(n, c);
 				w = ideal_weighting * state.defines.alice_need_drift_speed + w * (1.0f - state.defines.alice_need_drift_speed);
+				w = 1.f;
 
 				assert(std::isfinite(w));
 				assert(w <= count + 0.01f);

--- a/src/economy/economy.hpp
+++ b/src/economy/economy.hpp
@@ -122,7 +122,7 @@ inline constexpr float rgo_owners_cut = 0.05f;
 inline constexpr float price_speed_mod = 0.0001f;
 inline constexpr float price_rigging = 0.015f;
 inline constexpr float stockpile_to_supply = 0.1f;
-inline constexpr float production_throughput_multiplier = 2.f;
+inline constexpr float production_throughput_multiplier = 3.f;
 
 void presimulate(sys::state& state);
 void sanity_check(sys::state& state);

--- a/src/nations/nations.cpp
+++ b/src/nations/nations.cpp
@@ -358,7 +358,7 @@ void generate_sea_trade_routes(sys::state& state) {
 			}
 
 			auto population_target = state.world.state_instance_get_demographics(sid, demographics::total);
-			score += std::min(population_origin, population_target) / (400'000.f + world_population * 0.000'100f);
+			score += std::min(population_origin, population_target) / (400'000.f + world_population * 0.000'500f);
 
 			auto state_target_owner_capital = state.world.nation_get_capital(target_owner);
 			auto state_target_owner_capital_state = state.world.province_get_state_membership(state_target_owner_capital);
@@ -376,11 +376,20 @@ void generate_sea_trade_routes(sys::state& state) {
 					score = score + (
 						state.world.nation_get_demographics(owner, demographics::total)
 						+ state.world.nation_get_demographics(target_owner, demographics::total)
-					) / 2'000'000.f * mod;
+					) / (2'000'000.f * mod + world_population * 0.000'500f);
 
 			bool must_connect = same_owner && different_region && capitals_of_regions;
 
 			if(score < 3.f && !must_connect) {
+				return;
+			}
+
+			auto coast_0 = province::state_get_coastal_capital(state, origin);
+			auto coast_1 = province::state_get_coastal_capital(state, sid);
+
+			auto distance_approximation = province::direct_distance(state, coast_0, coast_1);
+
+			if(!((score / (2.f * distance_approximation / 200.f) >= 4.f) || must_connect)) {
 				return;
 			}
 
@@ -389,9 +398,6 @@ void generate_sea_trade_routes(sys::state& state) {
 				std::vector<dcon::province_id> path{ };
 				auto speed = base_speed;
 				dcon::province_id p_prev{ };
-
-				auto coast_0 = province::state_get_coastal_capital(state, origin);
-				auto coast_1 = province::state_get_coastal_capital(state, sid);
 				path = province::make_naval_path(state, coast_0, coast_1);
 				p_prev = coast_0;
 

--- a/src/parsing/defines.hpp
+++ b/src/parsing/defines.hpp
@@ -657,14 +657,14 @@
 	LUA_DEFINES_LIST_ELEMENT(alice_full_reinforce, 1.000000)                                                             \
 	LUA_DEFINES_LIST_ELEMENT(alice_ai_offensive_strength_overestimate, 1.000000) \
 	LUA_DEFINES_LIST_ELEMENT(alice_military_score_leadership_factor, 1.000000) \
-	LUA_DEFINES_LIST_ELEMENT(alice_lf_needs_scale, 1.000000) \
-	LUA_DEFINES_LIST_ELEMENT(alice_ev_needs_scale, 1.500000) \
-	LUA_DEFINES_LIST_ELEMENT(alice_lx_needs_scale, 2.500000) \
+	LUA_DEFINES_LIST_ELEMENT(alice_lf_needs_scale, 5.000000) \
+	LUA_DEFINES_LIST_ELEMENT(alice_ev_needs_scale, 0.750000) \
+	LUA_DEFINES_LIST_ELEMENT(alice_lx_needs_scale, 0.750000) \
 	LUA_DEFINES_LIST_ELEMENT(alice_max_event_iterations, 8.000000) \
 	LUA_DEFINES_LIST_ELEMENT(alice_needs_scaling_factor, 400000.000000) \
 	LUA_DEFINES_LIST_ELEMENT(alice_factory_per_level_employment, 10000.0) \
 	LUA_DEFINES_LIST_ELEMENT(alice_domestic_investment_multiplier, 50.0) \
-	LUA_DEFINES_LIST_ELEMENT(alice_rgo_boost, 1.0) \
+	LUA_DEFINES_LIST_ELEMENT(alice_rgo_boost, 1.5) \
 	LUA_DEFINES_LIST_ELEMENT(alice_base_rgo_employment_bonus, 150000.0) \
 	LUA_DEFINES_LIST_ELEMENT(alice_base_rgo_efficiency_bonus, 1.05) \
 	LUA_DEFINES_LIST_ELEMENT(alice_inputs_base_factor_artisans, 1.04) \
@@ -672,7 +672,7 @@
 	LUA_DEFINES_LIST_ELEMENT(alice_inputs_base_factor, 1.0) \
 	LUA_DEFINES_LIST_ELEMENT(alice_rgo_overhire_multiplier, 10.0) \
 	LUA_DEFINES_LIST_ELEMENT(alice_rgo_production_scale_neg_delta, 0.001) \
-	LUA_DEFINES_LIST_ELEMENT(alice_invest_capitalist, 0.2) \
+	LUA_DEFINES_LIST_ELEMENT(alice_invest_capitalist, 0.25) \
 	LUA_DEFINES_LIST_ELEMENT(alice_invest_aristocrat, 0.0125) \
 	LUA_DEFINES_LIST_ELEMENT(alice_save_capitalist, 0.025) \
 	LUA_DEFINES_LIST_ELEMENT(alice_save_aristocrat, 0.0125) \

--- a/src/parsing/defines.hpp
+++ b/src/parsing/defines.hpp
@@ -657,22 +657,22 @@
 	LUA_DEFINES_LIST_ELEMENT(alice_full_reinforce, 1.000000)                                                             \
 	LUA_DEFINES_LIST_ELEMENT(alice_ai_offensive_strength_overestimate, 1.000000) \
 	LUA_DEFINES_LIST_ELEMENT(alice_military_score_leadership_factor, 1.000000) \
-	LUA_DEFINES_LIST_ELEMENT(alice_lf_needs_scale, 2.000000) \
-	LUA_DEFINES_LIST_ELEMENT(alice_ev_needs_scale, 4.000000) \
-	LUA_DEFINES_LIST_ELEMENT(alice_lx_needs_scale, 4.000000) \
+	LUA_DEFINES_LIST_ELEMENT(alice_lf_needs_scale, 1.000000) \
+	LUA_DEFINES_LIST_ELEMENT(alice_ev_needs_scale, 1.500000) \
+	LUA_DEFINES_LIST_ELEMENT(alice_lx_needs_scale, 2.500000) \
 	LUA_DEFINES_LIST_ELEMENT(alice_max_event_iterations, 8.000000) \
 	LUA_DEFINES_LIST_ELEMENT(alice_needs_scaling_factor, 400000.000000) \
 	LUA_DEFINES_LIST_ELEMENT(alice_factory_per_level_employment, 10000.0) \
 	LUA_DEFINES_LIST_ELEMENT(alice_domestic_investment_multiplier, 50.0) \
-	LUA_DEFINES_LIST_ELEMENT(alice_rgo_boost, 1.5) \
+	LUA_DEFINES_LIST_ELEMENT(alice_rgo_boost, 1.0) \
 	LUA_DEFINES_LIST_ELEMENT(alice_base_rgo_employment_bonus, 150000.0) \
-	LUA_DEFINES_LIST_ELEMENT(alice_base_rgo_efficiency_bonus, 1.5) \
-	LUA_DEFINES_LIST_ELEMENT(alice_inputs_base_factor_artisans, 1.05) \
-	LUA_DEFINES_LIST_ELEMENT(alice_output_base_factor_artisans, 0.95) \
+	LUA_DEFINES_LIST_ELEMENT(alice_base_rgo_efficiency_bonus, 1.05) \
+	LUA_DEFINES_LIST_ELEMENT(alice_inputs_base_factor_artisans, 1.04) \
+	LUA_DEFINES_LIST_ELEMENT(alice_output_base_factor_artisans, 0.96) \
 	LUA_DEFINES_LIST_ELEMENT(alice_inputs_base_factor, 1.0) \
 	LUA_DEFINES_LIST_ELEMENT(alice_rgo_overhire_multiplier, 10.0) \
 	LUA_DEFINES_LIST_ELEMENT(alice_rgo_production_scale_neg_delta, 0.001) \
-	LUA_DEFINES_LIST_ELEMENT(alice_invest_capitalist, 0.1) \
+	LUA_DEFINES_LIST_ELEMENT(alice_invest_capitalist, 0.2) \
 	LUA_DEFINES_LIST_ELEMENT(alice_invest_aristocrat, 0.0125) \
 	LUA_DEFINES_LIST_ELEMENT(alice_save_capitalist, 0.025) \
 	LUA_DEFINES_LIST_ELEMENT(alice_save_aristocrat, 0.0125) \


### PR DESCRIPTION
- Less greedy artisans
- Need weights are set to 1 to encourage consumption of actual goods instead of coal
- Cull trade routes more aggressively to avoid 1 Jan freeze
- Tweak some numbers