### PR TITLE
Minor no-leader improvements

### DIFF
--- a/enc_temp_folder/d117bd389f5bd8931bff7b02cd868cc/gui_unit_panel.hpp
+++ b/enc_temp_folder/d117bd389f5bd8931bff7b02cd868cc/gui_unit_panel.hpp
@@ -210,11 +210,9 @@ class unit_selection_leader_name : public simple_text_element_base {
 			auto fat = dcon::fatten(state.world, content);
 			auto name = fat.get_general_from_army_leadership().get_name();
 			if(bool(name)) {
-				// if its a actual leader
 				set_text(state, std::string(state.to_string_view(name)));
 			}
 			else {
-				// if its no leader
 				set_text(state, text::produce_simple_string(state, "no_leader"));
 			}
 		}
@@ -222,11 +220,9 @@ class unit_selection_leader_name : public simple_text_element_base {
 			auto fat = dcon::fatten(state.world, content);
 			auto name = fat.get_admiral_from_navy_leadership().get_name();
 			if(bool(name)) {
-				// if its a actual leader
 				set_text(state, std::string(state.to_string_view(name)));
 			}
 			else {
-				// if its no leader
 				set_text(state, text::produce_simple_string(state, "no_leader"));
 			}
 		}

--- a/src/ai/ai.cpp
+++ b/src/ai/ai.cpp
@@ -5257,7 +5257,7 @@ float estimate_army_defensive_strength(sys::state& state, dcon::army_id a) {
 		if(!n)
 			n = state.world.national_identity_get_nation_from_identity_holder(state.national_definitions.rebel_id);
 		auto back = military::get_leader_background_wrapper(state, gen);
-		auto pers = state.world.leader_get_personality(gen);
+		auto pers = military::get_leader_personality_wrapper(state, gen);
 		float morale = state.world.nation_get_modifier_values(n, sys::national_mod_offsets::org_regain)
 			+ state.world.leader_trait_get_morale(back)
 			+ state.world.leader_trait_get_morale(pers) + 1.0f;
@@ -5291,7 +5291,7 @@ float estimate_army_offensive_strength(sys::state& state, dcon::army_id a) {
 		if(!n)
 			n = state.world.national_identity_get_nation_from_identity_holder(state.national_definitions.rebel_id);
 		auto back = military::get_leader_background_wrapper(state, gen);
-		auto pers = state.world.leader_get_personality(gen);
+		auto pers = military::get_leader_personality_wrapper(state, gen);
 		float morale = state.world.nation_get_modifier_values(n, sys::national_mod_offsets::org_regain)
 			+ state.world.leader_trait_get_morale(back)
 			+ state.world.leader_trait_get_morale(pers) + 1.0f;

--- a/src/ai/ai.cpp
+++ b/src/ai/ai.cpp
@@ -5256,7 +5256,7 @@ float estimate_army_defensive_strength(sys::state& state, dcon::army_id a) {
 		auto n = state.world.army_get_controller_from_army_control(a);
 		if(!n)
 			n = state.world.national_identity_get_nation_from_identity_holder(state.national_definitions.rebel_id);
-		auto back = state.world.leader_get_background(gen);
+		auto back = military::get_leader_background_wrapper(state, gen);
 		auto pers = state.world.leader_get_personality(gen);
 		float morale = state.world.nation_get_modifier_values(n, sys::national_mod_offsets::org_regain)
 			+ state.world.leader_trait_get_morale(back)
@@ -5290,7 +5290,7 @@ float estimate_army_offensive_strength(sys::state& state, dcon::army_id a) {
 		auto n = state.world.army_get_controller_from_army_control(a);
 		if(!n)
 			n = state.world.national_identity_get_nation_from_identity_holder(state.national_definitions.rebel_id);
-		auto back = state.world.leader_get_background(gen);
+		auto back = military::get_leader_background_wrapper(state, gen);
 		auto pers = state.world.leader_get_personality(gen);
 		float morale = state.world.nation_get_modifier_values(n, sys::national_mod_offsets::org_regain)
 			+ state.world.leader_trait_get_morale(back)

--- a/src/gui/gui_land_combat.hpp
+++ b/src/gui/gui_land_combat.hpp
@@ -568,7 +568,7 @@ class defender_combat_modifiers : public overlapping_listbox_element_base<lc_mod
 		auto location = state.world.land_battle_get_location_from_land_battle_location(b);
 		auto terrain_bonus = state.world.province_get_modifier_values(location, sys::provincial_mod_offsets::defense);
 
-		auto defender_per = state.world.leader_get_personality(state.world.land_battle_get_general_from_defending_general(b));
+		auto defender_per = military::get_leader_personality_wrapper(state, state.world.land_battle_get_general_from_defending_general(b));
 		auto defender_bg = military::get_leader_background_wrapper(state, state.world.land_battle_get_general_from_defending_general(b));
 
 		auto defence_bonus =
@@ -615,7 +615,7 @@ class attacker_combat_modifiers : public overlapping_listbox_element_base<lc_mod
 
 		auto attacker_dice = both_dice & 0x0F;
 
-		auto attacker_per = state.world.leader_get_personality(state.world.land_battle_get_general_from_attacking_general(b));
+		auto attacker_per = military::get_leader_personality_wrapper(state, state.world.land_battle_get_general_from_attacking_general(b));
 		auto attacker_bg = military::get_leader_background_wrapper(state, state.world.land_battle_get_general_from_attacking_general(b));
 
 		auto attack_bonus =

--- a/src/gui/gui_land_combat.hpp
+++ b/src/gui/gui_land_combat.hpp
@@ -569,7 +569,7 @@ class defender_combat_modifiers : public overlapping_listbox_element_base<lc_mod
 		auto terrain_bonus = state.world.province_get_modifier_values(location, sys::provincial_mod_offsets::defense);
 
 		auto defender_per = state.world.leader_get_personality(state.world.land_battle_get_general_from_defending_general(b));
-		auto defender_bg = state.world.leader_get_background(state.world.land_battle_get_general_from_defending_general(b));
+		auto defender_bg = military::get_leader_background_wrapper(state, state.world.land_battle_get_general_from_defending_general(b));
 
 		auto defence_bonus =
 			int32_t(state.world.leader_trait_get_defense(defender_per) + state.world.leader_trait_get_defense(defender_bg));
@@ -616,7 +616,7 @@ class attacker_combat_modifiers : public overlapping_listbox_element_base<lc_mod
 		auto attacker_dice = both_dice & 0x0F;
 
 		auto attacker_per = state.world.leader_get_personality(state.world.land_battle_get_general_from_attacking_general(b));
-		auto attacker_bg = state.world.leader_get_background(state.world.land_battle_get_general_from_attacking_general(b));
+		auto attacker_bg = military::get_leader_background_wrapper(state, state.world.land_battle_get_general_from_attacking_general(b));
 
 		auto attack_bonus =
 			int32_t(state.world.leader_trait_get_attack(attacker_per) + state.world.leader_trait_get_attack(attacker_bg));

--- a/src/gui/gui_land_combat.hpp
+++ b/src/gui/gui_land_combat.hpp
@@ -43,11 +43,10 @@ class lc_attacker_leader_img : public image_element_base {
 	void update_tooltip(sys::state& state, int32_t x, int32_t y, text::columnar_layout& contents) noexcept override {
 		auto b = retrieve<dcon::land_battle_id>(state, parent);
 		auto lid = state.world.land_battle_get_general_from_attacking_general(b);
-
-		if(lid)
-			display_leader_attributes(state, lid, contents, 0);
-		else
+		if(!lid) {
 			text::add_line(state, contents, "no_leader");
+		}
+		display_leader_attributes(state, lid, contents, 0);
 	}
 };
 class lc_defending_leader_img : public image_element_base {
@@ -86,11 +85,10 @@ class lc_defending_leader_img : public image_element_base {
 	void update_tooltip(sys::state& state, int32_t x, int32_t y, text::columnar_layout& contents) noexcept override {
 		auto b = retrieve<dcon::land_battle_id>(state, parent);
 		auto lid = state.world.land_battle_get_general_from_defending_general(b);
-
-		if(lid)
-			display_leader_attributes(state, lid, contents, 0);
-		else
+		if(!lid) {
 			text::add_line(state, contents, "no_leader");
+		}
+		display_leader_attributes(state, lid, contents, 0);
 	}
 };
 
@@ -1100,11 +1098,10 @@ class lc_our_leader_img : public image_element_base {
 		military::land_battle_report* report = retrieve< military::land_battle_report*>(state, parent);
 		bool we_are_attacker = (report->attacker_won == report->player_on_winning_side);
 		dcon::leader_id lid = we_are_attacker ? report->attacking_general : report->defending_general;
-
-		if(lid)
-			display_leader_attributes(state, lid, contents, 0);
-		else
+		if(!lid) {
 			text::add_line(state, contents, "no_leader");
+		}
+		display_leader_attributes(state, lid, contents, 0);
 	}
 };
 class lc_our_leader_name : public simple_text_element_base {
@@ -1160,11 +1157,10 @@ class lc_their_leader_img : public image_element_base {
 		military::land_battle_report* report = retrieve< military::land_battle_report*>(state, parent);
 		bool we_are_attacker = (report->attacker_won == report->player_on_winning_side);
 		dcon::leader_id lid = !we_are_attacker ? report->attacking_general : report->defending_general;
-
-		if(lid)
-			display_leader_attributes(state, lid, contents, 0);
-		else
+		if(!lid) {
 			text::add_line(state, contents, "no_leader");
+		}
+		display_leader_attributes(state, lid, contents, 0);
 	}
 };
 class lc_their_leader_name : public simple_text_element_base {

--- a/src/gui/gui_land_combat.hpp
+++ b/src/gui/gui_land_combat.hpp
@@ -102,7 +102,7 @@ public:
 			auto name = state.to_string_view(state.world.leader_get_name(lid));
 			set_text(state, std::string(name));
 		} else {
-			set_text(state, "");
+			set_text(state, text::produce_simple_string(state, "no_leader"));
 		}
 	}
 };
@@ -116,7 +116,7 @@ public:
 			auto name = state.to_string_view(state.world.leader_get_name(lid));
 			set_text(state, std::string(name));
 		} else {
-			set_text(state, "");
+			set_text(state, text::produce_simple_string(state, "no_leader"));
 		}
 	}
 };

--- a/src/gui/gui_leader_select.hpp
+++ b/src/gui/gui_leader_select.hpp
@@ -75,7 +75,7 @@ class passive_leader_attack : public  color_text_element {
 	void on_update(sys::state& state) noexcept override {
 		dcon::leader_id lid = retrieve<dcon::leader_id>(state, parent);
 		if(lid) {
-			auto attack = state.world.leader_trait_get_attack(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_attack(state.world.leader_get_personality(lid));
+			auto attack = state.world.leader_trait_get_attack(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_attack(military::get_leader_personality_wrapper(state, lid));
 			if(attack > 0) {
 				set_text(state, std::string("+") + text::format_float(attack, 2));
 				color = text::text_color::dark_green;
@@ -96,7 +96,7 @@ class passive_leader_defense : public  color_text_element {
 	void on_update(sys::state& state) noexcept override {
 		dcon::leader_id lid = retrieve<dcon::leader_id>(state, parent);
 		if(lid) {
-			auto v = state.world.leader_trait_get_defense(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_defense(state.world.leader_get_personality(lid));
+			auto v = state.world.leader_trait_get_defense(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_defense(military::get_leader_personality_wrapper(state, lid));
 			if(v > 0) {
 				set_text(state, std::string("+") + text::format_float(v, 2));
 				color = text::text_color::dark_green;
@@ -117,7 +117,7 @@ class passive_leader_org : public  color_text_element {
 	void on_update(sys::state& state) noexcept override {
 		dcon::leader_id lid = retrieve<dcon::leader_id>(state, parent);
 		if(lid) {
-			auto v = state.world.leader_trait_get_organisation(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_organisation(state.world.leader_get_personality(lid));
+			auto v = state.world.leader_trait_get_organisation(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_organisation(military::get_leader_personality_wrapper(state, lid));
 			if(v > 0) {
 				set_text(state, std::string("+") + text::format_float(v, 2));
 				color = text::text_color::dark_green;
@@ -138,7 +138,7 @@ class passive_leader_morale : public  color_text_element {
 	void on_update(sys::state& state) noexcept override {
 		dcon::leader_id lid = retrieve<dcon::leader_id>(state, parent);
 		if(lid) {
-			auto v = state.world.leader_trait_get_morale(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_morale(state.world.leader_get_personality(lid));
+			auto v = state.world.leader_trait_get_morale(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_morale(military::get_leader_personality_wrapper(state, lid));
 			if(v > 0) {
 				set_text(state, std::string("+") + text::format_float(v, 2));
 				color = text::text_color::dark_green;
@@ -159,7 +159,7 @@ class passive_leader_speed : public  color_text_element {
 	void on_update(sys::state& state) noexcept override {
 		dcon::leader_id lid = retrieve<dcon::leader_id>(state, parent);
 		if(lid) {
-			auto v = state.world.leader_trait_get_speed(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_speed(state.world.leader_get_personality(lid));
+			auto v = state.world.leader_trait_get_speed(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_speed(military::get_leader_personality_wrapper(state, lid));
 			if(v > 0) {
 				set_text(state, std::string("+") + text::format_float(v, 2));
 				color = text::text_color::dark_green;
@@ -180,7 +180,7 @@ class passive_leader_recon : public  color_text_element {
 	void on_update(sys::state& state) noexcept override {
 		dcon::leader_id lid = retrieve<dcon::leader_id>(state, parent);
 		if(lid) {
-			auto v = state.world.leader_trait_get_reconnaissance(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_reconnaissance(state.world.leader_get_personality(lid));
+			auto v = state.world.leader_trait_get_reconnaissance(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_reconnaissance(military::get_leader_personality_wrapper(state, lid));
 			if(v > 0) {
 				set_text(state, std::string("+") + text::format_float(v, 2));
 				color = text::text_color::dark_green;
@@ -201,7 +201,7 @@ class passive_leader_reliability : public  color_text_element {
 	void on_update(sys::state& state) noexcept override {
 		dcon::leader_id lid = retrieve<dcon::leader_id>(state, parent);
 		if(lid) {
-			auto v = state.world.leader_trait_get_reliability(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_reliability(state.world.leader_get_personality(lid));
+			auto v = state.world.leader_trait_get_reliability(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_reliability(military::get_leader_personality_wrapper(state, lid));
 			if(v > 0) {
 				set_text(state, std::string("+") + text::format_float(v, 2));
 				color = text::text_color::dark_green;
@@ -222,7 +222,7 @@ class passive_leader_exp : public  color_text_element {
 	void on_update(sys::state& state) noexcept override {
 		dcon::leader_id lid = retrieve<dcon::leader_id>(state, parent);
 		if(lid) {
-			auto v = state.world.leader_trait_get_experience(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_experience(state.world.leader_get_personality(lid));
+			auto v = state.world.leader_trait_get_experience(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_experience(military::get_leader_personality_wrapper(state, lid));
 			if(v > 0) {
 				set_text(state, std::string("+") + text::format_float(v, 2));
 				color = text::text_color::dark_green;
@@ -506,8 +506,8 @@ public:
 		switch(sort_type) {
 			case leader_select_sort::attack:
 				std::sort(row_contents.begin(), row_contents.end(), [&](dcon::leader_id a, dcon::leader_id b) {
-					auto av = state.world.leader_trait_get_attack(military::get_leader_background_wrapper(state, a)) + state.world.leader_trait_get_attack(state.world.leader_get_personality(a));
-					auto bv = state.world.leader_trait_get_attack(military::get_leader_background_wrapper(state, b)) + state.world.leader_trait_get_attack(state.world.leader_get_personality(b));
+					auto av = state.world.leader_trait_get_attack(military::get_leader_background_wrapper(state, a)) + state.world.leader_trait_get_attack(military::get_leader_personality_wrapper(state, a));
+					auto bv = state.world.leader_trait_get_attack(military::get_leader_background_wrapper(state, b)) + state.world.leader_trait_get_attack(military::get_leader_personality_wrapper(state, b));
 					if(av != bv)
 						return av > bv;
 					else
@@ -516,8 +516,8 @@ public:
 				break;
 			case leader_select_sort::defense:
 				std::sort(row_contents.begin(), row_contents.end(), [&](dcon::leader_id a, dcon::leader_id b) {
-					auto av = state.world.leader_trait_get_defense(military::get_leader_background_wrapper(state, a)) + state.world.leader_trait_get_defense(state.world.leader_get_personality(a));
-					auto bv = state.world.leader_trait_get_defense(military::get_leader_background_wrapper(state, b)) + state.world.leader_trait_get_defense(state.world.leader_get_personality(b));
+					auto av = state.world.leader_trait_get_defense(military::get_leader_background_wrapper(state, a)) + state.world.leader_trait_get_defense(military::get_leader_personality_wrapper(state, a));
+					auto bv = state.world.leader_trait_get_defense(military::get_leader_background_wrapper(state, b)) + state.world.leader_trait_get_defense(military::get_leader_personality_wrapper(state, b));
 					if(av != bv)
 						return av > bv;
 					else
@@ -526,8 +526,8 @@ public:
 				break;
 			case leader_select_sort::recon:
 				std::sort(row_contents.begin(), row_contents.end(), [&](dcon::leader_id a, dcon::leader_id b) {
-					auto av = state.world.leader_trait_get_reconnaissance(military::get_leader_background_wrapper(state, a)) + state.world.leader_trait_get_reconnaissance(state.world.leader_get_personality(a));
-					auto bv = state.world.leader_trait_get_reconnaissance(military::get_leader_background_wrapper(state, b)) + state.world.leader_trait_get_reconnaissance(state.world.leader_get_personality(b));
+					auto av = state.world.leader_trait_get_reconnaissance(military::get_leader_background_wrapper(state, a)) + state.world.leader_trait_get_reconnaissance(military::get_leader_personality_wrapper(state, a));
+					auto bv = state.world.leader_trait_get_reconnaissance(military::get_leader_background_wrapper(state, b)) + state.world.leader_trait_get_reconnaissance(military::get_leader_personality_wrapper(state, b));
 					if(av != bv)
 						return av > bv;
 					else
@@ -536,8 +536,8 @@ public:
 				break;
 			case leader_select_sort::morale:
 				std::sort(row_contents.begin(), row_contents.end(), [&](dcon::leader_id a, dcon::leader_id b) {
-					auto av = state.world.leader_trait_get_morale(military::get_leader_background_wrapper(state, a)) + state.world.leader_trait_get_morale(state.world.leader_get_personality(a));
-					auto bv = state.world.leader_trait_get_morale(military::get_leader_background_wrapper(state, b)) + state.world.leader_trait_get_morale(state.world.leader_get_personality(b));
+					auto av = state.world.leader_trait_get_morale(military::get_leader_background_wrapper(state, a)) + state.world.leader_trait_get_morale(military::get_leader_personality_wrapper(state, a));
+					auto bv = state.world.leader_trait_get_morale(military::get_leader_background_wrapper(state, b)) + state.world.leader_trait_get_morale(military::get_leader_personality_wrapper(state, b));
 					if(av != bv)
 						return av > bv;
 					else
@@ -546,8 +546,8 @@ public:
 				break;
 			case leader_select_sort::reliability:
 				std::sort(row_contents.begin(), row_contents.end(), [&](dcon::leader_id a, dcon::leader_id b) {
-					auto av = state.world.leader_trait_get_reliability(military::get_leader_background_wrapper(state, a)) + state.world.leader_trait_get_reliability(state.world.leader_get_personality(a));
-					auto bv = state.world.leader_trait_get_reliability(military::get_leader_background_wrapper(state, b)) + state.world.leader_trait_get_reliability(state.world.leader_get_personality(b));
+					auto av = state.world.leader_trait_get_reliability(military::get_leader_background_wrapper(state, a)) + state.world.leader_trait_get_reliability(military::get_leader_personality_wrapper(state, a));
+					auto bv = state.world.leader_trait_get_reliability(military::get_leader_background_wrapper(state, b)) + state.world.leader_trait_get_reliability(military::get_leader_personality_wrapper(state, b));
 					if(av != bv)
 						return av > bv;
 					else
@@ -556,8 +556,8 @@ public:
 				break;
 			case leader_select_sort::org:
 				std::sort(row_contents.begin(), row_contents.end(), [&](dcon::leader_id a, dcon::leader_id b) {
-					auto av = state.world.leader_trait_get_organisation(military::get_leader_background_wrapper(state, a)) + state.world.leader_trait_get_organisation(state.world.leader_get_personality(a));
-					auto bv = state.world.leader_trait_get_organisation(military::get_leader_background_wrapper(state, b)) + state.world.leader_trait_get_organisation(state.world.leader_get_personality(b));
+					auto av = state.world.leader_trait_get_organisation(military::get_leader_background_wrapper(state, a)) + state.world.leader_trait_get_organisation(military::get_leader_personality_wrapper(state, a));
+					auto bv = state.world.leader_trait_get_organisation(military::get_leader_background_wrapper(state, b)) + state.world.leader_trait_get_organisation(military::get_leader_personality_wrapper(state, b));
 					if(av != bv)
 						return av > bv;
 					else
@@ -566,8 +566,8 @@ public:
 				break;
 			case leader_select_sort::speed:
 				std::sort(row_contents.begin(), row_contents.end(), [&](dcon::leader_id a, dcon::leader_id b) {
-					auto av = state.world.leader_trait_get_speed(military::get_leader_background_wrapper(state, a)) + state.world.leader_trait_get_speed(state.world.leader_get_personality(a));
-					auto bv = state.world.leader_trait_get_speed(military::get_leader_background_wrapper(state, b)) + state.world.leader_trait_get_speed(state.world.leader_get_personality(b));
+					auto av = state.world.leader_trait_get_speed(military::get_leader_background_wrapper(state, a)) + state.world.leader_trait_get_speed(military::get_leader_personality_wrapper(state, a));
+					auto bv = state.world.leader_trait_get_speed(military::get_leader_background_wrapper(state, b)) + state.world.leader_trait_get_speed(military::get_leader_personality_wrapper(state, b));
 					if(av != bv)
 						return av > bv;
 					else
@@ -576,8 +576,8 @@ public:
 				break;
 			case leader_select_sort::experience:
 				std::sort(row_contents.begin(), row_contents.end(), [&](dcon::leader_id a, dcon::leader_id b) {
-					auto av = state.world.leader_trait_get_experience(military::get_leader_background_wrapper(state, a)) + state.world.leader_trait_get_experience(state.world.leader_get_personality(a));
-					auto bv = state.world.leader_trait_get_experience(military::get_leader_background_wrapper(state, b)) + state.world.leader_trait_get_experience(state.world.leader_get_personality(b));
+					auto av = state.world.leader_trait_get_experience(military::get_leader_background_wrapper(state, a)) + state.world.leader_trait_get_experience(military::get_leader_personality_wrapper(state, a));
+					auto bv = state.world.leader_trait_get_experience(military::get_leader_background_wrapper(state, b)) + state.world.leader_trait_get_experience(military::get_leader_personality_wrapper(state, b));
 					if(av != bv)
 						return av > bv;
 					else

--- a/src/gui/gui_leader_select.hpp
+++ b/src/gui/gui_leader_select.hpp
@@ -74,168 +74,128 @@ public:
 class passive_leader_attack : public  color_text_element {
 	void on_update(sys::state& state) noexcept override {
 		dcon::leader_id lid = retrieve<dcon::leader_id>(state, parent);
-		if(lid) {
-			auto attack = state.world.leader_trait_get_attack(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_attack(military::get_leader_personality_wrapper(state, lid));
-			if(attack > 0) {
-				set_text(state, std::string("+") + text::format_float(attack, 2));
-				color = text::text_color::dark_green;
-			} else if(attack == 0) {
-				set_text(state, "0");
-				color = text::text_color::black;
-			} else {
-				set_text(state, text::format_float(attack, 2));
-				color = text::text_color::red;
-			}
-		} else {
+		auto attack = state.world.leader_trait_get_attack(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_attack(military::get_leader_personality_wrapper(state, lid));
+		if(attack > 0) {
+			set_text(state, std::string("+") + text::format_float(attack, 2));
+			color = text::text_color::dark_green;
+		} else if(attack == 0) {
 			set_text(state, "0");
 			color = text::text_color::black;
+		} else {
+			set_text(state, text::format_float(attack, 2));
+			color = text::text_color::red;
 		}
 	}
 };
 class passive_leader_defense : public  color_text_element {
 	void on_update(sys::state& state) noexcept override {
 		dcon::leader_id lid = retrieve<dcon::leader_id>(state, parent);
-		if(lid) {
-			auto v = state.world.leader_trait_get_defense(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_defense(military::get_leader_personality_wrapper(state, lid));
-			if(v > 0) {
-				set_text(state, std::string("+") + text::format_float(v, 2));
-				color = text::text_color::dark_green;
-			} else if(v == 0) {
-				set_text(state, "0");
-				color = text::text_color::black;
-			} else {
-				set_text(state, text::format_float(v, 2));
-				color = text::text_color::red;
-			}
-		} else {
+		auto v = state.world.leader_trait_get_defense(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_defense(military::get_leader_personality_wrapper(state, lid));
+		if(v > 0) {
+			set_text(state, std::string("+") + text::format_float(v, 2));
+			color = text::text_color::dark_green;
+		} else if(v == 0) {
 			set_text(state, "0");
 			color = text::text_color::black;
+		} else {
+			set_text(state, text::format_float(v, 2));
+			color = text::text_color::red;
 		}
 	}
 };
 class passive_leader_org : public  color_text_element {
 	void on_update(sys::state& state) noexcept override {
 		dcon::leader_id lid = retrieve<dcon::leader_id>(state, parent);
-		if(lid) {
-			auto v = state.world.leader_trait_get_organisation(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_organisation(military::get_leader_personality_wrapper(state, lid));
-			if(v > 0) {
-				set_text(state, std::string("+") + text::format_float(v, 2));
-				color = text::text_color::dark_green;
-			} else if(v == 0) {
-				set_text(state, "0");
-				color = text::text_color::black;
-			} else {
-				set_text(state, text::format_float(v, 2));
-				color = text::text_color::red;
-			}
-		} else {
+		auto v = state.world.leader_trait_get_organisation(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_organisation(military::get_leader_personality_wrapper(state, lid));
+		if(v > 0) {
+			set_text(state, std::string("+") + text::format_float(v, 2));
+			color = text::text_color::dark_green;
+		} else if(v == 0) {
 			set_text(state, "0");
 			color = text::text_color::black;
+		} else {
+			set_text(state, text::format_float(v, 2));
+			color = text::text_color::red;
 		}
 	}
 };
 class passive_leader_morale : public  color_text_element {
 	void on_update(sys::state& state) noexcept override {
 		dcon::leader_id lid = retrieve<dcon::leader_id>(state, parent);
-		if(lid) {
-			auto v = state.world.leader_trait_get_morale(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_morale(military::get_leader_personality_wrapper(state, lid));
-			if(v > 0) {
-				set_text(state, std::string("+") + text::format_float(v, 2));
-				color = text::text_color::dark_green;
-			} else if(v == 0) {
-				set_text(state, "0");
-				color = text::text_color::black;
-			} else {
-				set_text(state, text::format_float(v, 2));
-				color = text::text_color::red;
-			}
-		} else {
+		auto v = state.world.leader_trait_get_morale(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_morale(military::get_leader_personality_wrapper(state, lid));
+		if(v > 0) {
+			set_text(state, std::string("+") + text::format_float(v, 2));
+			color = text::text_color::dark_green;
+		} else if(v == 0) {
 			set_text(state, "0");
 			color = text::text_color::black;
+		} else {
+			set_text(state, text::format_float(v, 2));
+			color = text::text_color::red;
 		}
 	}
 };
 class passive_leader_speed : public  color_text_element {
 	void on_update(sys::state& state) noexcept override {
 		dcon::leader_id lid = retrieve<dcon::leader_id>(state, parent);
-		if(lid) {
-			auto v = state.world.leader_trait_get_speed(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_speed(military::get_leader_personality_wrapper(state, lid));
-			if(v > 0) {
-				set_text(state, std::string("+") + text::format_float(v, 2));
-				color = text::text_color::dark_green;
-			} else if(v == 0) {
-				set_text(state, "0");
-				color = text::text_color::black;
-			} else {
-				set_text(state, text::format_float(v, 2));
-				color = text::text_color::red;
-			}
-		} else {
+		auto v = state.world.leader_trait_get_speed(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_speed(military::get_leader_personality_wrapper(state, lid));
+		if(v > 0) {
+			set_text(state, std::string("+") + text::format_float(v, 2));
+			color = text::text_color::dark_green;
+		} else if(v == 0) {
 			set_text(state, "0");
 			color = text::text_color::black;
+		} else {
+			set_text(state, text::format_float(v, 2));
+			color = text::text_color::red;
 		}
 	}
 };
 class passive_leader_recon : public  color_text_element {
 	void on_update(sys::state& state) noexcept override {
 		dcon::leader_id lid = retrieve<dcon::leader_id>(state, parent);
-		if(lid) {
-			auto v = state.world.leader_trait_get_reconnaissance(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_reconnaissance(military::get_leader_personality_wrapper(state, lid));
-			if(v > 0) {
-				set_text(state, std::string("+") + text::format_float(v, 2));
-				color = text::text_color::dark_green;
-			} else if(v == 0) {
-				set_text(state, "0");
-				color = text::text_color::black;
-			} else {
-				set_text(state, text::format_float(v, 2));
-				color = text::text_color::red;
-			}
-		} else {
+		auto v = state.world.leader_trait_get_reconnaissance(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_reconnaissance(military::get_leader_personality_wrapper(state, lid));
+		if(v > 0) {
+			set_text(state, std::string("+") + text::format_float(v, 2));
+			color = text::text_color::dark_green;
+		} else if(v == 0) {
 			set_text(state, "0");
 			color = text::text_color::black;
+		} else {
+			set_text(state, text::format_float(v, 2));
+			color = text::text_color::red;
 		}
 	}
 };
 class passive_leader_reliability : public  color_text_element {
 	void on_update(sys::state& state) noexcept override {
 		dcon::leader_id lid = retrieve<dcon::leader_id>(state, parent);
-		if(lid) {
-			auto v = state.world.leader_trait_get_reliability(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_reliability(military::get_leader_personality_wrapper(state, lid));
-			if(v > 0) {
-				set_text(state, std::string("+") + text::format_float(v, 2));
-				color = text::text_color::dark_green;
-			} else if(v == 0) {
-				set_text(state, "0");
-				color = text::text_color::black;
-			} else {
-				set_text(state, text::format_float(v, 2));
-				color = text::text_color::red;
-			}
-		} else {
+		auto v = state.world.leader_trait_get_reliability(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_reliability(military::get_leader_personality_wrapper(state, lid));
+		if(v > 0) {
+			set_text(state, std::string("+") + text::format_float(v, 2));
+			color = text::text_color::dark_green;
+		} else if(v == 0) {
 			set_text(state, "0");
 			color = text::text_color::black;
+		} else {
+			set_text(state, text::format_float(v, 2));
+			color = text::text_color::red;
 		}
 	}
 };
 class passive_leader_exp : public  color_text_element {
 	void on_update(sys::state& state) noexcept override {
 		dcon::leader_id lid = retrieve<dcon::leader_id>(state, parent);
-		if(lid) {
-			auto v = state.world.leader_trait_get_experience(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_experience(military::get_leader_personality_wrapper(state, lid));
-			if(v > 0) {
-				set_text(state, std::string("+") + text::format_float(v, 2));
-				color = text::text_color::dark_green;
-			} else if(v == 0) {
-				set_text(state, "0");
-				color = text::text_color::black;
-			} else {
-				set_text(state, text::format_float(v, 2));
-				color = text::text_color::red;
-			}
-		} else {
+		auto v = state.world.leader_trait_get_experience(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_experience(military::get_leader_personality_wrapper(state, lid));
+		if(v > 0) {
+			set_text(state, std::string("+") + text::format_float(v, 2));
+			color = text::text_color::dark_green;
+		} else if(v == 0) {
 			set_text(state, "0");
 			color = text::text_color::black;
+		} else {
+			set_text(state, text::format_float(v, 2));
+			color = text::text_color::red;
 		}
 	}
 };

--- a/src/gui/gui_leader_select.hpp
+++ b/src/gui/gui_leader_select.hpp
@@ -75,7 +75,7 @@ class passive_leader_attack : public  color_text_element {
 	void on_update(sys::state& state) noexcept override {
 		dcon::leader_id lid = retrieve<dcon::leader_id>(state, parent);
 		if(lid) {
-			auto attack = state.world.leader_trait_get_attack(state.world.leader_get_background(lid)) + state.world.leader_trait_get_attack(state.world.leader_get_personality(lid));
+			auto attack = state.world.leader_trait_get_attack(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_attack(state.world.leader_get_personality(lid));
 			if(attack > 0) {
 				set_text(state, std::string("+") + text::format_float(attack, 2));
 				color = text::text_color::dark_green;
@@ -96,7 +96,7 @@ class passive_leader_defense : public  color_text_element {
 	void on_update(sys::state& state) noexcept override {
 		dcon::leader_id lid = retrieve<dcon::leader_id>(state, parent);
 		if(lid) {
-			auto v = state.world.leader_trait_get_defense(state.world.leader_get_background(lid)) + state.world.leader_trait_get_defense(state.world.leader_get_personality(lid));
+			auto v = state.world.leader_trait_get_defense(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_defense(state.world.leader_get_personality(lid));
 			if(v > 0) {
 				set_text(state, std::string("+") + text::format_float(v, 2));
 				color = text::text_color::dark_green;
@@ -117,7 +117,7 @@ class passive_leader_org : public  color_text_element {
 	void on_update(sys::state& state) noexcept override {
 		dcon::leader_id lid = retrieve<dcon::leader_id>(state, parent);
 		if(lid) {
-			auto v = state.world.leader_trait_get_organisation(state.world.leader_get_background(lid)) + state.world.leader_trait_get_organisation(state.world.leader_get_personality(lid));
+			auto v = state.world.leader_trait_get_organisation(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_organisation(state.world.leader_get_personality(lid));
 			if(v > 0) {
 				set_text(state, std::string("+") + text::format_float(v, 2));
 				color = text::text_color::dark_green;
@@ -138,7 +138,7 @@ class passive_leader_morale : public  color_text_element {
 	void on_update(sys::state& state) noexcept override {
 		dcon::leader_id lid = retrieve<dcon::leader_id>(state, parent);
 		if(lid) {
-			auto v = state.world.leader_trait_get_morale(state.world.leader_get_background(lid)) + state.world.leader_trait_get_morale(state.world.leader_get_personality(lid));
+			auto v = state.world.leader_trait_get_morale(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_morale(state.world.leader_get_personality(lid));
 			if(v > 0) {
 				set_text(state, std::string("+") + text::format_float(v, 2));
 				color = text::text_color::dark_green;
@@ -159,7 +159,7 @@ class passive_leader_speed : public  color_text_element {
 	void on_update(sys::state& state) noexcept override {
 		dcon::leader_id lid = retrieve<dcon::leader_id>(state, parent);
 		if(lid) {
-			auto v = state.world.leader_trait_get_speed(state.world.leader_get_background(lid)) + state.world.leader_trait_get_speed(state.world.leader_get_personality(lid));
+			auto v = state.world.leader_trait_get_speed(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_speed(state.world.leader_get_personality(lid));
 			if(v > 0) {
 				set_text(state, std::string("+") + text::format_float(v, 2));
 				color = text::text_color::dark_green;
@@ -180,7 +180,7 @@ class passive_leader_recon : public  color_text_element {
 	void on_update(sys::state& state) noexcept override {
 		dcon::leader_id lid = retrieve<dcon::leader_id>(state, parent);
 		if(lid) {
-			auto v = state.world.leader_trait_get_reconnaissance(state.world.leader_get_background(lid)) + state.world.leader_trait_get_reconnaissance(state.world.leader_get_personality(lid));
+			auto v = state.world.leader_trait_get_reconnaissance(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_reconnaissance(state.world.leader_get_personality(lid));
 			if(v > 0) {
 				set_text(state, std::string("+") + text::format_float(v, 2));
 				color = text::text_color::dark_green;
@@ -201,7 +201,7 @@ class passive_leader_reliability : public  color_text_element {
 	void on_update(sys::state& state) noexcept override {
 		dcon::leader_id lid = retrieve<dcon::leader_id>(state, parent);
 		if(lid) {
-			auto v = state.world.leader_trait_get_reliability(state.world.leader_get_background(lid)) + state.world.leader_trait_get_reliability(state.world.leader_get_personality(lid));
+			auto v = state.world.leader_trait_get_reliability(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_reliability(state.world.leader_get_personality(lid));
 			if(v > 0) {
 				set_text(state, std::string("+") + text::format_float(v, 2));
 				color = text::text_color::dark_green;
@@ -222,7 +222,7 @@ class passive_leader_exp : public  color_text_element {
 	void on_update(sys::state& state) noexcept override {
 		dcon::leader_id lid = retrieve<dcon::leader_id>(state, parent);
 		if(lid) {
-			auto v = state.world.leader_trait_get_experience(state.world.leader_get_background(lid)) + state.world.leader_trait_get_experience(state.world.leader_get_personality(lid));
+			auto v = state.world.leader_trait_get_experience(military::get_leader_background_wrapper(state, lid)) + state.world.leader_trait_get_experience(state.world.leader_get_personality(lid));
 			if(v > 0) {
 				set_text(state, std::string("+") + text::format_float(v, 2));
 				color = text::text_color::dark_green;
@@ -506,8 +506,8 @@ public:
 		switch(sort_type) {
 			case leader_select_sort::attack:
 				std::sort(row_contents.begin(), row_contents.end(), [&](dcon::leader_id a, dcon::leader_id b) {
-					auto av = state.world.leader_trait_get_attack(state.world.leader_get_background(a)) + state.world.leader_trait_get_attack(state.world.leader_get_personality(a));
-					auto bv = state.world.leader_trait_get_attack(state.world.leader_get_background(b)) + state.world.leader_trait_get_attack(state.world.leader_get_personality(b));
+					auto av = state.world.leader_trait_get_attack(military::get_leader_background_wrapper(state, a)) + state.world.leader_trait_get_attack(state.world.leader_get_personality(a));
+					auto bv = state.world.leader_trait_get_attack(military::get_leader_background_wrapper(state, b)) + state.world.leader_trait_get_attack(state.world.leader_get_personality(b));
 					if(av != bv)
 						return av > bv;
 					else
@@ -516,8 +516,8 @@ public:
 				break;
 			case leader_select_sort::defense:
 				std::sort(row_contents.begin(), row_contents.end(), [&](dcon::leader_id a, dcon::leader_id b) {
-					auto av = state.world.leader_trait_get_defense(state.world.leader_get_background(a)) + state.world.leader_trait_get_defense(state.world.leader_get_personality(a));
-					auto bv = state.world.leader_trait_get_defense(state.world.leader_get_background(b)) + state.world.leader_trait_get_defense(state.world.leader_get_personality(b));
+					auto av = state.world.leader_trait_get_defense(military::get_leader_background_wrapper(state, a)) + state.world.leader_trait_get_defense(state.world.leader_get_personality(a));
+					auto bv = state.world.leader_trait_get_defense(military::get_leader_background_wrapper(state, b)) + state.world.leader_trait_get_defense(state.world.leader_get_personality(b));
 					if(av != bv)
 						return av > bv;
 					else
@@ -526,8 +526,8 @@ public:
 				break;
 			case leader_select_sort::recon:
 				std::sort(row_contents.begin(), row_contents.end(), [&](dcon::leader_id a, dcon::leader_id b) {
-					auto av = state.world.leader_trait_get_reconnaissance(state.world.leader_get_background(a)) + state.world.leader_trait_get_reconnaissance(state.world.leader_get_personality(a));
-					auto bv = state.world.leader_trait_get_reconnaissance(state.world.leader_get_background(b)) + state.world.leader_trait_get_reconnaissance(state.world.leader_get_personality(b));
+					auto av = state.world.leader_trait_get_reconnaissance(military::get_leader_background_wrapper(state, a)) + state.world.leader_trait_get_reconnaissance(state.world.leader_get_personality(a));
+					auto bv = state.world.leader_trait_get_reconnaissance(military::get_leader_background_wrapper(state, b)) + state.world.leader_trait_get_reconnaissance(state.world.leader_get_personality(b));
 					if(av != bv)
 						return av > bv;
 					else
@@ -536,8 +536,8 @@ public:
 				break;
 			case leader_select_sort::morale:
 				std::sort(row_contents.begin(), row_contents.end(), [&](dcon::leader_id a, dcon::leader_id b) {
-					auto av = state.world.leader_trait_get_morale(state.world.leader_get_background(a)) + state.world.leader_trait_get_morale(state.world.leader_get_personality(a));
-					auto bv = state.world.leader_trait_get_morale(state.world.leader_get_background(b)) + state.world.leader_trait_get_morale(state.world.leader_get_personality(b));
+					auto av = state.world.leader_trait_get_morale(military::get_leader_background_wrapper(state, a)) + state.world.leader_trait_get_morale(state.world.leader_get_personality(a));
+					auto bv = state.world.leader_trait_get_morale(military::get_leader_background_wrapper(state, b)) + state.world.leader_trait_get_morale(state.world.leader_get_personality(b));
 					if(av != bv)
 						return av > bv;
 					else
@@ -546,8 +546,8 @@ public:
 				break;
 			case leader_select_sort::reliability:
 				std::sort(row_contents.begin(), row_contents.end(), [&](dcon::leader_id a, dcon::leader_id b) {
-					auto av = state.world.leader_trait_get_reliability(state.world.leader_get_background(a)) + state.world.leader_trait_get_reliability(state.world.leader_get_personality(a));
-					auto bv = state.world.leader_trait_get_reliability(state.world.leader_get_background(b)) + state.world.leader_trait_get_reliability(state.world.leader_get_personality(b));
+					auto av = state.world.leader_trait_get_reliability(military::get_leader_background_wrapper(state, a)) + state.world.leader_trait_get_reliability(state.world.leader_get_personality(a));
+					auto bv = state.world.leader_trait_get_reliability(military::get_leader_background_wrapper(state, b)) + state.world.leader_trait_get_reliability(state.world.leader_get_personality(b));
 					if(av != bv)
 						return av > bv;
 					else
@@ -556,8 +556,8 @@ public:
 				break;
 			case leader_select_sort::org:
 				std::sort(row_contents.begin(), row_contents.end(), [&](dcon::leader_id a, dcon::leader_id b) {
-					auto av = state.world.leader_trait_get_organisation(state.world.leader_get_background(a)) + state.world.leader_trait_get_organisation(state.world.leader_get_personality(a));
-					auto bv = state.world.leader_trait_get_organisation(state.world.leader_get_background(b)) + state.world.leader_trait_get_organisation(state.world.leader_get_personality(b));
+					auto av = state.world.leader_trait_get_organisation(military::get_leader_background_wrapper(state, a)) + state.world.leader_trait_get_organisation(state.world.leader_get_personality(a));
+					auto bv = state.world.leader_trait_get_organisation(military::get_leader_background_wrapper(state, b)) + state.world.leader_trait_get_organisation(state.world.leader_get_personality(b));
 					if(av != bv)
 						return av > bv;
 					else
@@ -566,8 +566,8 @@ public:
 				break;
 			case leader_select_sort::speed:
 				std::sort(row_contents.begin(), row_contents.end(), [&](dcon::leader_id a, dcon::leader_id b) {
-					auto av = state.world.leader_trait_get_speed(state.world.leader_get_background(a)) + state.world.leader_trait_get_speed(state.world.leader_get_personality(a));
-					auto bv = state.world.leader_trait_get_speed(state.world.leader_get_background(b)) + state.world.leader_trait_get_speed(state.world.leader_get_personality(b));
+					auto av = state.world.leader_trait_get_speed(military::get_leader_background_wrapper(state, a)) + state.world.leader_trait_get_speed(state.world.leader_get_personality(a));
+					auto bv = state.world.leader_trait_get_speed(military::get_leader_background_wrapper(state, b)) + state.world.leader_trait_get_speed(state.world.leader_get_personality(b));
 					if(av != bv)
 						return av > bv;
 					else
@@ -576,8 +576,8 @@ public:
 				break;
 			case leader_select_sort::experience:
 				std::sort(row_contents.begin(), row_contents.end(), [&](dcon::leader_id a, dcon::leader_id b) {
-					auto av = state.world.leader_trait_get_experience(state.world.leader_get_background(a)) + state.world.leader_trait_get_experience(state.world.leader_get_personality(a));
-					auto bv = state.world.leader_trait_get_experience(state.world.leader_get_background(b)) + state.world.leader_trait_get_experience(state.world.leader_get_personality(b));
+					auto av = state.world.leader_trait_get_experience(military::get_leader_background_wrapper(state, a)) + state.world.leader_trait_get_experience(state.world.leader_get_personality(a));
+					auto bv = state.world.leader_trait_get_experience(military::get_leader_background_wrapper(state, b)) + state.world.leader_trait_get_experience(state.world.leader_get_personality(b));
 					if(av != bv)
 						return av > bv;
 					else

--- a/src/gui/gui_leader_tooltip.cpp
+++ b/src/gui/gui_leader_tooltip.cpp
@@ -2,7 +2,7 @@
 
 namespace ui {
 void display_leader_attributes(sys::state& state, dcon::leader_id lid, text::layout_base& contents, int32_t indent) {
-	auto leader_per = state.world.leader_get_personality(lid);
+	auto leader_per = military::get_leader_personality_wrapper(state, lid);
 	auto leader_bak = military::get_leader_background_wrapper(state, lid);
 	auto attack = state.world.leader_trait_get_attack(leader_per) + state.world.leader_trait_get_attack(leader_bak);
 	auto organisation = state.world.leader_trait_get_organisation(leader_per) + state.world.leader_trait_get_organisation(leader_bak);

--- a/src/gui/gui_leader_tooltip.cpp
+++ b/src/gui/gui_leader_tooltip.cpp
@@ -3,7 +3,7 @@
 namespace ui {
 void display_leader_attributes(sys::state& state, dcon::leader_id lid, text::layout_base& contents, int32_t indent) {
 	auto leader_per = state.world.leader_get_personality(lid);
-	auto leader_bak = state.world.leader_get_background(lid);
+	auto leader_bak = military::get_leader_background_wrapper(state, lid);
 	auto attack = state.world.leader_trait_get_attack(leader_per) + state.world.leader_trait_get_attack(leader_bak);
 	auto organisation = state.world.leader_trait_get_organisation(leader_per) + state.world.leader_trait_get_organisation(leader_bak);
 	auto morale = state.world.leader_trait_get_morale(leader_per) + state.world.leader_trait_get_morale(leader_bak);

--- a/src/gui/gui_leader_tooltip.cpp
+++ b/src/gui/gui_leader_tooltip.cpp
@@ -113,10 +113,15 @@ void display_leader_attributes(sys::state& state, dcon::leader_id lid, text::lay
 
 void display_leader_full(sys::state& state, dcon::leader_id lid, text::layout_base& contents, int32_t indent) {
 	auto lname = state.world.leader_get_name(lid);
-	auto resolved = state.to_string_view(lname);
-
+	//auto resolved = state.to_string_view(lname);
 	auto box = text::open_layout_box(contents, indent);
-	text::add_to_layout_box(state, contents, box, resolved);
+	if(bool(lname)) {
+		text::add_to_layout_box(state, contents, box, state.to_string_view(lname));
+	}
+	// if no leader
+	else {
+		text::add_to_layout_box(state, contents, box, state.lookup_key("no_leader"));
+	}
 	text::close_layout_box(contents, box);
 
 	display_leader_attributes(state, lid, contents, indent + 15);

--- a/src/gui/gui_naval_combat.hpp
+++ b/src/gui/gui_naval_combat.hpp
@@ -491,7 +491,7 @@ class nc_defender_combat_modifiers : public overlapping_listbox_element_base<lc_
 		auto defender_dice = (both_dice >> 4) & 0x0F;
 
 		auto defender_per = state.world.leader_get_personality(state.world.naval_battle_get_admiral_from_defending_admiral(b));
-		auto defender_bg = state.world.leader_get_background(state.world.naval_battle_get_admiral_from_defending_admiral(b));
+		auto defender_bg = military::get_leader_background_wrapper(state, state.world.naval_battle_get_admiral_from_defending_admiral(b));
 
 		auto defence_bonus =
 			int32_t(state.world.leader_trait_get_defense(defender_per) + state.world.leader_trait_get_defense(defender_bg));
@@ -518,7 +518,7 @@ class nc_attacker_combat_modifiers : public overlapping_listbox_element_base<lc_
 		auto attacker_dice = both_dice & 0x0F;
 
 		auto attacker_per = state.world.leader_get_personality(state.world.naval_battle_get_admiral_from_attacking_admiral(b));
-		auto attacker_bg = state.world.leader_get_background(state.world.naval_battle_get_admiral_from_attacking_admiral(b));
+		auto attacker_bg = military::get_leader_background_wrapper(state, state.world.naval_battle_get_admiral_from_attacking_admiral(b));
 
 		auto attack_bonus =
 			int32_t(state.world.leader_trait_get_attack(attacker_per) + state.world.leader_trait_get_attack(attacker_bg));

--- a/src/gui/gui_naval_combat.hpp
+++ b/src/gui/gui_naval_combat.hpp
@@ -102,7 +102,7 @@ public:
 			auto name = state.to_string_view(state.world.leader_get_name(lid));
 			set_text(state, std::string(name));
 		} else {
-			set_text(state, "");
+			set_text(state, text::produce_simple_string(state, "no_leader"));
 		}
 	}
 };
@@ -116,7 +116,7 @@ public:
 			auto name = state.to_string_view(state.world.leader_get_name(lid));
 			set_text(state, std::string(name));
 		} else {
-			set_text(state, "");
+			set_text(state, text::produce_simple_string(state, "no_leader"));
 		}
 	}
 };

--- a/src/gui/gui_naval_combat.hpp
+++ b/src/gui/gui_naval_combat.hpp
@@ -43,11 +43,10 @@ class nc_attacker_leader_img : public image_element_base {
 	void update_tooltip(sys::state& state, int32_t x, int32_t y, text::columnar_layout& contents) noexcept override {
 		auto b = retrieve<dcon::naval_battle_id>(state, parent);
 		auto lid = state.world.naval_battle_get_admiral_from_attacking_admiral(b);
-
-		if(lid)
-			display_leader_attributes(state, lid, contents, 0);
-		else
+		if(!lid) {
 			text::add_line(state, contents, "no_leader");
+		}
+		display_leader_attributes(state, lid, contents, 0);
 	}
 };
 class nc_defending_leader_img : public image_element_base {
@@ -86,11 +85,10 @@ class nc_defending_leader_img : public image_element_base {
 	void update_tooltip(sys::state& state, int32_t x, int32_t y, text::columnar_layout& contents) noexcept override {
 		auto b = retrieve<dcon::naval_battle_id>(state, parent);
 		auto lid = state.world.naval_battle_get_admiral_from_defending_admiral(b);
-
-		if(lid)
-			display_leader_attributes(state, lid, contents, 0);
-		else
+		if(!lid) {
 			text::add_line(state, contents, "no_leader");
+		}
+		display_leader_attributes(state, lid, contents, 0);
 	}
 };
 
@@ -756,11 +754,10 @@ class nc_our_leader_img : public image_element_base {
 		military::naval_battle_report* report = retrieve< military::naval_battle_report*>(state, parent);
 		bool we_are_attacker = (report->attacker_won == report->player_on_winning_side);
 		dcon::leader_id lid = we_are_attacker ? report->attacking_admiral : report->defending_admiral;
-
-		if(lid)
-			display_leader_attributes(state, lid, contents, 0);
-		else
+		if(!lid) {
 			text::add_line(state, contents, "no_leader");
+		}
+		display_leader_attributes(state, lid, contents, 0);
 	}
 };
 class nc_our_leader_name : public simple_text_element_base {
@@ -816,11 +813,10 @@ class nc_their_leader_img : public image_element_base {
 		military::naval_battle_report* report = retrieve< military::naval_battle_report*>(state, parent);
 		bool we_are_attacker = (report->attacker_won == report->player_on_winning_side);
 		dcon::leader_id lid = !we_are_attacker ? report->attacking_admiral : report->defending_admiral;
-
-		if(lid)
-			display_leader_attributes(state, lid, contents, 0);
-		else
+		if(!lid) {
 			text::add_line(state, contents, "no_leader");
+		}
+		display_leader_attributes(state, lid, contents, 0);
 	}
 };
 class nc_their_leader_name : public simple_text_element_base {

--- a/src/gui/gui_naval_combat.hpp
+++ b/src/gui/gui_naval_combat.hpp
@@ -490,7 +490,7 @@ class nc_defender_combat_modifiers : public overlapping_listbox_element_base<lc_
 
 		auto defender_dice = (both_dice >> 4) & 0x0F;
 
-		auto defender_per = state.world.leader_get_personality(state.world.naval_battle_get_admiral_from_defending_admiral(b));
+		auto defender_per = military::get_leader_personality_wrapper(state, state.world.naval_battle_get_admiral_from_defending_admiral(b));
 		auto defender_bg = military::get_leader_background_wrapper(state, state.world.naval_battle_get_admiral_from_defending_admiral(b));
 
 		auto defence_bonus =
@@ -517,7 +517,7 @@ class nc_attacker_combat_modifiers : public overlapping_listbox_element_base<lc_
 		auto both_dice = state.world.naval_battle_get_dice_rolls(b);
 		auto attacker_dice = both_dice & 0x0F;
 
-		auto attacker_per = state.world.leader_get_personality(state.world.naval_battle_get_admiral_from_attacking_admiral(b));
+		auto attacker_per = military::get_leader_personality_wrapper(state, state.world.naval_battle_get_admiral_from_attacking_admiral(b));
 		auto attacker_bg = military::get_leader_background_wrapper(state, state.world.naval_battle_get_admiral_from_attacking_admiral(b));
 
 		auto attack_bonus =

--- a/src/gui/gui_unit_panel.hpp
+++ b/src/gui/gui_unit_panel.hpp
@@ -232,8 +232,7 @@ public:
 		} else {
 			lid = state.world.navy_get_admiral_from_navy_leadership(unit);
 		}
-		if(lid)
-			display_leader_full(state, lid, contents, 0);
+		display_leader_full(state, lid, contents, 0);
 	}
 	
 
@@ -319,8 +318,7 @@ public:
 		} else {
 			lid = state.world.navy_get_admiral_from_navy_leadership(unit);
 		}
-		if(lid)
-			display_leader_full(state, lid, contents, 0);
+		display_leader_full(state, lid, contents, 0);
 	}
 
 
@@ -2696,8 +2694,7 @@ public:
 		} else if(std::holds_alternative<dcon::navy_id>(foru)) {
 			lid = state.world.navy_get_admiral_from_navy_leadership(std::get<dcon::navy_id>(foru));
 		}
-		if(lid)
-			display_leader_full(state, lid, contents, 0);
+		display_leader_full(state, lid, contents, 0);
 	}
 
 

--- a/src/gui/topbar_subwindows/military_subwindows/gui_leaders_window.hpp
+++ b/src/gui/topbar_subwindows/military_subwindows/gui_leaders_window.hpp
@@ -106,7 +106,7 @@ public:
 		}
 
 		if(background) {
-			auto background_id = state.world.leader_get_background(content).get_name();
+			auto background_id = fatten(state.world, military::get_leader_background_wrapper(state, content)).get_name();
 			auto background_content = text::produce_simple_string(state, background_id);
 			background->set_text(state, background_content);
 		}

--- a/src/gui/topbar_subwindows/military_subwindows/gui_leaders_window.hpp
+++ b/src/gui/topbar_subwindows/military_subwindows/gui_leaders_window.hpp
@@ -112,7 +112,7 @@ public:
 		}
 
 		if(personality) {
-			auto personality_id = state.world.leader_get_personality(content).get_name();
+			auto personality_id = fatten(state.world, military::get_leader_personality_wrapper(state, content)).get_name();
 			auto personality_content = text::produce_simple_string(state, personality_id);
 			personality->set_text(state, personality_content);
 		}

--- a/src/gui/topbar_subwindows/military_subwindows/gui_units_window.hpp
+++ b/src/gui/topbar_subwindows/military_subwindows/gui_units_window.hpp
@@ -206,8 +206,7 @@ class leader_in_army_img : public image_element_base {
 		} else {
 			lid = state.world.navy_get_admiral_from_navy_leadership(unit);
 		}
-		if(lid)
-			display_leader_full(state, lid, contents, 0);
+		display_leader_full(state, lid, contents, 0);
 	}
 };
 

--- a/src/military/military.cpp
+++ b/src/military/military.cpp
@@ -4334,7 +4334,7 @@ float effective_army_speed(sys::state& state, dcon::army_id a) {
 	 + 1)
 	*/
 	auto leader = state.world.army_get_general_from_army_leadership(a);
-	auto bg = state.world.leader_get_background(leader);
+	auto bg = get_leader_background_wrapper(state, leader);
 	auto per = state.world.leader_get_personality(leader);
 	auto leader_move = state.world.leader_trait_get_speed(bg) + state.world.leader_trait_get_speed(per);
 	return min_speed * (state.world.army_get_is_retreating(a) ? 2.0f : 1.0f) *
@@ -4352,7 +4352,7 @@ float effective_navy_speed(sys::state& state, dcon::navy_id n) {
 	}
 
 	auto leader = state.world.navy_get_admiral_from_navy_leadership(n);
-	auto bg = state.world.leader_get_background(leader);
+	auto bg = get_leader_background_wrapper(state, leader);
 	auto per = state.world.leader_get_personality(leader);
 	auto leader_move = state.world.leader_trait_get_speed(bg) + state.world.leader_trait_get_speed(per);
 	return min_speed * (state.world.navy_get_is_retreating(n) ? 2.0f : 1.0f) * (leader_move + 1.0f);
@@ -4845,7 +4845,7 @@ float get_leader_select_score(sys::state& state, dcon::leader_id l, bool is_atta
 	speed + attrition + experience / 2 + reconnaissance / 5  + reliability / 5) x (prestige + 1)
 	*/
 	auto per = state.world.leader_get_personality(l);
-	auto bak = state.world.leader_get_background(l);
+	auto bak = get_leader_background_wrapper(state, l);
 	// atk and def are both set to 0 initally, and will be set to its actual amount depending if on the on_attacking input param
 	// this makes it so for example if the leader is attacking, it will disregard all "defence" stats for the purposes of calculating the score
 	float atk = 0.f;
@@ -4918,7 +4918,7 @@ bool is_attacker_in_battle(sys::state& state, dcon::navy_id a) {
 
 // the wrapper will assign the proper background to a no_leader general if detected
 dcon::leader_trait_id get_leader_background_wrapper(sys::state& state, dcon::leader_id id) {
-	return (bool(id)) ? state.world.leader_get_background(id) : state.world.leader_get_background(dcon::leader_id(0));
+	return (bool(id)) ? state.world.leader_get_background(id) : state.military_definitions.first_background_trait;
 }
 
 
@@ -5859,7 +5859,7 @@ void update_land_battles(sys::state& state) {
 		auto terrain_bonus = state.world.province_get_modifier_values(location, sys::provincial_mod_offsets::defense);
 
 		auto attacker_per = state.world.leader_get_personality(state.world.land_battle_get_general_from_attacking_general(b));
-		auto attacker_bg = state.world.leader_get_background(state.world.land_battle_get_general_from_attacking_general(b));
+		auto attacker_bg = fatten(state.world, get_leader_background_wrapper(state, state.world.land_battle_get_general_from_attacking_general(b)));
 
 		auto attack_bonus =
 				int32_t(state.world.leader_trait_get_attack(attacker_per) + state.world.leader_trait_get_attack(attacker_bg));
@@ -5868,7 +5868,7 @@ void update_land_battles(sys::state& state) {
 			* (1.0f + state.world.leader_get_prestige(state.world.land_battle_get_general_from_attacking_general(b)) * state.defines.leader_prestige_to_max_org_factor);
 
 		auto defender_per = state.world.leader_get_personality(state.world.land_battle_get_general_from_defending_general(b));
-		auto defender_bg = state.world.leader_get_background(state.world.land_battle_get_general_from_defending_general(b));
+		auto defender_bg = get_leader_background_wrapper(state, state.world.land_battle_get_general_from_defending_general(b));
 
 		auto atk_leader_exp_mod = 1 + attacker_per.get_experience() + attacker_bg.get_experience();
 		auto def_leader_exp_mod = 1 + defender_per.get_experience() + defender_per.get_experience();
@@ -6382,7 +6382,7 @@ void update_naval_battles(sys::state& state) {
 		auto defender_dice = (both_dice >> 4) & 0x0F;
 
 		auto attacker_per = state.world.leader_get_personality(state.world.naval_battle_get_admiral_from_attacking_admiral(b));
-		auto attacker_bg = state.world.leader_get_background(state.world.naval_battle_get_admiral_from_attacking_admiral(b));
+		auto attacker_bg = fatten(state.world, get_leader_background_wrapper(state, state.world.naval_battle_get_admiral_from_attacking_admiral(b)));
 
 		auto attack_bonus =
 				int32_t(state.world.leader_trait_get_attack(attacker_per) + state.world.leader_trait_get_attack(attacker_bg));
@@ -6390,7 +6390,7 @@ void update_naval_battles(sys::state& state) {
 				1.0f + state.world.leader_trait_get_organisation(attacker_per) + state.world.leader_trait_get_organisation(attacker_bg);
 
 		auto defender_per = state.world.leader_get_personality(state.world.naval_battle_get_admiral_from_defending_admiral(b));
-		auto defender_bg = state.world.leader_get_background(state.world.naval_battle_get_admiral_from_defending_admiral(b));
+		auto defender_bg = get_leader_background_wrapper(state, state.world.naval_battle_get_admiral_from_defending_admiral(b));
 
 		auto atk_leader_exp_mod = 1 + attacker_per.get_experience() + attacker_bg.get_experience();
 		auto def_leader_exp_mod = 1 + defender_per.get_experience() + defender_per.get_experience();

--- a/src/military/military.cpp
+++ b/src/military/military.cpp
@@ -4922,7 +4922,7 @@ dcon::leader_trait_id get_leader_background_wrapper(sys::state& state, dcon::lea
 }
 // the wrapper will assign the proper personality to a no_leader general if detected
 dcon::leader_trait_id get_leader_personality_wrapper(sys::state& state, dcon::leader_id id) {
-	return (bool(id)) ? state.world.leader_get_personality(id) : state.military_definitions.first_personality_trait;
+	return (bool(id)) ? state.world.leader_get_personality(id) : dcon::leader_trait_id(0);
 }
 
 

--- a/src/military/military.cpp
+++ b/src/military/military.cpp
@@ -4335,7 +4335,7 @@ float effective_army_speed(sys::state& state, dcon::army_id a) {
 	*/
 	auto leader = state.world.army_get_general_from_army_leadership(a);
 	auto bg = get_leader_background_wrapper(state, leader);
-	auto per = state.world.leader_get_personality(leader);
+	auto per = get_leader_personality_wrapper(state, leader);
 	auto leader_move = state.world.leader_trait_get_speed(bg) + state.world.leader_trait_get_speed(per);
 	return min_speed * (state.world.army_get_is_retreating(a) ? 2.0f : 1.0f) *
 				 (1.0f + state.world.province_get_building_level(state.world.army_get_location_from_army_location(a), uint8_t(economy::province_building_type::railroad)) *
@@ -4353,7 +4353,7 @@ float effective_navy_speed(sys::state& state, dcon::navy_id n) {
 
 	auto leader = state.world.navy_get_admiral_from_navy_leadership(n);
 	auto bg = get_leader_background_wrapper(state, leader);
-	auto per = state.world.leader_get_personality(leader);
+	auto per = get_leader_personality_wrapper(state, leader);
 	auto leader_move = state.world.leader_trait_get_speed(bg) + state.world.leader_trait_get_speed(per);
 	return min_speed * (state.world.navy_get_is_retreating(n) ? 2.0f : 1.0f) * (leader_move + 1.0f);
 }
@@ -4844,7 +4844,7 @@ float get_leader_select_score(sys::state& state, dcon::leader_id l, bool is_atta
 	value as determined by the following formula: (organization x 5 + attack + defend + morale +
 	speed + attrition + experience / 2 + reconnaissance / 5  + reliability / 5) x (prestige + 1)
 	*/
-	auto per = state.world.leader_get_personality(l);
+	auto per = get_leader_personality_wrapper(state, l);
 	auto bak = get_leader_background_wrapper(state, l);
 	// atk and def are both set to 0 initally, and will be set to its actual amount depending if on the on_attacking input param
 	// this makes it so for example if the leader is attacking, it will disregard all "defence" stats for the purposes of calculating the score
@@ -5862,7 +5862,7 @@ void update_land_battles(sys::state& state) {
 		auto location = state.world.land_battle_get_location_from_land_battle_location(b);
 		auto terrain_bonus = state.world.province_get_modifier_values(location, sys::provincial_mod_offsets::defense);
 
-		auto attacker_per = state.world.leader_get_personality(state.world.land_battle_get_general_from_attacking_general(b));
+ 		auto attacker_per = fatten(state.world, get_leader_personality_wrapper(state, state.world.land_battle_get_general_from_attacking_general(b)));
 		auto attacker_bg = fatten(state.world, get_leader_background_wrapper(state, state.world.land_battle_get_general_from_attacking_general(b)));
 
 		auto attack_bonus =
@@ -5871,8 +5871,8 @@ void update_land_battles(sys::state& state) {
 				(1.0f + state.world.leader_trait_get_organisation(attacker_per) + state.world.leader_trait_get_organisation(attacker_bg))
 			* (1.0f + state.world.leader_get_prestige(state.world.land_battle_get_general_from_attacking_general(b)) * state.defines.leader_prestige_to_max_org_factor);
 
-		auto defender_per = state.world.leader_get_personality(state.world.land_battle_get_general_from_defending_general(b));
-		auto defender_bg = get_leader_background_wrapper(state, state.world.land_battle_get_general_from_defending_general(b));
+		auto defender_per = fatten(state.world, get_leader_personality_wrapper(state, state.world.land_battle_get_general_from_defending_general(b)));
+		auto defender_bg = fatten(state.world, get_leader_background_wrapper(state, state.world.land_battle_get_general_from_defending_general(b)));
 
 		auto atk_leader_exp_mod = 1 + attacker_per.get_experience() + attacker_bg.get_experience();
 		auto def_leader_exp_mod = 1 + defender_per.get_experience() + defender_bg.get_experience();

--- a/src/military/military.cpp
+++ b/src/military/military.cpp
@@ -4916,9 +4916,13 @@ bool is_attacker_in_battle(sys::state& state, dcon::navy_id a) {
 	
 }
 
-// the wrapper will assign the proper background to a no_leader general if detected
+// this wrapper will also assign the proper background to a no_leader general if detected
 dcon::leader_trait_id get_leader_background_wrapper(sys::state& state, dcon::leader_id id) {
 	return (bool(id)) ? state.world.leader_get_background(id) : state.military_definitions.first_background_trait;
+}
+// the wrapper will assign the proper personality to a no_leader general if detected
+dcon::leader_trait_id get_leader_personality_wrapper(sys::state& state, dcon::leader_id id) {
+	return (bool(id)) ? state.world.leader_get_personality(id) : state.military_definitions.first_personality_trait;
 }
 
 
@@ -6389,11 +6393,11 @@ void update_naval_battles(sys::state& state) {
 		auto attacker_org_bonus =
 				1.0f + state.world.leader_trait_get_organisation(attacker_per) + state.world.leader_trait_get_organisation(attacker_bg);
 
-		auto defender_per = state.world.leader_get_personality(state.world.naval_battle_get_admiral_from_defending_admiral(b));
-		auto defender_bg = get_leader_background_wrapper(state, state.world.naval_battle_get_admiral_from_defending_admiral(b));
+		auto defender_per = fatten(state.world, get_leader_personality_wrapper(state, state.world.naval_battle_get_admiral_from_defending_admiral(b)));
+		auto defender_bg = fatten(state.world, get_leader_background_wrapper(state, state.world.naval_battle_get_admiral_from_defending_admiral(b)));
 
 		auto atk_leader_exp_mod = 1 + attacker_per.get_experience() + attacker_bg.get_experience();
-		auto def_leader_exp_mod = 1 + defender_per.get_experience() + defender_per.get_experience();
+		auto def_leader_exp_mod = 1 + defender_per.get_experience() + defender_bg.get_experience();
 
 		auto defence_bonus =
 				int32_t(state.world.leader_trait_get_defense(defender_per) + state.world.leader_trait_get_defense(defender_bg));

--- a/src/military/military.cpp
+++ b/src/military/military.cpp
@@ -4916,6 +4916,11 @@ bool is_attacker_in_battle(sys::state& state, dcon::navy_id a) {
 	
 }
 
+// the wrapper will assign the proper background to a no_leader general if detected
+dcon::leader_trait_id get_leader_background_wrapper(sys::state& state, dcon::leader_id id) {
+	return (bool(id)) ? state.world.leader_get_background(id) : state.world.leader_get_background(dcon::leader_id(0));
+}
+
 
 void update_battle_leaders(sys::state& state, dcon::land_battle_id b) {
 	/*auto la = get_land_battle_lead_attacker(state, b);*/

--- a/src/military/military.cpp
+++ b/src/military/military.cpp
@@ -5875,7 +5875,7 @@ void update_land_battles(sys::state& state) {
 		auto defender_bg = get_leader_background_wrapper(state, state.world.land_battle_get_general_from_defending_general(b));
 
 		auto atk_leader_exp_mod = 1 + attacker_per.get_experience() + attacker_bg.get_experience();
-		auto def_leader_exp_mod = 1 + defender_per.get_experience() + defender_per.get_experience();
+		auto def_leader_exp_mod = 1 + defender_per.get_experience() + defender_bg.get_experience();
 
 		auto defence_bonus =
 				int32_t(state.world.leader_trait_get_defense(defender_per) + state.world.leader_trait_get_defense(defender_bg));
@@ -6385,7 +6385,7 @@ void update_naval_battles(sys::state& state) {
 		auto attacker_dice = both_dice & 0x0F;
 		auto defender_dice = (both_dice >> 4) & 0x0F;
 
-		auto attacker_per = state.world.leader_get_personality(state.world.naval_battle_get_admiral_from_attacking_admiral(b));
+		auto attacker_per = fatten(state.world, get_leader_personality_wrapper(state, state.world.naval_battle_get_admiral_from_attacking_admiral(b)));
 		auto attacker_bg = fatten(state.world, get_leader_background_wrapper(state, state.world.naval_battle_get_admiral_from_attacking_admiral(b)));
 
 		auto attack_bonus =

--- a/src/military/military.hpp
+++ b/src/military/military.hpp
@@ -501,6 +501,7 @@ float get_leader_select_score(sys::state& state, dcon::leader_id l, bool is_atta
 bool is_attacker_in_battle(sys::state& state, dcon::army_id a);
 bool is_attacker_in_battle(sys::state& state, dcon::navy_id a);
 dcon::leader_trait_id get_leader_background_wrapper(sys::state& state, dcon::leader_id id);
+dcon::leader_trait_id get_leader_personality_wrapper(sys::state& state, dcon::leader_id id);
 void update_battle_leaders(sys::state& state, dcon::land_battle_id b);
 void update_battle_leaders(sys::state& state, dcon::naval_battle_id b);
 

--- a/src/military/military.hpp
+++ b/src/military/military.hpp
@@ -146,6 +146,7 @@ struct global_military_state {
 	tagged_vector<unit_definition, dcon::unit_type_id> unit_base_definitions;
 
 	dcon::leader_trait_id first_background_trait;
+	dcon::leader_trait_id first_personality_trait;
 
 	bool great_wars_enabled = false;
 	bool world_wars_enabled = false;

--- a/src/military/military.hpp
+++ b/src/military/military.hpp
@@ -499,6 +499,7 @@ dcon::nation_id get_naval_battle_lead_attacker(sys::state& state, dcon::naval_ba
 float get_leader_select_score(sys::state& state, dcon::leader_id l, bool is_attacking);
 bool is_attacker_in_battle(sys::state& state, dcon::army_id a);
 bool is_attacker_in_battle(sys::state& state, dcon::navy_id a);
+dcon::leader_trait_id get_leader_background_wrapper(sys::state& state, dcon::leader_id id);
 void update_battle_leaders(sys::state& state, dcon::land_battle_id b);
 void update_battle_leaders(sys::state& state, dcon::naval_battle_id b);
 

--- a/src/military/military.hpp
+++ b/src/military/military.hpp
@@ -146,7 +146,6 @@ struct global_military_state {
 	tagged_vector<unit_definition, dcon::unit_type_id> unit_base_definitions;
 
 	dcon::leader_trait_id first_background_trait;
-	dcon::leader_trait_id first_personality_trait;
 
 	bool great_wars_enabled = false;
 	bool world_wars_enabled = false;

--- a/src/parsing/military_parsing.cpp
+++ b/src/parsing/military_parsing.cpp
@@ -51,6 +51,8 @@ void make_trait(std::string_view name, token_generator& gen, error_handler& err,
 	parse_trait(gen, err, new_context);
 }
 void personality_traits_set(token_generator& gen, error_handler& err, scenario_building_context& context) {
+	context.state.military_definitions.first_personality_trait =
+		dcon::leader_trait_id(dcon::leader_trait_id::value_base_t(context.state.world.leader_trait_size()));
 	parse_traits_set(gen, err, context);
 }
 void background_traits_set(token_generator& gen, error_handler& err, scenario_building_context& context) {

--- a/src/parsing/military_parsing.cpp
+++ b/src/parsing/military_parsing.cpp
@@ -51,8 +51,6 @@ void make_trait(std::string_view name, token_generator& gen, error_handler& err,
 	parse_trait(gen, err, new_context);
 }
 void personality_traits_set(token_generator& gen, error_handler& err, scenario_building_context& context) {
-	context.state.military_definitions.first_personality_trait =
-		dcon::leader_trait_id(dcon::leader_trait_id::value_base_t(context.state.world.leader_trait_size()));
 	parse_traits_set(gen, err, context);
 }
 void background_traits_set(token_generator& gen, error_handler& err, scenario_building_context& context) {


### PR DESCRIPTION
The purpose of this PR is to make minor visual improvements to "no-leader"'s (when you don't have a general or admiral selected), and enable its scriptabillity as is the case in base Vic2. The PR does the following:

1. Enables the traits of "no-leader" to be scriptable as it is in vic2, it will use the first personality trait, and the first background trait to apply the maluses (in base vic2 this means a -2 atk, -2 def malus, but it can easily be changed by a simple vic2 mod by changing traits.txt)

2. Makes minor visual improvements to how no-leaders are presented, such as writing the the value of the "no_leader" localisation key whenever a general name would be written instead, and allows the user to see the maluses of a no-leader by hovering over it, either in the army window or in a battle window.