### PR TITLE
Refactor economy.cpp getters, fix misc. MP stuff

### DIFF
--- a/src/economy/economy.cpp
+++ b/src/economy/economy.cpp
@@ -239,24 +239,21 @@ void initialize_needs_weights(sys::state& state, dcon::market_id n) {
 	{
 		state.world.for_each_commodity([&](dcon::commodity_id c) {
 			if(valid_life_need(state, nation, c)) {
-				auto& w = state.world.market_get_life_needs_weights(n, c);
-				w = 0.001f;
+				state.world.market_set_life_needs_weights(n, c, 0.001f);
 			}
 		});
 	}
 	{
 		state.world.for_each_commodity([&](dcon::commodity_id c) {
 			if(valid_everyday_need(state, nation, c)) {
-				auto& w = state.world.market_get_everyday_needs_weights(n, c);
-				w = 0.001f;
+				state.world.market_set_everyday_needs_weights(n, c, 0.001f);
 			}
 		});
 	}
 	{
 		state.world.for_each_commodity([&](dcon::commodity_id c) {
 			if(valid_luxury_need(state, nation, c)) {
-				auto& w = state.world.market_get_luxury_needs_weights(n, c);
-				w = 0.001f;
+				state.world.market_set_luxury_needs_weights(n, c, 0.001f);
 			}
 		});
 	}
@@ -283,7 +280,7 @@ void rebalance_needs_weights(sys::state& state, dcon::market_id n) {
 				auto base_life = std::max(1.f, state.world.pop_type_get_life_needs(t, c));
 				auto weight = need_weight(state, n, c, wage, base_life);
 				auto& w = state.world.market_get_life_needs_weights(n, c);
-				w = weight * state.defines.alice_need_drift_speed + w * (1.0f - state.defines.alice_need_drift_speed);
+				state.world.market_set_life_needs_weights(n, c, weight * state.defines.alice_need_drift_speed + w * (1.0f - state.defines.alice_need_drift_speed));
 
 				assert(std::isfinite(w));
 				assert(w <= 1.f + 0.01f);
@@ -298,7 +295,7 @@ void rebalance_needs_weights(sys::state& state, dcon::market_id n) {
 				auto base_everyday = std::max(1.f, state.world.pop_type_get_everyday_needs(t, c));
 				auto weight = need_weight(state, n, c, wage, base_everyday);
 				auto& w = state.world.market_get_everyday_needs_weights(n, c);
-				w = weight * state.defines.alice_need_drift_speed + w * (1.0f - state.defines.alice_need_drift_speed);
+				state.world.market_set_everyday_needs_weights(n, c, weight * state.defines.alice_need_drift_speed + w * (1.0f - state.defines.alice_need_drift_speed));
 
 				assert(std::isfinite(w));
 				assert(w <= 1.f + 0.01f);
@@ -313,7 +310,7 @@ void rebalance_needs_weights(sys::state& state, dcon::market_id n) {
 				auto base_luxury = std::max(1.f, state.world.pop_type_get_luxury_needs(t, c));
 				auto weight = need_weight(state, n, c, wage, base_luxury);
 				auto& w = state.world.market_get_luxury_needs_weights(n, c);
-				w = weight * state.defines.alice_need_drift_speed + w * (1.0f - state.defines.alice_need_drift_speed);
+				state.world.market_set_luxury_needs_weights(n, c, weight * state.defines.alice_need_drift_speed + w * (1.0f - state.defines.alice_need_drift_speed));
 
 				assert(std::isfinite(w));
 				assert(w <= 1.f + 0.01f);
@@ -1181,10 +1178,11 @@ void populate_army_consumption(sys::state& state) {
 				if(supply_cost.commodity_type[i]) {
 					// Day-to-day consumption
 					// Strength under 100% reduces unit supply consumption
-					state.world.market_get_army_demand(market, supply_cost.commodity_type[i]) +=
-						supply_cost.commodity_amounts[i]
+					auto& curr_demand = state.world.market_get_army_demand(market, supply_cost.commodity_type[i]);
+					state.world.market_set_army_demand(market, supply_cost.commodity_type[i], curr_demand + supply_cost.commodity_amounts[i]
 						* state.world.nation_get_unit_stats(owner, type).supply_consumption
-						* o_sc_mod * strength;
+						* o_sc_mod * strength);
+
 				} else {
 					break;
 				}
@@ -1196,9 +1194,8 @@ void populate_army_consumption(sys::state& state) {
 					auto reinforcement = military::unit_calculate_reinforcement(state, reg);
 					if(reinforcement > 0) {
 						// Regiment needs reinforcement - add extra consumption. Every 1% of reinforcement demands 1% of unit cost
-						state.world.market_get_army_demand(market, build_cost.commodity_type[i]) +=
-							build_cost.commodity_amounts[i]
-							* reinforcement;
+						auto& curr_demand = state.world.market_get_army_demand(market, build_cost.commodity_type[i]);
+						state.world.market_set_army_demand(market, build_cost.commodity_type[i], curr_demand + build_cost.commodity_amounts[i] * reinforcement);
 					}
 				} else {
 					break;
@@ -1233,10 +1230,11 @@ void populate_navy_consumption(sys::state& state) {
 			auto& supply_cost = state.military_definitions.unit_base_definitions[type].supply_cost;
 			for(uint32_t i = 0; i < commodity_set::set_size; ++i) {
 				if(supply_cost.commodity_type[i]) {
-					state.world.market_get_navy_demand(market, supply_cost.commodity_type[i]) +=
-						supply_cost.commodity_amounts[i]
+					auto& curr_demand = state.world.market_get_navy_demand(market, supply_cost.commodity_type[i]);
+					state.world.market_set_navy_demand(market, supply_cost.commodity_type[i], curr_demand + supply_cost.commodity_amounts[i]
 						* state.world.nation_get_unit_stats(owner, type).supply_consumption
-						* o_sc_mod;
+						* o_sc_mod);
+
 				} else {
 					break;
 				}
@@ -1249,9 +1247,9 @@ void populate_navy_consumption(sys::state& state) {
 					auto reinforcement = military::unit_calculate_reinforcement(state, shp);
 					if(reinforcement > 0) {
 						// Ship needs repair - add extra consumption. Every 1% of reinforcement demands 1% of unit cost
-						state.world.market_get_army_demand(market, build_cost.commodity_type[i]) +=
-							build_cost.commodity_amounts[i]
-							* reinforcement;
+
+						auto& curr_demand = state.world.market_get_navy_demand(market, build_cost.commodity_type[i]);
+						state.world.market_set_navy_demand(market, build_cost.commodity_type[i], curr_demand + build_cost.commodity_amounts[i] * reinforcement);
 					}
 				} else {
 					break;
@@ -1798,7 +1796,7 @@ void update_pop_consumption(
 
 		ve::apply(
 			[&](float transfer, dcon::nation_id n) {
-				state.world.nation_get_national_bank(n) += transfer;
+				state.world.nation_set_national_bank(n, state.world.nation_get_national_bank(n) + transfer);
 				return 0;
 			}, bank_deposits, nations
 		);
@@ -1897,12 +1895,12 @@ void update_pop_consumption(
 				assert(!isinf(scale_everyday));
 				assert(!isinf(scale_luxury));
 
-				state.world.market_get_life_needs_scale(m, pop_type) += scale_life;
-				state.world.market_get_everyday_needs_scale(m, pop_type) += scale_everyday;
-				state.world.market_get_luxury_needs_scale(m, pop_type) += scale_luxury;
+				state.world.market_set_life_needs_scale(m, pop_type, state.world.market_get_life_needs_scale(m, pop_type) + scale_life);
+				state.world.market_set_everyday_needs_scale(m, pop_type, state.world.market_get_everyday_needs_scale(m, pop_type) + scale_everyday);
+				state.world.market_set_luxury_needs_scale(m, pop_type, state.world.market_get_luxury_needs_scale(m, pop_type) + scale_luxury);
 				auto zone = state.world.market_get_zone_from_local_market(m);
 				auto nation = state.world.state_instance_get_nation_from_state_ownership(zone);
-				state.world.nation_get_private_investment(nation) += investment;
+				state.world.nation_set_private_investment(nation, state.world.nation_get_private_investment(nation) + investment);
 				if(nation == state.local_player_nation) {
 					state.ui_state.last_tick_investment_pool_change += investment;
 				}
@@ -2438,16 +2436,16 @@ void run_private_investment(sys::state& state) {
 				auto overlord = state.world.overlord_get_ruler(rel);
 
 				auto amt = state.world.nation_get_private_investment(n) * state.defines.alice_privateinvestment_subject_transfer / 100.f;
-				state.world.nation_get_private_investment(n) -= amt;
+				state.world.nation_set_private_investment(n, state.world.nation_get_private_investment(n) - amt);
 
 				auto subjects = nations::nation_get_subjects(state, n);
 				if(subjects.size() > 0) {
 					auto part = amt / subjects.size();
 					for(auto s : subjects) {
-						state.world.nation_get_private_investment(s) += part;
+						state.world.nation_set_private_investment(s, state.world.nation_get_private_investment(s) + part);
 					}
 				} else if(overlord) {
-					state.world.nation_get_private_investment(overlord) += amt;
+					state.world.nation_set_private_investment(overlord, state.world.nation_get_private_investment(overlord) + amt);
 				}
 			}
 		} else { // private investment not allowed
@@ -2894,8 +2892,8 @@ void daily_update(sys::state& state, bool presimulation, float presimulation_sta
 				}
 				// Interest payments
 				if(ip > 0) {
-					sp -= ip;
-					state.world.nation_get_national_bank(n) += ip;
+					state.world.nation_set_stockpiles(n, economy::money, sp - ip);
+					state.world.nation_set_national_bank(n, state.world.nation_get_national_bank(n) + ip);
 				}
 
 				// If available loans don't allow run 100% of spending, adjust spending scale
@@ -2922,15 +2920,17 @@ void daily_update(sys::state& state, bool presimulation, float presimulation_sta
 			assert(std::isfinite(spending_scale));
 			assert(std::isfinite(budget));
 
-			state.world.nation_get_stockpiles(n, economy::money) -= std::min(budget, total * spending_scale);
-			state.world.nation_set_spending_level(n, spending_scale);
 
 			auto& s = state.world.nation_get_stockpiles(n, economy::money);
+
+			state.world.nation_set_stockpiles(n, economy::money, s - std::min(budget, total * spending_scale));
+			state.world.nation_set_spending_level(n, spending_scale);
+
 			auto& l = state.world.nation_get_local_loan(n);
 
 			// Take loan
 			if(s < 0 && l < max_loan(state, n) && std::abs(s) <= max_loan(state, n) - l) {
-				state.world.nation_get_local_loan(n) += std::abs(s);
+				state.world.nation_set_local_loan(n, l + std::abs(s));
 				state.world.nation_set_stockpiles(n, economy::money, 0);
 			} else if(s < 0) {
 				// Nation somehow got into negative bigger than its loans allow
@@ -2938,8 +2938,8 @@ void daily_update(sys::state& state, bool presimulation, float presimulation_sta
 			// Repay loan
 			} else if(s > 0 && l > 0) {
 				auto change = std::min(s, l);
-				state.world.nation_get_local_loan(n) -= change;
-				state.world.nation_get_stockpiles(n, economy::money) -= change;
+				state.world.nation_set_local_loan(n, l - change);
+				state.world.nation_set_stockpiles(n, economy::money, s - change);
 			}
 
 			float pi_total = full_private_investment_cost(state, n);
@@ -3388,8 +3388,8 @@ void daily_update(sys::state& state, bool presimulation, float presimulation_sta
 			auto difference = state.world.nation_get_stockpile_targets(n, c) - state.world.nation_get_stockpiles(n, c);
 			if(difference > 0.f && state.world.nation_get_drawing_on_stockpiles(n, c) == false) {
 				auto sat = state.world.market_get_direct_demand_satisfaction(capital_market, c);
-				state.world.nation_get_stockpiles(n, c) +=
-					difference * nations_commodity_spending * sat;
+				auto& curr = state.world.nation_get_stockpiles(n, c);
+				state.world.nation_set_stockpiles(n, c, curr + difference * nations_commodity_spending * sat);
 				auto delta =
 					difference
 					* (1.0f - sat)
@@ -3438,7 +3438,7 @@ void daily_update(sys::state& state, bool presimulation, float presimulation_sta
 
 		// finally, pay back refund:
 		assert(std::isfinite(refund) && refund >= 0.0f);
-		state.world.nation_get_stockpiles(n, money) += refund;
+		state.world.nation_set_stockpiles(n, money, state.world.nation_get_stockpiles(n, money) + refund);
 	});
 
 	sanity_check(state);
@@ -3540,19 +3540,22 @@ void daily_update(sys::state& state, bool presimulation, float presimulation_sta
 				continue;
 			}
 			trade_and_tariff route_data = explain_trade_route_commodity(state, trade_route, data, cid);
-			state.world.market_get_export(route_data.origin, cid) += route_data.amount_origin;
-			state.world.market_get_import(route_data.target, cid) += route_data.amount_target;			
-			state.world.market_get_stockpile(route_data.origin, economy::money) += route_data.amount_origin * route_data.payment_received_per_unit;
-			state.world.market_get_stockpile(route_data.target, economy::money) -= route_data.amount_origin * route_data.payment_per_unit;
+			auto& cur_export = state.world.market_get_export(route_data.origin, cid);
+			state.world.market_set_export(route_data.origin, cid, cur_export + route_data.amount_origin);
+			auto& cur_import = state.world.market_get_import(route_data.target, cid);
+			state.world.market_set_import(route_data.target, cid, cur_import + route_data.amount_target);
+			auto& cur_origin_stockpile = state.world.market_get_stockpile(route_data.origin, economy::money);
+			state.world.market_set_stockpile(route_data.origin, economy::money, cur_origin_stockpile + route_data.amount_origin * route_data.payment_received_per_unit);
+			auto& cur_target_stockpile = state.world.market_get_stockpile(route_data.target, economy::money);
+			state.world.market_set_stockpile(route_data.target, economy::money, cur_target_stockpile - route_data.amount_origin * route_data.payment_per_unit);
 
 #ifndef NDEBUG
 			total_trade_paid += route_data.amount_origin * route_data.payment_per_unit;
 			total_merchant_cut += route_data.amount_origin * route_data.payment_received_per_unit;
 #endif // !NDEBUG
-
-			state.world.market_get_tariff_collected(route_data.origin) += route_data.tariff_origin;
-			state.world.market_get_tariff_collected(route_data.target) += route_data.tariff_target;
-			state.world.market_get_stockpile(route_data.target, cid) += route_data.amount_target;
+			state.world.market_set_tariff_collected(route_data.origin, state.world.market_get_tariff_collected(route_data.origin) + route_data.tariff_origin);
+			state.world.market_set_tariff_collected(route_data.target, state.world.market_get_tariff_collected(route_data.target) + route_data.tariff_target);
+			state.world.market_set_stockpile(route_data.target, cid, state.world.market_get_stockpile(route_data.target, cid) + route_data.amount_target);
 
 			assert(std::isfinite(state.world.market_get_export(route_data.origin, cid)));
 			assert(std::isfinite(state.world.market_get_import(route_data.target, cid)));
@@ -3858,13 +3861,13 @@ void daily_update(sys::state& state, bool presimulation, float presimulation_sta
 				// we forgive some debt to avoid death spirals:
 				// it generates a bit of money to keep the economy running
 				if(market.get_stockpile(economy::money) < 0.f) {
-					market.get_stockpile(economy::money) *= 0.9f;
+					market.set_stockpile(economy::money, market.get_stockpile(economy::money) * 0.9f);
 				}
 
 				auto income_scale = state.world.market_get_income_scale(market);
 				auto trade_income = market.get_stockpile(economy::money) * 0.1f;
 				if(trade_income > 0.f) {
-					market.get_stockpile(economy::money) *= 0.9f;
+					market.set_stockpile(economy::money, market.get_stockpile(economy::money) * 0.9f);
 				} else {
 					continue;
 				}
@@ -4082,8 +4085,8 @@ void daily_update(sys::state& state, bool presimulation, float presimulation_sta
 			} else {
 				market_profit += total_rgo_profit;
 			}
-
-			state.world.market_get_stockpile(market, economy::money) += market_profit + market_rgo_activity_cut;
+			auto& cur_money = state.world.market_get_stockpile(market, economy::money);
+			state.world.market_set_stockpile(market, economy::money, cur_money + market_profit + market_rgo_activity_cut);
 
 			auto market_cut_from_wages = 0.f;
 			auto total_wage = 0.f;
@@ -4173,7 +4176,7 @@ void daily_update(sys::state& state, bool presimulation, float presimulation_sta
 			}
 
 			market_cut_from_wages += total_wage * local_market_cut;
-			state.world.market_get_stockpile(market, economy::money) += market_cut_from_wages;
+			state.world.market_set_stockpile(market, economy::money, state.world.market_get_stockpile(market, economy::money) + market_cut_from_wages);
 		}
 
 		/* advance construction */
@@ -4285,7 +4288,7 @@ void daily_update(sys::state& state, bool presimulation, float presimulation_sta
 
 			assert(std::isfinite(t_total));
 			assert(t_total >= 0);
-			state.world.nation_get_stockpiles(n, money) += t_total;
+			state.world.nation_set_stockpiles(n, money, state.world.nation_get_stockpiles(n, money) + t_total);
 		}
 
 		// shift needs weights
@@ -4452,8 +4455,8 @@ void daily_update(sys::state& state, bool presimulation, float presimulation_sta
 
 		if(overlord) {
 			auto transferamt = estimate_subject_payments_paid(state, n);
-			state.world.nation_get_stockpiles(n, money) -= transferamt;
-			state.world.nation_get_stockpiles(overlord, money) += transferamt;
+			state.world.nation_set_stockpiles(n, money, state.world.nation_get_stockpiles(n, money) - transferamt);
+			state.world.nation_set_stockpiles(overlord, money, state.world.nation_get_stockpiles(overlord, money) + transferamt);
 		}
 
 		for(auto uni : n.get_unilateral_relationship_as_source()) {
@@ -4461,8 +4464,9 @@ void daily_update(sys::state& state, bool presimulation, float presimulation_sta
 				auto sub_size = estimate_war_subsidies(state, uni.get_target(), uni.get_source());
 
 				if(sub_size <= n.get_stockpiles(money)) {
-					n.get_stockpiles(money) -= sub_size;
-					uni.get_target().get_stockpiles(money) += sub_size;
+					n.set_stockpiles(money, n.get_stockpiles(money) - sub_size);
+					auto& current = uni.get_target().get_stockpiles(money);
+					uni.get_target().set_stockpiles(money, current + sub_size);
 				} else {
 					uni.set_war_subsidies(false);
 
@@ -4483,9 +4487,9 @@ void daily_update(sys::state& state, bool presimulation, float presimulation_sta
 				auto payout = total_tax_base * tax_eff * state.defines.reparations_tax_hit;
 				auto capped_payout = std::min(n.get_stockpiles(money), payout);
 				assert(capped_payout >= 0.0f);
-
-				n.get_stockpiles(money) -= capped_payout;
-				uni.get_target().get_stockpiles(money) += capped_payout;
+				n.set_stockpiles(money, n.get_stockpiles(money) - capped_payout);
+				auto& current = uni.get_target().get_stockpiles(money);
+				uni.get_target().set_stockpiles(money, current + capped_payout);
 			}
 		}
 	}
@@ -5286,7 +5290,7 @@ void resolve_constructions(sys::state& state) {
 
 		if(all_finished) {
 			if(state.world.province_get_building_level(for_province, uint8_t(t)) < state.world.nation_get_max_building_level(state.world.province_get_nation_from_province_ownership(for_province), uint8_t(t))) {
-				state.world.province_get_building_level(for_province, uint8_t(t)) += 1;
+				state.world.province_set_building_level(for_province, uint8_t(t), uint8_t(state.world.province_get_building_level(for_province, uint8_t(t)) + 1));
 
 				if(t == province_building_type::railroad) {
 					/* Notify the railroad mesh builder to update the railroads! */
@@ -5561,12 +5565,12 @@ void bound_budget_settings(sys::state& state, dcon::nation_id n) {
 
 		{
 			auto& tariff = state.world.nation_get_tariffs_import(n);
-			tariff = int8_t(std::clamp(std::clamp(int32_t(tariff), min_tariff, max_tariff), 0, 100));
+			state.world.nation_set_tariffs_import(n, int8_t(std::clamp(std::clamp(int32_t(tariff), min_tariff, max_tariff), 0, 100)));
 		}
 
 		{
 			auto& tariff = state.world.nation_get_tariffs_export(n);
-			tariff = int8_t(std::clamp(std::clamp(int32_t(tariff), min_tariff, max_tariff), 0, 100));
+			state.world.nation_set_tariffs_export(n, int8_t(std::clamp(std::clamp(int32_t(tariff), min_tariff, max_tariff), 0, 100)));
 		}
 	}
 	{
@@ -5577,11 +5581,11 @@ void bound_budget_settings(sys::state& state, dcon::nation_id n) {
 		max_tax = std::max(min_tax, max_tax);
 
 		auto& ptax = state.world.nation_get_poor_tax(n);
-		ptax = int8_t(std::clamp(std::clamp(int32_t(ptax), min_tax, max_tax), 0, 100));
+		state.world.nation_set_poor_tax(n, int8_t(std::clamp(std::clamp(int32_t(ptax), min_tax, max_tax), 0, 100)));
 		auto& mtax = state.world.nation_get_middle_tax(n);
-		mtax = int8_t(std::clamp(std::clamp(int32_t(mtax), min_tax, max_tax), 0, 100));
+		state.world.nation_set_middle_tax(n, int8_t(std::clamp(std::clamp(int32_t(mtax), min_tax, max_tax), 0, 100)));
 		auto& rtax = state.world.nation_get_rich_tax(n);
-		rtax = int8_t(std::clamp(std::clamp(int32_t(rtax), min_tax, max_tax), 0, 100));
+		state.world.nation_set_rich_tax(n, int8_t(std::clamp(std::clamp(int32_t(rtax), min_tax, max_tax), 0, 100)));
 	}
 	{
 		auto min_spend =
@@ -5593,7 +5597,7 @@ void bound_budget_settings(sys::state& state, dcon::nation_id n) {
 		max_spend = std::max(min_spend, max_spend);
 
 		auto& v = state.world.nation_get_military_spending(n);
-		v = int8_t(std::clamp(std::clamp(int32_t(v), min_spend, max_spend), 0, 100));
+		state.world.nation_set_military_spending(n, int8_t(std::clamp(std::clamp(int32_t(v), min_spend, max_spend), 0, 100)));
 	}
 	{
 		auto min_spend = int32_t(100.0f * state.world.nation_get_modifier_values(n, sys::national_mod_offsets::min_social_spending));
@@ -5603,7 +5607,7 @@ void bound_budget_settings(sys::state& state, dcon::nation_id n) {
 		max_spend = std::max(min_spend, max_spend);
 
 		auto& v = state.world.nation_get_social_spending(n);
-		v = int8_t(std::clamp(std::clamp(int32_t(v), min_spend, max_spend), 0, 100));
+		state.world.nation_set_social_spending(n, int8_t(std::clamp(std::clamp(int32_t(v), min_spend, max_spend), 0, 100)));
 	}
 	{
 		auto min_spend = int32_t(100.0f * state.world.nation_get_modifier_values(n, sys::national_mod_offsets::min_domestic_investment));
@@ -5613,7 +5617,7 @@ void bound_budget_settings(sys::state& state, dcon::nation_id n) {
 		max_spend = std::max(min_spend, max_spend);
 
 		auto& v = state.world.nation_get_domestic_investment_spending(n);
-		v = int8_t(std::clamp(std::clamp(int32_t(v), min_spend, max_spend), 0, 100));
+		state.world.nation_set_domestic_investment_spending(n, int8_t(std::clamp(std::clamp(int32_t(v), min_spend, max_spend), 0, 100)));
 	}
 }
 
@@ -5694,7 +5698,7 @@ void go_bankrupt(sys::state& state, dcon::nation_id n) {
 	sys::add_modifier_to_nation(state, n, state.national_definitions.in_bankrupcy, state.current_date + int32_t(state.defines.bankrupcy_duration * 365));
 	sys::add_modifier_to_nation(state, n, state.national_definitions.bad_debter, state.current_date + int32_t(state.defines.bankruptcy_external_loan_years * 365));
 
-	debt = 0.0f;
+	state.world.nation_set_local_loan(n, 0.0f);
 	state.world.nation_set_is_debt_spending(n, false);
 	state.world.nation_set_bankrupt_until(n, state.current_date + int32_t(state.defines.bankrupcy_duration * 365));
 

--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -30,8 +30,7 @@ void add_to_command_queue(sys::state& state, payload& p) {
 
 	switch(p.type) {
 		
-	case command_type::notify_start_game:
-	case command_type::notify_stop_game:
+	
 	case command_type::notify_player_joins:
 	case command_type::notify_player_leaves:
 	case command_type::notify_player_picks_nation:
@@ -46,6 +45,15 @@ void add_to_command_queue(sys::state& state, payload& p) {
 	case command_type::chat_message:
 		// Notifications can be sent because it's an-always do thing
 		break;
+	case command_type::notify_start_game:
+	case command_type::notify_stop_game:
+		// do not allow starting or stopping the game whilst clients are loading!
+		if(state.network_state.num_client_loading == 0) {
+			break;
+		}
+		else {
+			return;
+		}
 	default:
 		// Normal commands are discarded iff we are not in the game, or if any other client is loading
 		if(!state.current_scene.game_in_progress || state.network_state.num_client_loading != 0)

--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -5669,9 +5669,8 @@ void notify_reload(sys::state& state, dcon::nation_id source) {
 }
 void execute_notify_reload(sys::state& state, dcon::nation_id source, sys::checksum_key& k) {
 	state.session_host_checksum = k;
-	/* Reset OOS state, and for host, advise new clients with a save stream so they can hotjoin!
-	   Additionally we will clear the new client sending queue, since the state is no longer
-	   "replayable" without heavy bandwidth costs */
+	// reload the save *locally* to ensure synch with the rest of the lobby. Primarily to update unsaved data.
+	// this only happens when a new player joins, or when a manual resync is initiated, and only for the clients which are already "in sync". If a new or oos'd client needs a fresh save, it will be provided as a save stream elsewhere.
 	state.network_state.is_new_game = false;
 	state.network_state.out_of_sync = false;
 	state.network_state.reported_oos = false;
@@ -5706,16 +5705,6 @@ void execute_notify_reload(sys::state& state, dcon::nation_id source, sys::check
 	state.console_log("client:exec:cmd | type=notify_reload from:" + std::to_string(source.index()) + "| checksum: " + encodedchecksum);
 #endif
 	 
-	ui::chat_message m{};
-	m.source = source;
-	text::substitution_map sub{};
-
-	auto p = network::find_country_player(state, source);
-	auto nickname = state.world.mp_player_get_nickname(p);
-	text::add_to_substitution_map(sub, text::variable_type::playername, sys::player_name{nickname }.to_string_view());
-	m.body = text::resolve_string_substitution(state, "chat_player_reload", sub);
-	post_chat_message(state, m);
-
 	network::log_player_nations(state);
 }
 

--- a/src/gui/gui_nation_picker.hpp
+++ b/src/gui/gui_nation_picker.hpp
@@ -629,10 +629,6 @@ public:
 		if(state.network_mode == sys::network_mode_type::client) {
 			if(state.network_state.save_stream) { //in the middle of a save stream
 				disabled = true;
-			} else {
-				if(state.network_state.out_of_sync) { //can't start if oos
-					disabled = true;
-				}
 			}
 		}
 	}
@@ -668,9 +664,6 @@ public:
 		if(state.network_mode == sys::network_mode_type::client) {
 			if(state.network_state.save_stream) {
 				text::localised_format_box(state, contents, box, std::string_view("alice_play_save_stream"));
-			}
-			else if(state.network_state.out_of_sync) {
-				text::localised_format_box(state, contents, box, std::string_view("alice_play_checksum_host"));
 			}
 			for(auto const& client : state.network_state.clients) {
 				if(client.is_active()) {

--- a/src/gui/gui_nation_picker.hpp
+++ b/src/gui/gui_nation_picker.hpp
@@ -630,7 +630,7 @@ public:
 			if(state.network_state.save_stream) { //in the middle of a save stream
 				disabled = true;
 			} else {
-				if(!state.session_host_checksum.is_equal(state.get_mp_state_checksum())) { //can't start if checksum doesn't match
+				if(state.network_state.out_of_sync) { //can't start if oos
 					disabled = true;
 				}
 			}
@@ -669,7 +669,7 @@ public:
 			if(state.network_state.save_stream) {
 				text::localised_format_box(state, contents, box, std::string_view("alice_play_save_stream"));
 			}
-			else if(!state.session_host_checksum.is_equal(state.get_mp_state_checksum())) {
+			else if(state.network_state.out_of_sync) {
 				text::localised_format_box(state, contents, box, std::string_view("alice_play_checksum_host"));
 			}
 			for(auto const& client : state.network_state.clients) {

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -1646,7 +1646,7 @@ void send_and_receive_commands(sys::state& state) {
 				state.network_state.save_data.clear();
 				state.network_state.save_stream = false; // go back to normal command loop stuff
 				window::change_cursor(state, window::cursor_type::normal);
-				// check that the gamestates are equal after loading, otherwise out of sync.
+				// check that the client gamestate is equal to the gamestate of the host, otherwise oos
 				if(!mp_state_checksum.is_equal(state.session_host_checksum)) {
 					state.network_state.out_of_sync = true;
 				}


### PR DESCRIPTION
This PR refactors the economy.cpp getter+setters into proper setters, and fixes a bug i stumbled upon in which naval consumption was added to army_demand instead of navy_demand.

It adds an additional safeguard in commands to ensure that it is not possible to stop/start a game while a client is loading (as this can lead to desyncs).

Removed some out-of-date text including a tooltip on the "start" button for the client which warned against a checksum mismatch. It now does a checksum/oos check when a client joins instead.

Removed the "host has reloated players" text message being sent when a reload is initiated. This was initially used for automatic resyncing, but has since been replaced by manual resyncing.