### PR TITLE
Leader selection fix

### DIFF
--- a/src/military/military.cpp
+++ b/src/military/military.cpp
@@ -4906,14 +4906,17 @@ bool is_attacker_in_battle(sys::state& state, dcon::army_id a) {
 bool is_attacker_in_battle(sys::state& state, dcon::navy_id a) {
 	assert(state.world.navy_get_battle_from_navy_battle_participation(a)); // make sure the army is actually in a battle
 	auto battle = state.world.navy_get_battle_from_navy_battle_participation(a);
+	auto war = state.world.naval_battle_get_war_from_naval_battle_in_war(battle);
 	auto thisnation = state.world.navy_get_controller_from_navy_control(a);
 	// country vs country
 	bool war_attacker = state.world.naval_battle_get_war_attacker_is_attacker(battle);
 	for(const auto par : state.world.nation_get_war_participant(thisnation)) {
-		if((par.get_is_attacker() && war_attacker) || (!par.get_is_attacker() && !war_attacker)) {
-			return true;
-		} else if((!par.get_is_attacker() && war_attacker) || (par.get_is_attacker() && !war_attacker)) {
-			return false;
+		if(par.get_war() == war) {
+			if((par.get_is_attacker() && war_attacker) || (!par.get_is_attacker() && !war_attacker)) {
+				return true;
+			} else if((!par.get_is_attacker() && war_attacker) || (par.get_is_attacker() && !war_attacker)) {
+				return false;
+			}
 		}
 	}
 	return false;

--- a/src/military/military.cpp
+++ b/src/military/military.cpp
@@ -4870,6 +4870,7 @@ float get_leader_select_score(sys::state& state, dcon::leader_id l, bool is_atta
 bool is_attacker_in_battle(sys::state& state, dcon::army_id a) {
 	assert(state.world.army_get_battle_from_army_battle_participation(a)); // make sure the army is actually in a battle
 	auto battle = state.world.army_get_battle_from_army_battle_participation(a);
+	auto war = state.world.land_battle_get_war_from_land_battle_in_war(battle);
 	auto lead_attacker = get_land_battle_lead_attacker(state, battle);
 	auto lead_defender = get_land_battle_lead_defender(state, battle);
 	auto thisnation = state.world.army_get_controller_from_army_control(a);
@@ -4877,12 +4878,15 @@ bool is_attacker_in_battle(sys::state& state, dcon::army_id a) {
 	// country vs country
 	if(lead_attacker && lead_defender) {
 		for(const auto par : state.world.nation_get_war_participant(thisnation)) {
-			if((par.get_is_attacker() && war_attacker) || (!par.get_is_attacker() && !war_attacker)) {
-				return true;
+			if(par.get_war() == war) {
+				if((par.get_is_attacker() && war_attacker) || (!par.get_is_attacker() && !war_attacker)) {
+					return true;
+				}
+				else if((!par.get_is_attacker() && war_attacker) || (par.get_is_attacker() && !war_attacker)) {
+					return false;
+				}
 			}
-			else if((!par.get_is_attacker() && war_attacker) || (par.get_is_attacker() && !war_attacker)) {
-				return false;
-			}
+			
 		}
 		return false;
 	}


### PR DESCRIPTION
Bugfix fixing incorrect leader selection (friendly leader might end up leading the enemy side, and vice versa) if one of the participants in the battle is in multiple wars at the same time, due to faulty logic in determining who is the attacker of the battle.