### PR TITLE
New trade animation.

### DIFF
--- a/assets/shaders/glsl/map_sprite_f.glsl
+++ b/assets/shaders/glsl/map_sprite_f.glsl
@@ -1,0 +1,9 @@
+in vec2 tex_coord;
+out vec4 frag_color;
+
+uniform sampler2D texture_sampler;
+
+void main()
+{
+    frag_color = texture(texture_sampler, vec2(tex_coord.x, 1.f - tex_coord.y));
+}

--- a/assets/shaders/glsl/map_sprite_v.glsl
+++ b/assets/shaders/glsl/map_sprite_v.glsl
@@ -1,0 +1,109 @@
+layout (location = 0) in vec2 position;
+
+// Sprite position
+uniform vec2 position_offset;
+uniform vec2 scale;
+
+// Texture params
+uniform vec2 texture_start;
+uniform vec2 texture_size;
+
+// Camera position
+uniform vec2 offset;
+uniform float aspect_ratio;
+
+// Zoom: big numbers = close
+uniform float zoom;
+
+// The size of the map in pixels
+uniform vec2 map_size;
+uniform mat3 rotation;
+
+// map projection
+uniform uint subroutines_index;
+
+out vec2 tex_coord;
+
+vec4 globe_coords(vec2 world_pos) {
+
+	vec3 new_world_pos;
+	float section_x = 200;
+	float angle_x1 = 2 * PI * floor(world_pos.x * section_x) / section_x;
+	float angle_x2 = 2 * PI * floor(world_pos.x * section_x + 1) / section_x;
+	float angle_x = mix(angle_x1, angle_x2, mod(world_pos.x * section_x, 1));
+	new_world_pos.x = mix(cos(angle_x1), cos(angle_x2), mod(world_pos.x * section_x, 1));
+	new_world_pos.y = mix(sin(angle_x1), sin(angle_x2), mod(world_pos.x * section_x, 1));
+	float section_y = 200;
+	float angle_y1 = PI * floor(world_pos.y * section_y) / section_y;
+	float angle_y2 = PI * floor(world_pos.y * section_y + 1) / section_y;
+	new_world_pos.x *= mix(sin(angle_y1), sin(angle_y2), mod(world_pos.y * section_y, 1));
+	new_world_pos.y *= mix(sin(angle_y1), sin(angle_y2), mod(world_pos.y * section_y, 1));
+	new_world_pos.z = mix(cos(angle_y1), cos(angle_y2), mod(world_pos.y * section_y, 1));
+	new_world_pos = rotation * new_world_pos;
+	new_world_pos /= PI; 		// Will make the zoom be the same for the globe and flat map
+	new_world_pos.y *= 0.02; 	// Sqeeze the z coords. Needs to be between -1 and 1
+	new_world_pos.xz *= -1; 	// Invert the globe
+	new_world_pos.xyz += 0.5; 	// Move the globe to the center
+
+	return vec4(
+		(2. * new_world_pos.x - 1.f) / aspect_ratio * zoom,
+		(2. * new_world_pos.z - 1.f) * zoom,
+		(2. * new_world_pos.y - 1.f), 1.0);
+}
+
+vec4 flat_coords(vec2 world_pos) {
+	world_pos += vec2(-offset.x, offset.y);
+	world_pos.x = mod(world_pos.x, 1.0f);
+	return vec4(
+		(2. * world_pos.x - 1.f) * zoom / aspect_ratio * map_size.x / map_size.y,
+		(2. * world_pos.y - 1.f) * zoom,
+		abs(world_pos.x - 0.5) * 2.1f,
+		1.0);
+}
+
+vec4 perspective_coords(vec2 world_pos) {
+	vec3 new_world_pos;
+	float angle_x = 2 * world_pos.x * PI;
+	new_world_pos.x = cos(angle_x);
+	new_world_pos.y = sin(angle_x);
+	float angle_y = world_pos.y * PI;
+	new_world_pos.x *= sin(angle_y);
+	new_world_pos.y *= sin(angle_y);
+	new_world_pos.z = cos(angle_y);
+
+	new_world_pos = rotation * new_world_pos;
+	new_world_pos /= PI; // Will make the zoom be the same for the globe and flat map
+	new_world_pos.xz *= -1;
+	new_world_pos.zy = new_world_pos.yz;
+
+	new_world_pos.x /= aspect_ratio;
+	new_world_pos.z -= 1.2;
+	float near = 0.1;
+	float tangent_length_square = 1.2f * 1.2f - 1 / PI / PI;
+	float far = tangent_length_square / 1.2f;
+	float right = near * tan(PI / 6) / zoom;
+	float top = near * tan(PI / 6) / zoom;
+	new_world_pos.x *= near / right;
+	new_world_pos.y *= near / top;
+	float w = -new_world_pos.z;
+	new_world_pos.z = -(far + near) / (far - near) * new_world_pos.z - 2 * far * near / (far - near);
+	return vec4(new_world_pos, w);
+}
+
+vec4 calc_gl_position(vec2 world_pos) {
+	switch(int(subroutines_index)) {
+case 0: return globe_coords(world_pos);
+case 1: return perspective_coords(world_pos);
+case 2: return flat_coords(world_pos);
+default: break;
+	}
+	return vec4(0.f);
+}
+
+
+void main()
+{
+	gl_Position = calc_gl_position(position * scale + position_offset);
+
+	tex_coord = texture_start + ((position + vec2(1.f, 1.f)) / vec2(2.f, 2.f)) * texture_size;
+}

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -23,6 +23,13 @@ struct map_vertex {
 	map_vertex(float x, float y) : position_(x, y){};
 	glm::vec2 position_;
 };
+struct trade_particle {
+	glm::vec2 position_;
+	glm::vec2 target_;
+	int trade_graph_node_current;
+	int trade_graph_node_prev = -1;
+	int trade_graph_node_next;
+};
 struct screen_vertex {
 	screen_vertex(float x, float y) : position_(x, y){};
 	glm::vec2 position_;
@@ -137,6 +144,11 @@ public:
 	std::vector<textured_line_with_width_vertex> trade_flow_vertices;
 	std::vector<GLint> trade_flow_arrow_starts;
 	std::vector<GLsizei> trade_flow_arrow_counts;
+	// trade particles
+	std::vector<trade_particle> trade_particles_positions;
+	ankerl::unordered_dense::map<int, ankerl::unordered_dense::map<int, float>> particle_next_node_probability;
+	ankerl::unordered_dense::map<int, float> particle_creation_probability;
+	ankerl::unordered_dense::map<int, glm::vec2> trade_node_position;
 	//
 	std::vector<curved_line_vertex> unit_arrow_vertices;
 	std::vector<GLint> unit_arrow_starts;
@@ -199,7 +211,8 @@ public:
 	static constexpr uint32_t vo_objective_unit_arrow = 13;
 	static constexpr uint32_t vo_other_objective_unit_arrow = 14;
 	static constexpr uint32_t vo_trade_flow = 15;
-	static constexpr uint32_t vo_count = 16;
+	static constexpr uint32_t vo_square = 16;
+	static constexpr uint32_t vo_count = 17;
 	GLuint vao_array[vo_count] = { 0 };
 	GLuint vbo_array[vo_count] = { 0 };
 	// Textures
@@ -251,7 +264,8 @@ public:
 	static constexpr uint32_t shader_trade_flow = 10;
 	static constexpr uint32_t shader_provinces = 11;
 	static constexpr uint32_t shader_borders_provinces = 12;
-	static constexpr uint32_t shader_count = 13;
+	static constexpr uint32_t shader_map_sprite = 13;
+	static constexpr uint32_t shader_count = 14;
 	GLuint shaders[shader_count] = { 0 };
 
 	static constexpr uint32_t uniform_offset = 0;
@@ -290,7 +304,11 @@ public:
 	static constexpr uint32_t uniform_provinces_sea_mask = 32;
 	static constexpr uint32_t uniform_provinces_real_texture_sampler = 33;
 	static constexpr uint32_t uniform_screen_size = 34;
-	static constexpr uint32_t uniform_count = 35;
+	static constexpr uint32_t uniform_sprite_offsets = 35;
+	static constexpr uint32_t uniform_sprite_scale = 36;
+	static constexpr uint32_t uniform_sprite_texture_start = 37;
+	static constexpr uint32_t uniform_sprite_texture_size = 38;
+	static constexpr uint32_t uniform_count = 39;
 	GLuint shader_uniforms[shader_count][uniform_count] = { };
 
 	// models: Textures for static meshes

--- a/src/map/map_state.cpp
+++ b/src/map/map_state.cpp
@@ -78,7 +78,33 @@ glm::vec2 get_army_location(sys::state& state, dcon::province_id prov_id) {
 	return state.world.province_get_mid_point(prov_id);
 }
 
+void register_trade_flow(display_data& map_data, int node1, int node2, float volume) {
+	if(map_data.particle_next_node_probability.contains(node1)) {
+		if(map_data.particle_next_node_probability[node1].contains(node2)) {
+			map_data.particle_next_node_probability[node1][node2] += volume;
+		} else {
+			map_data.particle_next_node_probability[node1][node2] = volume;
+		}
+	} else {
+		map_data.particle_next_node_probability[node1] = { };
+		map_data.particle_next_node_probability[node1][node2] = volume;
+	}
+}
+
 void update_trade_flow_arrows(sys::state& state, display_data& map_data) {
+	// idea:
+	// trade graph emits particles which move from the start of edge to the end of edge
+	// when particle reaches the node, it has a chance to dissappear
+	// depending on difference between trade inflow and outflow
+	// or it can be redirected to one of other nodes depending on the volume
+
+	map_data.trade_particles_positions.clear();
+	map_data.particle_next_node_probability.clear();
+	map_data.particle_creation_probability.clear();
+
+	auto size_x = float(map_data.size_x);
+	auto size_y = float(map_data.size_y);
+
 	map_data.trade_flow_vertices.clear();
 	map_data.trade_flow_arrow_counts.clear();
 	map_data.trade_flow_arrow_starts.clear();
@@ -96,6 +122,7 @@ void update_trade_flow_arrows(sys::state& state, display_data& map_data) {
 	auto count = 0.f;
 
 	std::vector<float> volume_sample;
+	float total_volume = 0.f;
 
 	state.world.for_each_trade_route([&](dcon::trade_route_id trade_route) {
 		auto current_volume = state.world.trade_route_get_volume(trade_route, cid);
@@ -109,9 +136,13 @@ void update_trade_flow_arrows(sys::state& state, display_data& map_data) {
 			: state.world.trade_route_get_connected_markets(trade_route, 1);
 		auto sat = state.world.market_get_direct_demand_satisfaction(origin, cid);
 		auto absolute_volume = std::abs(sat * current_volume);
-
+		total_volume += absolute_volume;
 		volume_sample.push_back(absolute_volume);
 	});
+
+	if(total_volume == 0.f) {
+		return;
+	}
 
 	std::sort(volume_sample.begin(), volume_sample.end());
 	// we are interested only in the most significant routes
@@ -162,6 +193,16 @@ void update_trade_flow_arrows(sys::state& state, display_data& map_data) {
 					trade_graph[start.index()][end.index()] = absolute_volume;
 				}
 
+				auto start_index = start.index();
+				if(start.index() < state.province_definitions.first_sea_province.index()) {
+					start_index += state.world.province_size();
+				}
+				auto end_index = end.index();
+				if(end.index() < state.province_definitions.first_sea_province.index()) {
+					end_index += state.world.province_size();
+				}
+				register_trade_flow(map_data, start_index, end_index, absolute_volume);
+
 				start = end;
 			}
 		} else {
@@ -180,6 +221,8 @@ void update_trade_flow_arrows(sys::state& state, display_data& map_data) {
 					trade_graph[start.index()][end.index()] = absolute_volume;
 				}
 
+				register_trade_flow(map_data, start.index(), end.index(), absolute_volume);
+
 				start = end;
 			}
 		}
@@ -188,6 +231,9 @@ void update_trade_flow_arrows(sys::state& state, display_data& map_data) {
 	state.world.for_each_market([&](dcon::market_id mid) {
 		auto trade_balance_sea = 0.f;
 		auto trade_balance_land = 0.f;
+
+		auto total_in = 0.f;
+		auto total_out = 0.f;
 
 		state.world.market_for_each_trade_route(mid, [&](auto route) {
 			auto current_volume = state.world.trade_route_get_volume(route, cid);		
@@ -212,14 +258,46 @@ void update_trade_flow_arrows(sys::state& state, display_data& map_data) {
 			} else {
 				trade_balance_land += current_volume * sat;
 			}
+
+			if(current_volume > 0) {
+				total_out += current_volume * sat;
+			} else {
+				total_in -= current_volume * sat;
+			}
 		});
+
+		
+
+		// if total in > total out
+		// we assume that commodity has a chance to be consumed
+		// it will be represented by a loop edge
+		// so we can assume that total out is actually total in
+
+		auto disappear_weight = 0.f;
+		if(total_in > total_out) {
+			total_out = total_in;
+			disappear_weight = total_in - total_out;
+		}
+
+		
 
 		auto sid = state.world.market_get_zone_from_local_market(mid);
 		auto port = province::state_get_coastal_capital(state, sid);
 		auto stockpile_location = state.world.state_instance_get_capital(sid);
 		auto absolute_volume = std::abs(trade_balance_sea);
 
-		if(trade_balance_sea < -cutoff) {
+
+		// set trade graph edges
+
+		auto stockpile_index = stockpile_location.id.index();
+		register_trade_flow(map_data, stockpile_index, stockpile_index, disappear_weight);
+
+
+		if(total_out > total_in) {
+			map_data.particle_creation_probability[stockpile_index] = total_out - total_in;
+		}
+
+		if(trade_balance_sea > cutoff) {
 			auto path = province::make_unowned_path(state, stockpile_location, port);
 			auto start = stockpile_location.id;
 			for(int i = int(path.size()) - 1; i >= 0; i--) {
@@ -235,14 +313,21 @@ void update_trade_flow_arrows(sys::state& state, display_data& map_data) {
 					trade_graph[start.index()][end.index()] = absolute_volume;
 				}
 
+				register_trade_flow(map_data, start.index(), end.index(), absolute_volume);
+
 				start = end;
 			}
 			trade_graph_toward_port[port.index()] = absolute_volume;
-		} else if(trade_balance_sea > cutoff) {
+
+			auto port_index = port.index() + state.world.province_size();
+			auto city_index = port.index();
+			register_trade_flow(map_data, city_index, port_index, absolute_volume);
+		} else if(trade_balance_sea < -cutoff) {
 			auto path = province::make_unowned_path(state, port, stockpile_location);
 			auto start = port;
 			for(int i = int(path.size()) - 1; i >= 0; i--) {
 				auto end = path[i];
+
 				if(trade_graph.contains(start.index())) {
 					if(trade_graph[start.index()].contains(end.index())) {
 						trade_graph[start.index()][end.index()] += absolute_volume;
@@ -254,16 +339,85 @@ void update_trade_flow_arrows(sys::state& state, display_data& map_data) {
 					trade_graph[start.index()][end.index()] = absolute_volume;
 				}
 
+				register_trade_flow(map_data, start.index(), end.index(), absolute_volume);
+
 				start = end;
 			}
+
 			trade_graph_toward_port[port.index()] = -absolute_volume;
+
+			auto port_index = port.index() + state.world.province_size();
+			auto city_index = port.index();
+			register_trade_flow(map_data, port_index, city_index, absolute_volume);
+		}
+	});
+
+	// generate some particles:
+
+	for(int i = 0; i < std::min(std::max(300, (int)total_volume), 5000); i++) {
+		trade_particle data{
+			{ },
+			{ },
+			-1,
+			-1,
+			-1
+		};
+		map_data.trade_particles_positions.push_back(data);
+	}
+
+	// normalisation:
+
+	{
+		float total_score = 0.f;
+		for(auto const& [candidate, probability] : map_data.particle_creation_probability) {
+			total_score += probability;
+		}
+
+		if(total_score > 0.f) {
+			for(auto const& [candidate, probability] : map_data.particle_creation_probability) {
+				map_data.particle_creation_probability[candidate] /= total_score;
+			}
+		}
+	}
+
+	state.world.for_each_province([&](dcon::province_id origin) {
+		// normal prov
+
+		auto base_index = origin.index();
+		if(map_data.particle_next_node_probability.contains(base_index)) {
+			float total_volume_out = 0.f;
+			for(auto const& [target_index, volume] : map_data.particle_next_node_probability[base_index]) {
+				total_volume_out += volume;
+			}
+
+			for(auto const& [target_index, volume] : map_data.particle_next_node_probability[base_index]) {
+				map_data.particle_next_node_probability[base_index][target_index] = volume / total_volume_out;
+			}
+		}
+
+		map_data.trade_node_position[base_index] = get_army_location(state, origin);
+
+		// port prov
+
+		base_index += state.world.province_size();
+		if(map_data.particle_next_node_probability.contains(base_index)) {
+			float total_volume_out = 0.f;
+			for(auto const& [target_index, volume] : map_data.particle_next_node_probability[base_index]) {
+				total_volume_out += volume;
+			}
+
+			if(total_volume_out > 0.f)
+				for(auto const& [target_index, volume] : map_data.particle_next_node_probability[base_index]) {
+					map_data.particle_next_node_probability[base_index][target_index] = volume / total_volume_out;
+				}
+		}
+
+		if(state.world.province_get_port_to(origin)) {
+			map_data.trade_node_position[base_index] = get_port_location(state, origin) ;
 		}
 	});
 
 	// now we are building vertices
-
-	auto size_x = float(map_data.size_x);
-	auto size_y = float(map_data.size_y);
 
 	for(auto const& [coastal_province_index, volume] : trade_graph_toward_port) {
 		auto coastal_province = dcon::province_id{ dcon::province_id::value_base_t(coastal_province_index) };


### PR DESCRIPTION
Implements the following feature:
After selecting a trade good to examine trade routes around the world, the game will spawn moving sprites which will follow trade routes according to throughput of the routes and eventually despawn them in places where incoming trade volume is larger that outgoing trade volume