### PR TITLE
Update save_editor_main.cpp

### DIFF
--- a/SaveEditor/save_editor_main.cpp
+++ b/SaveEditor/save_editor_main.cpp
@@ -1,83 +1,172 @@
-#define ALICE_NO_ENTRY_POINT 1
-#include "main.cpp"
+#include <cstdio>
+#include <cstring>
+#include <string_view>
+#include <algorithm>
+
+// Forward declarations:
+//   - open_file, simple_fs::view_contents, dcon::for_each_record, etc.
+//   - We assume these exist as in your code.
+
+namespace {
+
+// Utility function to safely dump hex around a mismatch
+void printHexContext(
+  std::byte const* dataStart,
+  std::byte const* dataEnd,
+  std::byte const* mismatchPos)
+{
+  // We'll dump 8 bytes before and after the mismatch, within bounds
+  constexpr int contextSize = 8;
+  auto totalSize = dataEnd - dataStart;
+  auto mismatchOffset = mismatchPos - dataStart;
+
+  // Start offset
+  auto startOffset = mismatchOffset > contextSize 
+                    ? (mismatchOffset - contextSize) 
+                    : 0;
+  // End offset
+  auto endOffset = std::min(mismatchOffset + contextSize, totalSize);
+
+  std::printf("Mismatch at offset %zu. Hex context:\n<", size_t(mismatchOffset));
+  for (auto i = startOffset; i < endOffset; i++) {
+    std::printf("%02x ", static_cast<unsigned char>(dataStart[i]));
+  }
+  std::printf(">\n");
+}
+
+// Compares two records for data and size
+void compareRecords(
+  dcon::record_header const& header1,
+  std::byte const* dataStart1, 
+  std::byte const* dataEnd1,
+  dcon::record_header const& header2,
+  std::byte const* dataStart2, 
+  std::byte const* dataEnd2,
+  uint8_t const* fileStart1,
+  uint8_t const* fileStart2)
+{
+  auto size1 = dataEnd1 - dataStart1;
+  auto size2 = dataEnd2 - dataStart2;
+  auto offset1 = dataStart1 - reinterpret_cast<const std::byte*>(fileStart1);
+  auto offset2 = dataStart2 - reinterpret_cast<const std::byte*>(fileStart2);
+
+  bool match = true;
+  // Check size mismatch
+  if (size1 != size2) {
+    std::printf("%s.%s.%s: Size mismatch (%u/%u)\n", 
+      header1.object_name_start, 
+      header1.property_name_start, 
+      header1.type_name_start,
+      static_cast<unsigned int>(offset1), 
+      static_cast<unsigned int>(offset2));
+    match = false;
+  }
+  // Check data mismatch (only compare up to min(size1, size2))
+  auto cmpSize = std::min(size1, size2);
+  if (std::memcmp(dataStart1, dataStart2, cmpSize) != 0) {
+    std::printf("%s.%s.%s: Data mismatch (%u/%u)\n", 
+      header1.object_name_start, 
+      header1.property_name_start, 
+      header1.type_name_start,
+      static_cast<unsigned int>(offset1), 
+      static_cast<unsigned int>(offset2));
+
+    // Find first mismatch
+    auto p1 = dataStart1;
+    auto p2 = dataStart2;
+    while (*p1 == *p2 && (p1 < dataEnd1) && (p2 < dataEnd2)) {
+      ++p1; 
+      ++p2;
+    }
+    // Print hex context around mismatch
+    printHexContext(dataStart1, dataEnd1, p1);
+    printHexContext(dataStart2, dataEnd2, p2);
+    match = false;
+  }
+
+  if (!match) {
+    std::printf("*NOT MATCHING*\n");
+  }
+}
+
+} // unnamed namespace
 
 int main(int argc, char** argv) {
-	auto dir = simple_fs::get_or_create_oos_directory();
-	if(argc <= 1) {
-		std::printf("Usage: %s [file1] [file2]\n", argv[0]);
-		return EXIT_FAILURE;
-	}
+  auto dir = simple_fs::get_or_create_oos_directory();
+  if (argc <= 1) {
+    std::printf("Usage: %s [file1] [file2]\n", argv[0]);
+    return EXIT_FAILURE;
+  }
 
-	auto oos_file_1 = open_file(dir, simple_fs::utf8_to_native(argv[1]));
-	if(!bool(oos_file_1))
-		return EXIT_FAILURE;
-	auto contents_1 = simple_fs::view_contents(*oos_file_1);
-	auto const* start_1 = reinterpret_cast<uint8_t const*>(contents_1.data);
-	auto end_1 = start_1 + contents_1.file_size;
-	if(argc <= 2) {
-		std::printf("Doing a report of %s\n", argv[1]);
-		dcon::for_each_record(reinterpret_cast<const std::byte*>(start_1), reinterpret_cast<const std::byte*>(end_1), [&](dcon::record_header const& header_1, std::byte const* data_start_1, std::byte const* data_end_1) {
-			auto size1 = data_end_1 - data_start_1;
-			std::printf("%s.%s.%s,%zu\n", header_1.object_name_start, header_1.property_name_start, header_1.type_name_start, static_cast<size_t>(size1));
-		});
-	} else {
-		auto oos_file_2 = open_file(dir, simple_fs::utf8_to_native(argv[2]));
-		if(!bool(oos_file_2))
-			return EXIT_FAILURE;
-		auto contents_2 = simple_fs::view_contents(*oos_file_2);
-		auto const* start_2 = reinterpret_cast<uint8_t const*>(contents_2.data);
-		auto end_2 = start_2 + contents_2.file_size;
+  auto oos_file_1 = open_file(dir, simple_fs::utf8_to_native(argv[1]));
+  if(!bool(oos_file_1)) {
+    return EXIT_FAILURE;
+  }
+  auto contents_1 = simple_fs::view_contents(*oos_file_1);
+  auto const* start_1 = reinterpret_cast<uint8_t const*>(contents_1.data);
+  auto end_1 = start_1 + contents_1.file_size;
 
-		std::printf("Comparing files %s and %s\n", argv[1], argv[2]);
+  // If only one file: just report
+  if(argc <= 2) {
+    std::printf("Doing a report of %s\n", argv[1]);
+    dcon::for_each_record(reinterpret_cast<const std::byte*>(start_1),
+                          reinterpret_cast<const std::byte*>(end_1),
+      [&](dcon::record_header const& header_1, 
+          std::byte const* data_start_1, 
+          std::byte const* data_end_1) 
+      {
+        auto size1 = data_end_1 - data_start_1;
+        std::printf("%s.%s.%s, %zu\n", 
+          header_1.object_name_start, 
+          header_1.property_name_start, 
+          header_1.type_name_start, 
+          static_cast<size_t>(size1));
+      }
+    );
+  } 
+  // If two files: compare
+  else {
+    auto oos_file_2 = open_file(dir, simple_fs::utf8_to_native(argv[2]));
+    if(!bool(oos_file_2)) {
+      return EXIT_FAILURE;
+    }
+    auto contents_2 = simple_fs::view_contents(*oos_file_2);
+    auto const* start_2 = reinterpret_cast<uint8_t const*>(contents_2.data);
+    auto end_2 = start_2 + contents_2.file_size;
 
-		dcon::for_each_record(reinterpret_cast<const std::byte*>(start_1), reinterpret_cast<const std::byte*>(end_1), [&](dcon::record_header const& header_1, std::byte const* data_start_1, std::byte const* data_end_1) {
-			dcon::for_each_record(reinterpret_cast<const std::byte*>(start_2), reinterpret_cast<const std::byte*>(end_2), [&](dcon::record_header const& header_2, std::byte const* data_start_2, std::byte const* data_end_2) {
-				auto obj1 = std::string_view{ header_1.object_name_start, header_1.object_name_end };
-				auto obj2 = std::string_view{ header_2.object_name_start, header_2.object_name_end };
-				if(obj1 == obj2) {
-					auto pop1 = std::string_view{ header_1.property_name_start, header_1.property_name_end };
-					auto pop2 = std::string_view{ header_2.property_name_start, header_2.property_name_end };
-					if(pop1 == pop2) {
-						auto size1 = data_end_1 - data_start_1;
-						auto size2 = data_end_2 - data_start_2;
-						auto offset1 = data_start_1 - reinterpret_cast<const std::byte*>(start_1);
-						auto offset2 = data_start_2 - reinterpret_cast<const std::byte*>(start_2);
-						bool match = true;
-						//
-						if(size1 != size2) {
-							std::printf("%s.%s.%s:", header_1.object_name_start, header_1.property_name_start, header_1.type_name_start);
-							std::printf("Size mismatch (%u/%u)\n", static_cast<unsigned int>(offset1), static_cast<unsigned int>(offset2));
-							match = false;
-						}
-						//
-						if(std::memcmp(data_start_1, data_start_2, std::min(size1, size2))) {
-							std::printf("%s.%s.%s:", header_1.object_name_start, header_1.property_name_start, header_1.type_name_start);
-							std::printf("Data mismatch (%u/%u)", static_cast<unsigned int>(offset1), static_cast<unsigned int>(offset2));
+    std::printf("Comparing files %s and %s\n", argv[1], argv[2]);
 
-							auto p1 = data_start_1;
-							auto p2 = data_start_2;
-							for(; *p1 == *p2; p1++, p2++);
-							std::printf("<@+%u> ->\n", static_cast<unsigned int>(p1 - data_start_1));
+    dcon::for_each_record(reinterpret_cast<const std::byte*>(start_1),
+                          reinterpret_cast<const std::byte*>(end_1),
+      [&](dcon::record_header const& header_1, 
+          std::byte const* data_start_1, 
+          std::byte const* data_end_1) 
+      {
+        dcon::for_each_record(reinterpret_cast<const std::byte*>(start_2),
+                              reinterpret_cast<const std::byte*>(end_2),
+          [&](dcon::record_header const& header_2, 
+              std::byte const* data_start_2, 
+              std::byte const* data_end_2)
+          {
+            auto obj1 = std::string_view{ header_1.object_name_start, header_1.object_name_end };
+            auto obj2 = std::string_view{ header_2.object_name_start, header_2.object_name_end };
+            if (obj1 == obj2) {
+              auto prop1 = std::string_view{ header_1.property_name_start, header_1.property_name_end };
+              auto prop2 = std::string_view{ header_2.property_name_start, header_2.property_name_end };
+              if (prop1 == prop2) {
+                // Compare
+                compareRecords(header_1, data_start_1, data_end_1,
+                               header_2, data_start_2, data_end_2,
+                               start_1, start_2);
+              }
+            }
+          }
+        );
+      }
+    );
+  }
 
-							std::printf("<");
-							for(int32_t i = -8; i < 8; i++)
-								std::printf("%x ", p1[i]);
-							std::printf(">\n<");
-							for(int32_t i = -8; i < 8; i++)
-								std::printf("%x ", p2[i]);
-							std::printf(">\n");
-
-							match = false;
-						}
-						//
-						if(!match) {
-							std::printf("*NOT MATCHING*\n");
-						}
-					}
-				}
-			});
-		});
-	}
-	std::printf("Kosher! Finished! ^-^\n");
-	return EXIT_SUCCESS;
+  std::printf("Kosher! Finished! ^-^\n");
+  return EXIT_SUCCESS;
 }
+


### PR DESCRIPTION
Verify Understanding
You’ve shared a C++ program that compares the contents of one or two “OOS” files (presumably a custom format). Specifically:

If only one file is provided, it “does a report” of each record in that file, printing object name, property name, type name, and data size. If two files are provided, it compares all matching records—by object name and property name—between the two files. If records differ in size or content, it prints diagnostic information showing how the data mismatches. The code uses:

A custom filesystem interface (simple_fs::get_or_create_oos_directory, simple_fs::view_contents, etc.). A dcon::for_each_record function that iterates over “records” in the OOS data. Low-level pointer arithmetic for data comparisons. Below is a review of the code’s structure, recommended improvements for clarity, maintainability, and safety, plus a potential refactoring approach.

1. High-Level Observations Global vs. Local Code

All logic is contained in main(), relying on free functions like open_file, view_contents, etc. That can be acceptable for small utilities, but if this code expands, you might consider separating out logic into smaller, testable functions or classes. Pointer Arithmetic and Byte Comparisons

The code directly uses std::memcmp and pointer arithmetic (data_start_1 - reinterpret_cast<const std::byte*>(start_1)). This is efficient and valid, but also prone to subtle off-by-one or out-of-bounds errors. You’ve already included checks for mismatched sizes, which is good. Potential Out-of-Bounds Risk

In the mismatch reporting code, you do:
cpp
Copy code
for(int32_t i = -8; i < 8; i++)
  std::printf("%x ", p1[i]);
Here, p1 + i can easily go out of range (e.g., if the mismatch is at the very beginning or end of the buffer). You might want to ensure p1 + i is still within the valid memory region, or clamp i so you don’t access memory before the start of p1 or beyond the end. Nested Loops for Comparison

When two files are supplied, the comparison code calls dcon::for_each_record on file 1, and inside that lambda calls dcon::for_each_record on file 2. That’s an O(N*M) approach. For small files this is fine, but if the files contain many records, you might consider more efficient ways to match records. For example: Index records from each file in a std::unordered_map<std::pair<std::string, std::string>, record_info> keyed by (objectName, propertyName). Then compare records with matching keys directly, in O(N + M) time. Error Handling

The code gracefully checks if file open fails, printing usage or returning EXIT_FAILURE. That’s good. Once you have a valid file handle, you assume the format is correct. If the OOS data is malformed, your code might still run into undefined behavior. Debug/Diagnostic Printing

The mismatch printing is thorough (printing offsets, partial hexdumps). This is useful for debugging. Consider a function that prints a nicely formatted hex dump, to avoid repeating code in multiple places. Usage Output

If no arguments are provided, it prints usage. That’s appropriate. If exactly one file is provided, it does a “report.” If two are provided, it compares. That logic is straightforward and well organized.
2. Suggestions for Improvement Extract Compare Logic

Currently, the comparison logic is deeply nested in lambdas. You could move that into a named function. For instance: cpp
Copy code
static void compareRecords(
  dcon::record_header const& header1,
  std::byte const* data_start_1, 
  std::byte const* data_end_1,
  dcon::record_header const& header2,
  std::byte const* data_start_2, 
  std::byte const* data_end_2,
  uint8_t const* file_start_1,
  uint8_t const* file_start_2)
{
  // do the size check, memcmp, etc.
}
This would reduce nesting and make the code more readable. Protect Hex Dump

In the block:
cpp
Copy code
for(int32_t i = -8; i < 8; i++)
  std::printf("%x ", p1[i]);
p1 + i might go out of bounds. Consider clamping the range: cpp
Copy code
// Example safety check:
int32_t offset = static_cast<int32_t>(p1 - data_start_1); for(int32_t i = -8; i < 8; i++) {
  auto checkPos = offset + i;
  if(checkPos >= 0 && (data_start_1 + checkPos) < data_end_1)
    std::printf("%02x ", data_start_1[checkPos]);
  else
    std::printf("?? ");
}
This ensures you don’t try to read out-of-bounds memory. Record Matching Efficiency

If the user’s data sets are large, nested for_each_record calls lead to repeated comparisons. A more scalable way is: Load all records from file 1 into a map (objectName, propertyName) -> (data pointer, size, offset, etc.). Then iterate file 2, looking up each record by (objectName, propertyName) in that map. Compare as needed.
This approach handles data in O(N+M) rather than O(N*M). Better Type Safety

You’re using reinterpret_cast<const std::byte*>(...) throughout. That’s valid if you know the memory layout. Just remain consistent (i.e., always treat the underlying data as std::byte* if you’re using dcon::for_each_record that way). Use RAII for File Handling

Since you’re already returning EXIT_FAILURE early if the file open fails, you’re likely safe. But if open_file(...) returns some resource, ensure it’s closed or destructed properly. The code suggests you have a wrapper type that automatically closes on destruction—just confirm that is happening behind the scenes. Consider a Dedicated Library

If you expect to parse or compare OOS files often, extracting this logic into a small library or utility class might help. Then main() becomes just a thin CLI wrapper.
3. Illustrative (Partial) Refactor Below is an example of how you could modularize the comparison portion. It’s not a full rewrite, but shows how to reduce nesting and handle hex-dumping more safely:

cpp
Copy code
#include <cstdio>
#include <cstring>
#include <string_view>
#include <algorithm>

// Forward declarations:
//   - open_file, simple_fs::view_contents, dcon::for_each_record, etc.
//   - We assume these exist as in your code.

namespace {

// Utility function to safely dump hex around a mismatch void printHexContext(
  std::byte const* dataStart,
  std::byte const* dataEnd,
  std::byte const* mismatchPos)
{
  // We'll dump 8 bytes before and after the mismatch, within bounds
  constexpr int contextSize = 8;
  auto totalSize = dataEnd - dataStart;
  auto mismatchOffset = mismatchPos - dataStart;

  // Start offset
  auto startOffset = mismatchOffset > contextSize 
                    ? (mismatchOffset - contextSize) 
                    : 0;
  // End offset
  auto endOffset = std::min(mismatchOffset + contextSize, totalSize);

  std::printf("Mismatch at offset %zu. Hex context:\n<", size_t(mismatchOffset));
  for (auto i = startOffset; i < endOffset; i++) {
    std::printf("%02x ", static_cast<unsigned char>(dataStart[i]));
  }
  std::printf(">\n");
}

// Compares two records for data and size
void compareRecords(
  dcon::record_header const& header1,
  std::byte const* dataStart1, 
  std::byte const* dataEnd1,
  dcon::record_header const& header2,
  std::byte const* dataStart2, 
  std::byte const* dataEnd2,
  uint8_t const* fileStart1,
  uint8_t const* fileStart2)
{
  auto size1 = dataEnd1 - dataStart1;
  auto size2 = dataEnd2 - dataStart2;
  auto offset1 = dataStart1 - reinterpret_cast<const std::byte*>(fileStart1);
  auto offset2 = dataStart2 - reinterpret_cast<const std::byte*>(fileStart2);

  bool match = true;
  // Check size mismatch
  if (size1 != size2) {
    std::printf("%s.%s.%s: Size mismatch (%u/%u)\n", 
      header1.object_name_start, 
      header1.property_name_start, 
      header1.type_name_start,
      static_cast<unsigned int>(offset1), 
      static_cast<unsigned int>(offset2));
    match = false;
  }
  // Check data mismatch (only compare up to min(size1, size2))
  auto cmpSize = std::min(size1, size2);
  if (std::memcmp(dataStart1, dataStart2, cmpSize) != 0) {
    std::printf("%s.%s.%s: Data mismatch (%u/%u)\n", 
      header1.object_name_start, 
      header1.property_name_start, 
      header1.type_name_start,
      static_cast<unsigned int>(offset1), 
      static_cast<unsigned int>(offset2));

    // Find first mismatch
    auto p1 = dataStart1;
    auto p2 = dataStart2;
    while (*p1 == *p2 && (p1 < dataEnd1) && (p2 < dataEnd2)) {
      ++p1; 
      ++p2;
    }
    // Print hex context around mismatch
    printHexContext(dataStart1, dataEnd1, p1);
    printHexContext(dataStart2, dataEnd2, p2);
    match = false;
  }

  if (!match) {
    std::printf("*NOT MATCHING*\n");
  }
}

} // unnamed namespace

int main(int argc, char** argv) {
  auto dir = simple_fs::get_or_create_oos_directory();
  if (argc <= 1) {
    std::printf("Usage: %s [file1] [file2]\n", argv[0]);
    return EXIT_FAILURE;
  }

  auto oos_file_1 = open_file(dir, simple_fs::utf8_to_native(argv[1]));
  if(!bool(oos_file_1)) {
    return EXIT_FAILURE;
  }
  auto contents_1 = simple_fs::view_contents(*oos_file_1);
  auto const* start_1 = reinterpret_cast<uint8_t const*>(contents_1.data);
  auto end_1 = start_1 + contents_1.file_size;

  // If only one file: just report
  if(argc <= 2) {
    std::printf("Doing a report of %s\n", argv[1]);
    dcon::for_each_record(reinterpret_cast<const std::byte*>(start_1),
                          reinterpret_cast<const std::byte*>(end_1),
      [&](dcon::record_header const& header_1, 
          std::byte const* data_start_1, 
          std::byte const* data_end_1) 
      {
        auto size1 = data_end_1 - data_start_1;
        std::printf("%s.%s.%s, %zu\n", 
          header_1.object_name_start, 
          header_1.property_name_start, 
          header_1.type_name_start, 
          static_cast<size_t>(size1));
      }
    );
  } 
  // If two files: compare
  else {
    auto oos_file_2 = open_file(dir, simple_fs::utf8_to_native(argv[2]));
    if(!bool(oos_file_2)) {
      return EXIT_FAILURE;
    }
    auto contents_2 = simple_fs::view_contents(*oos_file_2);
    auto const* start_2 = reinterpret_cast<uint8_t const*>(contents_2.data);
    auto end_2 = start_2 + contents_2.file_size;

    std::printf("Comparing files %s and %s\n", argv[1], argv[2]);

    dcon::for_each_record(reinterpret_cast<const std::byte*>(start_1),
                          reinterpret_cast<const std::byte*>(end_1),
      [&](dcon::record_header const& header_1, 
          std::byte const* data_start_1, 
          std::byte const* data_end_1) 
      {
        dcon::for_each_record(reinterpret_cast<const std::byte*>(start_2),
                              reinterpret_cast<const std::byte*>(end_2),
          [&](dcon::record_header const& header_2, 
              std::byte const* data_start_2, 
              std::byte const* data_end_2)
          {
            auto obj1 = std::string_view{ header_1.object_name_start, header_1.object_name_end };
            auto obj2 = std::string_view{ header_2.object_name_start, header_2.object_name_end };
            if (obj1 == obj2) {
              auto prop1 = std::string_view{ header_1.property_name_start, header_1.property_name_end };
              auto prop2 = std::string_view{ header_2.property_name_start, header_2.property_name_end };
              if (prop1 == prop2) {
                // Compare
                compareRecords(header_1, data_start_1, data_end_1,
                               header_2, data_start_2, data_end_2,
                               start_1, start_2);
              }
            }
          }
        );
      }
    );
  }

  std::printf("Kosher! Finished! ^-^\n");
  return EXIT_SUCCESS;
}
Key Improvements Shown

We factored out the record-comparison logic into compareRecords(), reducing nesting in the main lambdas. We added a safe printHexContext() function that prevents out-of-bounds reads when printing around a mismatch. We used the same approach to do the single-file “report” vs. two-file “compare.” You could further improve by building a record index for each file and doing a direct lookup rather than a nested loop, if you expect large files.

4. Addressing Edge Cases Truncated or Corrupted File

If the OOS file is truncated, dcon::for_each_record might encounter a partial record or invalid offsets. Ensure that the library or the loop code handles this gracefully (likely by returning an error or skipping invalid data). Identical Object/Property but Different Type

Currently, the code only checks object_name_start/end and property_name_start/end. If the type is also critical, consider checking type_name_start/end too, or factoring that into the comparison logic. Comparisons at the Very First or Last Bytes

The hex dump code has been updated to avoid reading out-of-bounds. If you expand mismatch printing to show lines of hex, watch for negative indexing or indexing beyond file size. Performance

For large datasets, nested iteration is O(N*M). If files have many records, building a map or index is recommended.
5. Conclusion and Future Enhancements Separating Concerns: Currently everything is in main(). For a larger tool or library, you might move the “report” and “compare” logic into separate functions or classes. Streamlined CLI: If you plan additional subcommands, consider a CLI parsing library (e.g., cxxopts) for more flexible usage. Testing: A few unit tests (or integration tests) with mock or sample OOS files can help confirm correctness (e.g., checking that a known mismatch is correctly detected). Overall, the code is straightforward for a utility: open files, parse records, compare, and print findings. By introducing small improvements—like safer pointer handling, reduced nesting via helper functions, and possible record indexing—you’ll have a more robust, maintainable comparison tool.