### PR TITLE
Improving leader selection in land and naval battles

### DIFF
--- a/src/military/military.cpp
+++ b/src/military/military.cpp
@@ -4838,7 +4838,7 @@ dcon::nation_id get_land_battle_lead_defender(sys::state& state, dcon::land_batt
 	return dcon::nation_id{};
 }
 
-float get_leader_select_score(sys::state& state, dcon::leader_id l) {
+float get_leader_select_score(sys::state& state, dcon::leader_id l, bool is_attacking) {
 	/*
 	- Each side has a leader that is in charge of the combat, which is the leader with the greatest
 	value as determined by the following formula: (organization x 5 + attack + defend + morale +
@@ -4846,10 +4846,17 @@ float get_leader_select_score(sys::state& state, dcon::leader_id l) {
 	*/
 	auto per = state.world.leader_get_personality(l);
 	auto bak = state.world.leader_get_background(l);
-	//
+	// atk and def are both set to 0 initally, and will be set to its actual amount depending if on the on_attacking input param
+	// this makes it so for example if the leader is attacking, it will disregard all "defence" stats for the purposes of calculating the score
+	float atk = 0.f;
+	float def = 0.f;
 	auto org = state.world.leader_trait_get_organisation(per) + state.world.leader_trait_get_organisation(bak);
-	auto atk = state.world.leader_trait_get_attack(per) + state.world.leader_trait_get_attack(bak);
-	auto def = state.world.leader_trait_get_defense(per) + state.world.leader_trait_get_defense(bak);
+	if(is_attacking) {
+		atk = state.world.leader_trait_get_attack(per) + state.world.leader_trait_get_attack(bak);
+	}
+	else {
+		def = state.world.leader_trait_get_defense(per) + state.world.leader_trait_get_defense(bak);
+	}
 	auto spd = state.world.leader_trait_get_speed(per) + state.world.leader_trait_get_speed(bak);
 	auto mor = state.world.leader_trait_get_morale(per) + state.world.leader_trait_get_morale(bak);
 	auto att = state.world.leader_trait_get_experience(per) + state.world.leader_trait_get_experience(bak);
@@ -4925,7 +4932,7 @@ void update_battle_leaders(sys::state& state, dcon::land_battle_id b) {
 			continue;
 		}
 		bool is_attacking = is_attacker_in_battle(state, a.get_army());
-		auto score = get_leader_select_score(state, l);
+		auto score = get_leader_select_score(state, l, is_attacking);
 		/*if(a.get_army().get_controller_from_army_control() == la) {*/
 		if(is_attacking) {
 			if(score > a_score) {
@@ -4960,7 +4967,7 @@ void update_battle_leaders(sys::state& state, dcon::naval_battle_id b) {
 			continue;
 		}
 		bool is_attacking = is_attacker_in_battle(state, a.get_navy());
-		auto score = get_leader_select_score(state, l);
+		auto score = get_leader_select_score(state, l, is_attacking);
 		if(is_attacking) {
 			if(score > a_score) {
 				a_lid = l;

--- a/src/military/military.cpp
+++ b/src/military/military.cpp
@@ -4485,6 +4485,7 @@ void add_army_to_battle(sys::state& state, dcon::army_id a, dcon::land_battle_id
 
 	state.world.army_set_battle_from_army_battle_participation(a, b);
 	state.world.army_set_arrival_time(a, sys::date{}); // pause movement
+	update_battle_leaders(state, b);
 }
 
 void army_arrives_in_province(sys::state& state, dcon::army_id a, dcon::province_id p, crossing_type crossing, dcon::land_battle_id from) {
@@ -4860,12 +4861,16 @@ float get_leader_select_score(sys::state& state, dcon::leader_id l) {
 void update_battle_leaders(sys::state& state, dcon::land_battle_id b) {
 	auto la = get_land_battle_lead_attacker(state, b);
 	dcon::leader_id a_lid;
-	float a_score = 0.f;
+	float a_score = -999.f;
 	auto ld = get_land_battle_lead_defender(state, b);
 	dcon::leader_id d_lid;
-	float d_score = 0.f;
+		float d_score = -999.f;
 	for(const auto a : state.world.land_battle_get_army_battle_participation(b)) {
 		auto l = a.get_army().get_general_from_army_leadership();
+		// if its no leader, skip
+		if(!l.is_valid()) {
+			continue;
+		}
 		auto score = get_leader_select_score(state, l);
 		if(a.get_army().get_controller_from_army_control() == la) {
 			if(score > a_score) {

--- a/src/military/military.cpp
+++ b/src/military/military.cpp
@@ -4873,9 +4873,9 @@ bool is_attacker_in_battle(sys::state& state, dcon::army_id a) {
 	auto lead_attacker = get_land_battle_lead_attacker(state, battle);
 	auto lead_defender = get_land_battle_lead_defender(state, battle);
 	auto thisnation = state.world.army_get_controller_from_army_control(a);
+	bool war_attacker = state.world.land_battle_get_war_attacker_is_attacker(battle);
 	// country vs country
 	if(lead_attacker && lead_defender) {
-		bool war_attacker = state.world.land_battle_get_war_attacker_is_attacker(battle);
 		for(const auto par : state.world.nation_get_war_participant(thisnation)) {
 			if((par.get_is_attacker() && war_attacker) || (!par.get_is_attacker() && !war_attacker)) {
 				return true;
@@ -4888,13 +4888,13 @@ bool is_attacker_in_battle(sys::state& state, dcon::army_id a) {
 	}
 	// country vs rebels
 	else {
-		// if the "this" nation is not rebels
-		if(thisnation) {
-			return lead_attacker == thisnation;
+		// if the "this" nation is the rebels, and they are attacking
+		if(!thisnation) {
+			return war_attacker;
 		}
-		// if the "this" nation is rebels
+		// if the "this" nation is not rebels
 		else {
-			return lead_defender == thisnation;
+			return !war_attacker;
 		}
 	}
 }

--- a/src/military/military.cpp
+++ b/src/military/military.cpp
@@ -4858,26 +4858,63 @@ float get_leader_select_score(sys::state& state, dcon::leader_id l) {
 	auto lp = state.world.leader_get_prestige(l);
 	return (org * 5.f + atk + def + mor + spd + att + exp / 2.f + rec / 5.f + rel / 5.f) * (lp + 1.f);
 }
+
+bool is_attacker_in_battle(sys::state& state, dcon::army_id a) {
+	assert(state.world.army_get_battle_from_army_battle_participation(a)); // make sure the army is actually in a battle
+	auto battle = state.world.army_get_battle_from_army_battle_participation(a);
+	auto lead_attacker = get_land_battle_lead_attacker(state, battle);
+	auto lead_defender = get_land_battle_lead_defender(state, battle);
+	auto thisnation = state.world.army_get_controller_from_army_control(a);
+	// country vs country
+	if(lead_attacker && lead_defender) {
+		bool war_attacker = state.world.land_battle_get_war_attacker_is_attacker(battle);
+		for(const auto par : state.world.nation_get_war_participant(thisnation)) {
+			if((par.get_is_attacker() && war_attacker) || (!par.get_is_attacker() && !war_attacker)) {
+				return true;
+			}
+			else if((!par.get_is_attacker() && war_attacker) || (par.get_is_attacker() && !war_attacker)) {
+				return false;
+			}
+		}
+		return false;
+	}
+	// country vs rebels
+	else {
+		// if the "this" nation is not rebels
+		if(thisnation) {
+			return lead_attacker == thisnation;
+		}
+		// if the "this" nation is rebels
+		else {
+			return lead_defender == thisnation;
+		}
+	}
+}
+
 void update_battle_leaders(sys::state& state, dcon::land_battle_id b) {
-	auto la = get_land_battle_lead_attacker(state, b);
+	/*auto la = get_land_battle_lead_attacker(state, b);*/
 	dcon::leader_id a_lid;
+	// starting a_score and d_score set to low number, so no-leader won't take over sometimes even if there is a leader available
 	float a_score = -999.f;
-	auto ld = get_land_battle_lead_defender(state, b);
+	/*auto ld = get_land_battle_lead_defender(state, b);*/
 	dcon::leader_id d_lid;
-		float d_score = -999.f;
+	float d_score = -999.f;
 	for(const auto a : state.world.land_battle_get_army_battle_participation(b)) {
 		auto l = a.get_army().get_general_from_army_leadership();
 		// if its no leader, skip
 		if(!l.is_valid()) {
 			continue;
 		}
+		bool is_attacking = is_attacker_in_battle(state, a.get_army());
 		auto score = get_leader_select_score(state, l);
-		if(a.get_army().get_controller_from_army_control() == la) {
+		/*if(a.get_army().get_controller_from_army_control() == la) {*/
+		if(is_attacking) {
 			if(score > a_score) {
 				a_lid = l;
 				a_score = score;
 			}
-		} else if(a.get_army().get_controller_from_army_control() == ld) {
+		} /*else if(a.get_army().get_controller_from_army_control() == ld) {*/
+		else if(!is_attacking) {
 			if(score > d_score) {
 				d_lid = l;
 				d_score = score;

--- a/src/military/military.hpp
+++ b/src/military/military.hpp
@@ -498,6 +498,7 @@ dcon::nation_id get_naval_battle_lead_attacker(sys::state& state, dcon::naval_ba
 
 float get_leader_select_score(sys::state& state, dcon::leader_id l, bool is_attacking);
 bool is_attacker_in_battle(sys::state& state, dcon::army_id a);
+bool is_attacker_in_battle(sys::state& state, dcon::navy_id a);
 void update_battle_leaders(sys::state& state, dcon::land_battle_id b);
 void update_battle_leaders(sys::state& state, dcon::naval_battle_id b);
 

--- a/src/military/military.hpp
+++ b/src/military/military.hpp
@@ -496,7 +496,8 @@ dcon::nation_id get_land_battle_lead_defender(sys::state& state, dcon::land_batt
 dcon::nation_id get_naval_battle_lead_defender(sys::state& state, dcon::naval_battle_id b);
 dcon::nation_id get_naval_battle_lead_attacker(sys::state& state, dcon::naval_battle_id b);
 
-float get_leader_select_score(sys::state& state, dcon::leader_id l);
+float get_leader_select_score(sys::state& state, dcon::leader_id l, bool is_attacking);
+bool is_attacker_in_battle(sys::state& state, dcon::army_id a);
 void update_battle_leaders(sys::state& state, dcon::land_battle_id b);
 void update_battle_leaders(sys::state& state, dcon::naval_battle_id b);
 


### PR DESCRIPTION
This PR is meant to improve the selection of leaders in battles (ie who the game picks to be the leader, and apply their +atk and +def stats).

At the moment once a leader is chosen in a battle (whichever army starts the battle first), the leaders are more or less set in stone, and won't change even if a better leader is inserted together with another army. 

The PR changes the following regarding selection logic:

1: When a new army joins the battle, it will re-calculate all the leader scores in the battle, and select the one with the highest score. This enables the player to not have to worry about which army they have to insert "first", as any "Better" generals will automatically take over once inserted.
2: The leader score calculation is changed so that it will ignore the opposite stat, ie if a leader is attacking, it will not factor in any +defence bonus in the calculation. This leads to less user frustation if they, say, have a very good attack general, but is -2 defence. This general might take over defensive battles instead of more qualified defensive generals in the same stack.