### PR TITLE
Add define to weigh between military and industrial power in ai::estimate_strength.

### DIFF
--- a/src/ai/ai.cpp
+++ b/src/ai/ai.cpp
@@ -17,9 +17,12 @@ enum ai_strategies {
 };
 
 float estimate_strength(sys::state& state, dcon::nation_id n) {
-	float value = state.world.nation_get_military_score(n);
-	for(auto subj : state.world.nation_get_overlord_as_ruler(n))
-		value += subj.get_subject().get_military_score();
+	float value = state.world.nation_get_military_score(n) * state.defines.alice_ai_strength_estimation_military_industrial_balance;
+	value += state.world.nation_get_military_score(n) * (1.f - state.defines.alice_ai_strength_estimation_military_industrial_balance);
+	for(auto subj : state.world.nation_get_overlord_as_ruler(n)) {
+		value += subj.get_subject().get_military_score() * state.defines.alice_ai_strength_estimation_military_industrial_balance;
+		value += subj.get_subject().get_military_score() * (1.f - state.defines.alice_ai_strength_estimation_military_industrial_balance);
+	}
 	return value;
 }
 

--- a/src/ai/ai.cpp
+++ b/src/ai/ai.cpp
@@ -18,10 +18,10 @@ enum ai_strategies {
 
 float estimate_strength(sys::state& state, dcon::nation_id n) {
 	float value = state.world.nation_get_military_score(n) * state.defines.alice_ai_strength_estimation_military_industrial_balance;
-	value += state.world.nation_get_military_score(n) * (1.f - state.defines.alice_ai_strength_estimation_military_industrial_balance);
+	value += state.world.nation_get_industrial_score(n) * (1.f - state.defines.alice_ai_strength_estimation_military_industrial_balance);
 	for(auto subj : state.world.nation_get_overlord_as_ruler(n)) {
 		value += subj.get_subject().get_military_score() * state.defines.alice_ai_strength_estimation_military_industrial_balance;
-		value += subj.get_subject().get_military_score() * (1.f - state.defines.alice_ai_strength_estimation_military_industrial_balance);
+		value += subj.get_subject().get_industrial_score() * (1.f - state.defines.alice_ai_strength_estimation_military_industrial_balance);
 	}
 	return value;
 }

--- a/src/gamestate/serialization.hpp
+++ b/src/gamestate/serialization.hpp
@@ -151,7 +151,7 @@ inline uint8_t const* deserialize(uint8_t const* ptr_in, ankerl::unordered_dense
 	return ptr_in + sizeof(uint32_t) + sizeof(vec.values()[0]) * length;
 }
 
-constexpr inline uint32_t save_file_version = 43;
+constexpr inline uint32_t save_file_version = 44;
 constexpr inline uint32_t scenario_file_version = 137 + save_file_version;
 
 struct scenario_header {

--- a/src/parsing/defines.hpp
+++ b/src/parsing/defines.hpp
@@ -701,6 +701,7 @@
 	LUA_DEFINES_LIST_ELEMENT(alice_allow_revoke_subject_states, 0.0) \
 	LUA_DEFINES_LIST_ELEMENT(alice_take_province_militancy_subject, 2.0) \
 	LUA_DEFINES_LIST_ELEMENT(alice_take_province_militancy_all_subjects, 1.0) \
+	LUA_DEFINES_LIST_ELEMENT(alice_ai_strength_estimation_military_industrial_balance, 1.0) \
 
 
 // scales the needs values so that they are needs per this many pops

--- a/src/parsing/defines.hpp
+++ b/src/parsing/defines.hpp
@@ -694,13 +694,13 @@
 	LUA_DEFINES_LIST_ELEMENT(alice_rgo_per_size_employment, 40000.0) \
 	LUA_DEFINES_LIST_ELEMENT(alice_eval_ai_mil_everyday, 0.0) \
 	LUA_DEFINES_LIST_ELEMENT(alice_allow_subjects_declare_wars, 0.0) \
-	LUA_DEFINES_LIST_ELEMENT(alice_research_points_on_conquer_base, 0.75)                                                          \
-	LUA_DEFINES_LIST_ELEMENT(alice_substate_subject_money_transfer, 40.0)                                                          \
-	LUA_DEFINES_LIST_ELEMENT(alice_puppet_subject_money_transfer, 30.0)                                                          \
-	LUA_DEFINES_LIST_ELEMENT(alice_privateinvestment_subject_transfer, 2.0)                                                          \
-	LUA_DEFINES_LIST_ELEMENT(alice_allow_revoke_subject_states, 0.0)                                                          \
-	LUA_DEFINES_LIST_ELEMENT(alice_take_province_militancy_subject, 2.0)                                                          \
-	LUA_DEFINES_LIST_ELEMENT(alice_take_province_militancy_all_subjects, 1.0)                                                          \
+	LUA_DEFINES_LIST_ELEMENT(alice_research_points_on_conquer_base, 0.75) \
+	LUA_DEFINES_LIST_ELEMENT(alice_substate_subject_money_transfer, 40.0) \
+	LUA_DEFINES_LIST_ELEMENT(alice_puppet_subject_money_transfer, 30.0) \
+	LUA_DEFINES_LIST_ELEMENT(alice_privateinvestment_subject_transfer, 2.0) \
+	LUA_DEFINES_LIST_ELEMENT(alice_allow_revoke_subject_states, 0.0) \
+	LUA_DEFINES_LIST_ELEMENT(alice_take_province_militancy_subject, 2.0) \
+	LUA_DEFINES_LIST_ELEMENT(alice_take_province_militancy_all_subjects, 1.0) \
 
 
 // scales the needs values so that they are needs per this many pops


### PR DESCRIPTION
The name of the define is "alice_ai_strength_estimation_military_industrial_balance", and its default is "1.0" (which doesn't change it from its previous behavior for now, others may fine tune as wished.)

Also cleans up weird looking stuff in defines.hpp as well.