### PR TITLE
Small adjustments to migration and bureacracy.

### DIFF
--- a/assets/localisation/en-US/alice.csv
+++ b/assets/localisation/en-US/alice.csv
@@ -552,6 +552,7 @@ pop_mig_1;There is no internal migration from colonial provinces
 pop_mig_2;Slaves do not migrate internally
 pop_mig_3;The number of people that will migrate internally is equal to the size of the pop times the immigration scale ($x$) times the province's immigrant-push modifier ($y$) times the migration factor ($val$)
 pop_mig_4;?YMigration factor:
+pop_migration_bureaucracy;Bureaucracy has to move around in order to administer the land: $x$
 pop_cmig_1;The nation does not have any colonies
 pop_cmig_2;There is no colonial migration from colonial provinces
 pop_cmig_3;Slaves do not migrate colonially
@@ -1478,4 +1479,6 @@ pop_emigration_attraction_2;The national modifier to immigrant attraction: $x$
 pop_emigration_attraction_3;And the migration target factor: $x$
 pop_migration_attraction_1;Migration attraction is the product of:
 pop_migration_attraction_2;The provincial modifier to immigrant attraction: $x$
-pop_migration_attraction_3;And the migration target factor: $x$
+pop_migration_attraction_3;The migration target factor: $x$
+pop_migration_attraction_wage_ratio;And the wage difference multipler: $x$
+pop_migration_attraction_bureaucracy;Bureaucracy base attraction: $x$

--- a/src/ai/ai.cpp
+++ b/src/ai/ai.cpp
@@ -3995,8 +3995,8 @@ void update_budget(sys::state& state) {
 		n.set_land_spending(int8_t(ratio_land));
 		n.set_naval_spending(int8_t(ratio_naval));
 
-		n.set_construction_spending(75);
-		n.set_administrative_spending(10);
+		n.set_construction_spending(50);
+		n.set_administrative_spending(25);
 		
 		float max_education_budget = 1.f + economy::estimate_pop_payouts_by_income_type(state, n, culture::income_type::education);
 		float max_soldiers_budget = 1.f + economy::estimate_pop_payouts_by_income_type(state, n, culture::income_type::military);

--- a/src/economy/demographics.cpp
+++ b/src/economy/demographics.cpp
@@ -3564,8 +3564,8 @@ void update_internal_migration(sys::state& state, uint32_t offset, uint32_t divi
 		ve::fp_vector base = ve::select(
 			pop_types == state.culture_definitions.bureaucrat
 			&& (accepted || state.world.nation_get_primary_culture(owners) == state.world.pop_get_culture(ids)),
-			administration_base_push,
-			0.f
+			ve::fp_vector { administration_base_push },
+			ve::fp_vector { }
 		);
 
 		auto amounts =
@@ -3688,8 +3688,8 @@ void update_colonial_migration(sys::state& state, uint32_t offset, uint32_t divi
 		ve::fp_vector base = ve::select(
 			pop_types == state.culture_definitions.bureaucrat
 			&& (accepted || state.world.nation_get_primary_culture(owners) == state.world.pop_get_culture(ids)),
-			administration_base_push,
-			0.f
+			ve::fp_vector{ administration_base_push },
+			ve::fp_vector{ 0.f }
 		);
 
 		auto amounts = (base + ve::max(trigger::evaluate_additive_modifier(state, state.culture_definitions.colonialmigration_chance, trigger::to_generic(ids), trigger::to_generic(ids), 0),  0.0f)) *

--- a/src/economy/demographics.hpp
+++ b/src/economy/demographics.hpp
@@ -289,6 +289,19 @@ float get_estimated_mil_change(sys::state& state, dcon::nation_id n);
 float get_estimated_con_change(sys::state& state, dcon::nation_id n);
 float get_estimated_promotion(sys::state& state, dcon::nation_id n);
 
+// bureacracy has to travel around the realm
+inline constexpr float administration_base_push = 0.9f;
+inline constexpr float administration_additional_province_weight = 0.1f;
+
+struct province_migration_weight_explanation {
+	float base_multiplier;
+	float base_weight;
+	float modifier;
+	float wage_multiplier;
+	float result;
+};
+province_migration_weight_explanation explain_province_internal_migration_weight(sys::state& state, dcon::pop_id p, dcon::province_id pid);
+
 void apply_ideologies(sys::state& state, uint32_t offset, uint32_t divisions, ideology_buffer& pbuf);
 void apply_issues(sys::state& state, uint32_t offset, uint32_t divisions, issues_buffer& pbuf);
 void apply_type_changes(sys::state& state, uint32_t offset, uint32_t divisions, promotion_buffer& pbuf);

--- a/src/economy/economy.cpp
+++ b/src/economy/economy.cpp
@@ -2844,8 +2844,7 @@ void daily_update(sys::state& state, bool presimulation, float presimulation_sta
 
 			if(!state.world.commodity_get_is_available_from_start(c)) {
 				reset_route_commodity = reset_route_commodity
-					|| !unlocked_A
-					|| !unlocked_B;
+					|| (!unlocked_A && !unlocked_B);
 			}
 
 			//state.world.execute_serial_over_trade_route([&](auto trade_route) {

--- a/src/economy/economy.cpp
+++ b/src/economy/economy.cpp
@@ -844,7 +844,7 @@ void initialize(sys::state& state) {
 
 	state.world.for_each_nation([&](dcon::nation_id n) {
 		auto fn = fatten(state.world, n);
-		fn.set_administrative_spending(int8_t(10));
+		fn.set_administrative_spending(int8_t(25));
 		fn.set_military_spending(int8_t(60));
 		fn.set_education_spending(int8_t(100));
 		fn.set_social_spending(int8_t(100));
@@ -1128,6 +1128,10 @@ void update_pops_employment(sys::state& state) {
 			auto subsistence_employment = 0.f;
 			for(auto pop_location : state.world.province_get_pop_location(p)) {
 				auto pop = pop_location.get_pop();
+
+				auto accepted = state.world.nation_get_accepted_cultures(n, pop.get_culture())
+					|| state.world.nation_get_primary_culture(n) == pop.get_culture();
+
 				if(pop.get_poptype() == state.culture_definitions.slaves) {
 					pop_demographics::set_raw_employment(state, pop, rgo);
 					subsistence_employment += pop.get_size() * (1.f - rgo);
@@ -1138,7 +1142,7 @@ void update_pops_employment(sys::state& state) {
 					pop_demographics::set_raw_employment(state, pop, primary);
 					subsistence_employment += pop.get_size() * (1.f - primary);
 				} else if(pop.get_poptype() == state.culture_definitions.secondary_factory_worker) {
-					if(state.world.nation_get_accepted_cultures(n, pop.get_culture())) {
+					if(accepted) {
 						pop_demographics::set_raw_employment(state, pop, high_accepted);
 						subsistence_employment += pop.get_size() * (1.f - high_accepted);
 					} else {
@@ -1146,7 +1150,7 @@ void update_pops_employment(sys::state& state) {
 						subsistence_employment += pop.get_size() * (1.f - high);
 					}
 				} else if(pop.get_poptype() == state.culture_definitions.bureaucrat) {
-					if(state.world.nation_get_accepted_cultures(n, pop.get_culture())) {
+					if(accepted) {
 						pop_demographics::set_raw_employment(state, pop, high_accepted);
 						subsistence_employment += pop.get_size() * (1.f - high_accepted);
 					} else {
@@ -1154,7 +1158,7 @@ void update_pops_employment(sys::state& state) {
 						subsistence_employment += pop.get_size() * (1.f - high);
 					}
 				} else if(pop.get_poptype() == state.culture_definitions.clergy) {
-					if(state.world.nation_get_accepted_cultures(n, pop.get_culture())) {
+					if(accepted) {
 						pop_demographics::set_raw_employment(state, pop, high_accepted);
 						subsistence_employment += pop.get_size() * (1.f - high_accepted);
 					} else {
@@ -4144,14 +4148,17 @@ void daily_update(sys::state& state, bool presimulation, float presimulation_sta
 			auto total_high_education = ve::apply([&](auto p, auto n) {
 				auto total = 0.f;
 				for(auto pl : state.world.province_get_pop_location(p)) {
+					auto not_accepted = !state.world.nation_get_accepted_cultures(n, pl.get_pop().get_culture())
+						&& state.world.nation_get_primary_culture(n) != pl.get_pop().get_culture().id;
+
 					if(state.culture_definitions.secondary_factory_worker == pl.get_pop().get_poptype()) {
-						if(!state.world.nation_get_accepted_cultures(n, pl.get_pop().get_culture()) && state.world.nation_get_primary_culture(n) != pl.get_pop().get_culture().id)
+						if(not_accepted)
 							total += pl.get_pop().get_size();
 					} else if(pl.get_pop().get_poptype() == state.culture_definitions.bureaucrat) {
-						if(!state.world.nation_get_accepted_cultures(n, pl.get_pop().get_culture()) && state.world.nation_get_primary_culture(n) != pl.get_pop().get_culture().id)
+						if(not_accepted)
 							total += pl.get_pop().get_size();
 					} else if(pl.get_pop().get_poptype() == state.culture_definitions.clergy) {
-						if(!state.world.nation_get_accepted_cultures(n, pl.get_pop().get_culture()) && state.world.nation_get_primary_culture(n) != pl.get_pop().get_culture().id)
+						if(not_accepted)
 							total += pl.get_pop().get_size();
 					}
 				}
@@ -4161,14 +4168,17 @@ void daily_update(sys::state& state, bool presimulation, float presimulation_sta
 			auto total_high_education_and_accepted = ve::apply([&](auto p, auto n) {
 				auto total = 0.f;
 				for(auto pl : state.world.province_get_pop_location(p)) {
+					auto accepted = state.world.nation_get_accepted_cultures(n, pl.get_pop().get_culture())
+						|| state.world.nation_get_primary_culture(n) == pl.get_pop().get_culture().id;
+
 					if(state.culture_definitions.secondary_factory_worker == pl.get_pop().get_poptype()) {
-						if(state.world.nation_get_accepted_cultures(n, pl.get_pop().get_culture()) || state.world.nation_get_primary_culture(n) == pl.get_pop().get_culture().id)
+						if(accepted)
 							total += pl.get_pop().get_size();
 					} else if(pl.get_pop().get_poptype() == state.culture_definitions.bureaucrat) {
-						if(state.world.nation_get_accepted_cultures(n, pl.get_pop().get_culture()) || state.world.nation_get_primary_culture(n) == pl.get_pop().get_culture().id)
+						if(accepted)
 							total += pl.get_pop().get_size();
 					} else if(pl.get_pop().get_poptype() == state.culture_definitions.clergy) {
-						if(state.world.nation_get_accepted_cultures(n, pl.get_pop().get_culture()) || state.world.nation_get_primary_culture(n) == pl.get_pop().get_culture().id)
+						if(accepted)
 							total += pl.get_pop().get_size();
 					}
 				}
@@ -4540,6 +4550,10 @@ void daily_update(sys::state& state, bool presimulation, float presimulation_sta
 				auto savings = pop.get_savings();
 				auto poptype = pop.get_poptype();
 				auto size = pop.get_size();
+
+				auto accepted = state.world.nation_get_accepted_cultures(n, pop.get_culture())
+					|| state.world.nation_get_primary_culture(n) == pop.get_culture();
+
 				if(poptype.get_is_paid_rgo_worker()) {
 					pop.set_savings(savings + income_scale * state.inflation * size * rgo_workers_wage * (1.f - local_market_cut));
 					total_wage += size * rgo_workers_wage;
@@ -4554,7 +4568,7 @@ void daily_update(sys::state& state, bool presimulation, float presimulation_sta
 					assert(std::isfinite(pop.get_savings()) && pop.get_savings() >= 0);
 #endif
 				} else if(state.culture_definitions.secondary_factory_worker == pop.get_poptype()) {
-					if(state.world.nation_get_accepted_cultures(n, pop.get_culture())) {
+					if(accepted) {
 						pop.set_savings(savings + income_scale * state.inflation * size * high_accepted_workers_wage * (1.f - local_market_cut));
 						total_wage += size * high_accepted_workers_wage;
 #ifndef NDEBUG
@@ -4569,7 +4583,7 @@ void daily_update(sys::state& state, bool presimulation, float presimulation_sta
 					}
 					assert(std::isfinite(pop.get_savings()) && pop.get_savings() >= 0);
 				} else if(pop.get_poptype() == state.culture_definitions.bureaucrat) {
-					if(state.world.nation_get_accepted_cultures(n, pop.get_culture())) {
+					if(accepted) {
 						pop.set_savings(savings + income_scale * state.inflation * size * high_accepted_workers_wage * (1.f - local_market_cut));
 						total_wage += size * high_accepted_workers_wage;
 #ifndef NDEBUG
@@ -4583,7 +4597,7 @@ void daily_update(sys::state& state, bool presimulation, float presimulation_sta
 #endif
 					}
 				} else if(pop.get_poptype() == state.culture_definitions.clergy) {
-					if(state.world.nation_get_accepted_cultures(n, pop.get_culture())) {
+					if(accepted) {
 						pop.set_savings(pop.get_savings() + income_scale * state.inflation * size * high_accepted_workers_wage * (1.f - local_market_cut));
 						total_wage += size * high_accepted_workers_wage;
 #ifndef NDEBUG


### PR DESCRIPTION
- Add additional multiplier to increase a chance of migration to province with high wage
- Add base chance for primary culture bureaucracy to migrate to problematic regions (resolves issues with far away regions with diverging administration costs)
- Use state capital bureaucracy instead of provincial one (has to be done as bureaucracy does not migrate to random provinces)
- Minor fix for trade: allow trade if at least one party unlocked related commodity