### PR TITLE
MP player network refactor, support co-op, and some minor military changes

### DIFF
--- a/assets/alice.gui
+++ b/assets/alice.gui
@@ -1,4 +1,14 @@
 guiTypes = {
+	guiButtonType = {
+		name = "observer_button"
+		extends = "lobby"
+		position = { x = 17 y = -200 }
+		quadTextureSprite ="GFX_frontend_play_button"	
+		buttonText = "alice_observer_btn_text"
+		buttonFont = "vic_32_black"
+		Orientation = "LOWER_LEFT"
+	}
+			
 	iconType = {
         name = "gfx_storage_unit_types"
         spriteType = "GFX_unit_strip"

--- a/assets/localisation/en-US/alice.csv
+++ b/assets/localisation/en-US/alice.csv
@@ -1554,3 +1554,5 @@ alice_host_has_resync;Host has resynced the lobby
 alice_naval_coordination_penalty;The $x$ are receiving a naval coordination penalty of ?R$y$?W from outnumbering their enemy, which reduces their target selection by ?R$val$?W
 alice_naval_coordination_bonus;The $x$ are receiving a naval coordination bonus of ?G$y$?W from being outnumbered, which increases their target selection by ?G$val$?W
 alice_naval_stacking_penalty;The $x$ are receiving a damage multiplier of ?R$y$?W from stacking penalties.
+alice_observer_btn_text;Play as observer
+alice_observer_already_observer_tooltip;You are already on the observer tag.

--- a/assets/localisation/en-US/alice.csv
+++ b/assets/localisation/en-US/alice.csv
@@ -1036,6 +1036,7 @@ disband_all;Disband all selected units
 alice_play_checksum_host;Checksum mismatch with host, ensure you have the same mods and savefiles
 alice_play_save_stream;Host is streaming a save to you, wait until it completes
 alice_no_start_game_player_loading;Cannot start the game while players are loading
+alice_no_start_game_invalid_nations;Cannot start the game while players are on non-existant nations
 ai_will_accept_po;They will accept this offer
 ai_will_not_accept_po;They will NOT accept this offer
 close_and_del;Close & Delete Factory

--- a/assets/localisation/en-US/mapmodes.csv
+++ b/assets/localisation/en-US/mapmodes.csv
@@ -95,6 +95,7 @@ mapmode_tooltip_34;Player: $x$
 mapmode_tooltip_34_you_sp;This is you! 
 mapmode_tooltip_34_you;Player: $x$ (This is you!) 
 mapmode_tooltip_34_ai;AI controlled
+mapmode_tooltip_35_no_ai;Not AI controlled
 mapmode_tooltip_35;Life needs satisfied: $x$
 mapmode_tooltip_36;Everyday needs satisfied: $x$
 mapmode_tooltip_37;Luxury needs satisfied: $x$

--- a/assets/localisation/en-US/mapmodes.csv
+++ b/assets/localisation/en-US/mapmodes.csv
@@ -95,7 +95,7 @@ mapmode_tooltip_34;Player: $x$
 mapmode_tooltip_34_you_sp;This is you! 
 mapmode_tooltip_34_you;Player: $x$ (This is you!) 
 mapmode_tooltip_34_ai;AI controlled
-mapmode_tooltip_35_no_ai;Not AI controlled
+mapmode_tooltip_34_no_ai;Not AI controlled
 mapmode_tooltip_35;Life needs satisfied: $x$
 mapmode_tooltip_36;Everyday needs satisfied: $x$
 mapmode_tooltip_37;Luxury needs satisfied: $x$

--- a/src/common_types/container_types.hpp
+++ b/src/common_types/container_types.hpp
@@ -302,6 +302,10 @@ struct player_value {
 		return *this;
 	}
 
+	bool is_equal(player_value<_Size> other) {
+		return other.data == data;
+	}
+
 	std::string to_string() noexcept {
 		return std::string(to_string_view());
 	}

--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -43,12 +43,13 @@ void add_to_command_queue(sys::state& state, payload& p) {
 	case command_type::notify_player_fully_loaded:
 	case command_type::notify_player_is_loading:
 	case command_type::chat_message:
+	case command_type::change_ai_nation_state:
 		// Notifications can be sent because it's an-always do thing
 		break;
 	case command_type::notify_start_game:
 	case command_type::notify_stop_game:
 		// do not allow starting or stopping the game whilst clients are loading!
-		if(state.network_state.num_client_loading == 0) {
+		if(!network::check_any_players_loading(state)) {
 			break;
 		}
 		else {
@@ -56,7 +57,7 @@ void add_to_command_queue(sys::state& state, payload& p) {
 		}
 	default:
 		// Normal commands are discarded iff we are not in the game, or if any other client is loading
-		if(!state.current_scene.game_in_progress || state.network_state.num_client_loading != 0)
+		if(!state.current_scene.game_in_progress || network::check_any_players_loading(state))
 			return;
 		state.network_state.is_new_game = false;
 		break;
@@ -5352,27 +5353,29 @@ void execute_notify_player_joins(sys::state& state, dcon::nation_id source, sys:
 	state.console_log("client:receive:cmd | type:notify_player_joins | nation: " + std::to_string(source.index()) + " | name: " + name.to_string());
 #endif
 
-	auto p = network::find_mp_player(state, name);
-	if(p) {
-		auto oldnation = state.world.mp_player_get_nation_from_player_nation(p);
+	network::create_mp_player(state, name, password, !needs_loading, false, source);
 
-		if (oldnation != source && oldnation) // check for old nation validity before setting it to be not player controlled
-			state.world.nation_set_is_player_controlled(oldnation, false);
+	//auto p = network::find_mp_player(state, name);
+	//if(p) {
+	//	auto oldnation = state.world.mp_player_get_nation_from_player_nation(p);
 
-		// Server already validated password by this point
-		// Client always receives empty passwords
-		if(!password.empty()) {
-			network::update_mp_player_password(state, p, password);
-		}
-		// update mp player with the joining players loading state
-		state.world.mp_player_set_fully_loaded(p, !needs_loading);
-		state.world.mp_player_set_is_oos(p, false);
-	}
-	else {
-		p = network::create_mp_player(state, name, password, !needs_loading, false);
-	}
- 	state.world.nation_set_is_player_controlled(source, true);
-	state.world.force_create_player_nation(source, p);
+	//	if (oldnation != source && oldnation) // check for old nation validity before setting it to be not player controlled
+	//		state.world.nation_set_is_player_controlled(oldnation, false);
+
+	//	// Server already validated password by this point
+	//	// Client always receives empty passwords
+	//	if(!password.empty()) {
+	//		network::update_mp_player_password(state, p, password);
+	//	}
+	//	// update mp player with the joining players loading state
+	//	state.world.mp_player_set_fully_loaded(p, !needs_loading);
+	//	state.world.mp_player_set_is_oos(p, false);
+	//}
+	//else {
+	//	p = network::create_mp_player(state, name, password, !needs_loading, false);
+	//}
+ //	state.world.nation_set_is_player_controlled(source, true);
+	//state.world.force_create_player_nation(source, p);
 
 	if(needs_loading) {
 		payload cmd;
@@ -5397,31 +5400,40 @@ void execute_notify_player_joins(sys::state& state, dcon::nation_id source, sys:
 	network::log_player_nations(state);
 }
 
-void notify_player_leaves(sys::state& state, dcon::nation_id source, bool make_ai) {
+void notify_player_leaves(sys::state& state, dcon::nation_id source, bool make_ai, sys::player_name& player_name) {
 	payload p;
 	memset(&p, 0, sizeof(payload));
 	p.type = command_type::notify_player_leaves;
 	p.source = source;
 	p.data.notify_leave.make_ai = make_ai;
+	p.data.notify_leave.player_name = player_name;
 	add_to_command_queue(state, p);
 }
-bool can_notify_player_leaves(sys::state& state, dcon::nation_id source, bool make_ai) {
+bool can_notify_player_leaves(sys::state& state, dcon::nation_id source, bool make_ai, sys::player_name& player_name) {
 	return state.world.nation_get_is_player_controlled(source);
 }
-void execute_notify_player_leaves(sys::state& state, dcon::nation_id source, bool make_ai) {
-	if(make_ai) {
-		state.world.nation_set_is_player_controlled(source, false);
+void execute_notify_player_leaves(sys::state& state, dcon::nation_id source, bool make_ai, sys::player_name& player_name) {
+
+
+	auto p = network::find_mp_player(state, player_name);
+	if(p) {
+
+		network::delete_mp_player(state, p, make_ai);
 	}
-	auto player = network::find_country_player(state, source);
-	// if the leaving player was loading, decrement num of loading clients
-	if(player && !state.world.mp_player_get_fully_loaded(player) && state.network_state.num_client_loading != 0) {
-		state.network_state.num_client_loading--;
-		state.world.mp_player_set_is_oos(player, false);
-	}
+
+	//if(make_ai) {
+	//	state.world.nation_set_is_player_controlled(source, false);
+	//}
+	//auto player = network::find_country_player(state, source);
+	//// if the leaving player was loading, decrement num of loading clients
+	//if(player && !state.world.mp_player_get_fully_loaded(player) && state.network_state.num_client_loading != 0) {
+	//	state.network_state.num_client_loading--;
+	//	state.world.mp_player_set_is_oos(player, false);
+	//}
 
 	if(state.network_mode == sys::network_mode_type::host) {
 		for(auto& client : state.network_state.clients) {
-			if(client.is_active() && client.playing_as == source) {
+			if(client.is_active() && client.hshake_buffer.nickname.is_equal(player_name)) {
 				network::clear_socket(state, client);
 			}
 		}
@@ -5430,46 +5442,51 @@ void execute_notify_player_leaves(sys::state& state, dcon::nation_id source, boo
 	ui::chat_message m{};
 	m.source = source;
 	text::substitution_map sub{};
-	auto p = network::find_country_player(state, source);
 	auto nickname = state.world.mp_player_get_nickname(p);
 	text::add_to_substitution_map(sub, text::variable_type::playername, sys::player_name{nickname }.to_string_view());
 	m.body = text::resolve_string_substitution(state, "chat_player_leaves", sub);
 	post_chat_message(state, m);
 }
 
-void notify_player_ban(sys::state& state, dcon::nation_id source, dcon::nation_id target) {
+void execute_change_ai_nation_state(sys::state& state, dcon::nation_id source, bool no_ai) 	{
+	state.world.nation_set_is_player_controlled(source, no_ai);
+}
+void notify_player_ban(sys::state& state, dcon::nation_id source, bool make_ai, sys::player_name& name) {
 	payload p;
 	memset(&p, 0, sizeof(payload));
 	p.type = command_type::notify_player_ban;
 	p.source = source;
-	p.data.nation_pick.target = target;
+	p.data.notify_player_ban.make_ai = make_ai;
+	p.data.notify_player_ban.player_name = name;
 	add_to_command_queue(state, p);
 }
-bool can_notify_player_ban(sys::state& state, dcon::nation_id source, dcon::nation_id target) {
-	if(source == target) // can't perform on self
+bool can_notify_player_ban(sys::state& state, dcon::nation_id source, sys::player_name& name) {
+	if(state.network_state.nickname.is_equal(name)) // can't perform on self
 		return false;
 	return true;
 }
-void execute_notify_player_ban(sys::state& state, dcon::nation_id source, dcon::nation_id target) {
+void execute_notify_player_ban(sys::state& state, dcon::nation_id source, bool make_ai, sys::player_name& name) {
 
-	auto player = network::find_country_player(state, source);
+	auto player = network::find_mp_player(state, name);
+	auto nickname = state.world.mp_player_get_nickname(player);
+	if(player) {
+		network::delete_mp_player(state, player, make_ai);
+	}
 	// if the leaving player was loading, decrement num of loading clients
-	if(player && !state.world.mp_player_get_fully_loaded(player) && state.network_state.num_client_loading != 0) {
+	/*if(player && !state.world.mp_player_get_fully_loaded(player) && state.network_state.num_client_loading != 0) {
 		state.network_state.num_client_loading--;
 		state.world.mp_player_set_is_oos(player, false);
-	}
+	}*/
 
 	if(state.network_mode == sys::network_mode_type::host) {
 		for(auto& client : state.network_state.clients) {
-			if(client.is_active() && client.playing_as == target) {
+			if(client.is_active() && client.hshake_buffer.nickname.is_equal(name)) {
 				network::ban_player(state, client);
 			}
 		}
 	}
-	state.world.nation_set_is_player_controlled(target, false);
+	/*state.world.nation_set_is_player_controlled(target, false);*/
 
-	auto p = network::find_country_player(state, target);
-	auto nickname = state.world.mp_player_get_nickname(p);
 
 	ui::chat_message m{};
 	m.source = source;
@@ -5479,82 +5496,91 @@ void execute_notify_player_ban(sys::state& state, dcon::nation_id source, dcon::
 	post_chat_message(state, m);
 }
 
-void notify_player_kick(sys::state& state, dcon::nation_id source, dcon::nation_id target) {
+void notify_player_kick(sys::state& state, dcon::nation_id source, bool make_ai, sys::player_name& name) {
 	payload p;
 	memset(&p, 0, sizeof(payload));
 	p.type = command_type::notify_player_kick;
 	p.source = source;
-	p.data.nation_pick.target = target;
+	p.data.notify_player_kick.make_ai = make_ai;
+	p.data.notify_player_kick.player_name = name;
 	add_to_command_queue(state, p);
 }
-bool can_notify_player_kick(sys::state& state, dcon::nation_id source, dcon::nation_id target) {
-	if(source == target) // can't perform on self
+bool can_notify_player_kick(sys::state& state, dcon::nation_id source, sys::player_name& name) {
+	if(state.network_state.nickname.is_equal(name)) // can't perform on self
 		return false;
 	return true;
 }
-void execute_notify_player_kick(sys::state& state, dcon::nation_id source, dcon::nation_id target) {
-	auto player = network::find_country_player(state, source);
+void execute_notify_player_kick(sys::state& state, dcon::nation_id source, bool make_ai, sys::player_name& name) {
+	auto player = network::find_mp_player(state, name);
+	auto nickname = state.world.mp_player_get_nickname(player);
+	if(player) {
+		network::delete_mp_player(state, player, make_ai);
+	}
 	// if the leaving player was loading, decrement num of loading clients
-	if(player && !state.world.mp_player_get_fully_loaded(player) && state.network_state.num_client_loading != 0) {
+	/*if(player && !state.world.mp_player_get_fully_loaded(player) && state.network_state.num_client_loading != 0) {
 		state.network_state.num_client_loading--;
 		state.world.mp_player_set_is_oos(player, false);
-	}
+	}*/
 	if(state.network_mode == sys::network_mode_type::host) {
 		for(auto& client : state.network_state.clients) {
-			if(client.is_active() && client.playing_as == target) {
+			if(client.is_active() && client.hshake_buffer.nickname.is_equal(name)) {
 				network::kick_player(state, client);
 			}
 		}
 	}
-	state.world.nation_set_is_player_controlled(target, false);
+	/*state.world.nation_set_is_player_controlled(target, false);*/
 
 	ui::chat_message m{};
 	m.source = source;
 	text::substitution_map sub{};
 
-	auto p = network::find_country_player(state, target);
-	auto nickname = state.world.mp_player_get_nickname(p);
 	text::add_to_substitution_map(sub, text::variable_type::playername, sys::player_name{nickname }.to_string_view());
 	m.body = text::resolve_string_substitution(state, "chat_player_kick", sub);
 	post_chat_message(state, m);
 }
 
-void notify_player_picks_nation(sys::state& state, dcon::nation_id source, dcon::nation_id target) {
+void notify_player_picks_nation(sys::state& state, dcon::nation_id source, dcon::nation_id target, sys::player_name& name) {
 	payload p;
 	memset(&p, 0, sizeof(payload));
 	p.type = command_type::notify_player_picks_nation;
 	p.source = source;
 	p.data.nation_pick.target = target;
+	p.data.nation_pick.player_name = name;
 	add_to_command_queue(state, p);
 }
-bool can_notify_player_picks_nation(sys::state& state, dcon::nation_id source, dcon::nation_id target) {
-	if(source == target) //redundant
+bool can_notify_player_picks_nation(sys::state& state, dcon::nation_id source, dcon::nation_id target, sys::player_name& name) {
+	auto player = network::find_mp_player(state, name);
+	if(source == target || !player) //redundant
 		return false;
 	if(!bool(target) || target == state.world.national_identity_get_nation_from_identity_holder(state.national_definitions.rebel_id)) //Invalid OR rebel nation
 		return false;
-	// TODO: Support Co-op (one day)
-	return state.world.nation_get_is_player_controlled(target) == false;
+	// Should support co-op now. Make sure the source nation for the player is the same as the one being sent
+	return state.world.mp_player_get_nation_from_player_nation(player) == source;
 }
-void execute_notify_player_picks_nation(sys::state& state, dcon::nation_id source, dcon::nation_id target) {
+void execute_notify_player_picks_nation(sys::state& state, dcon::nation_id source, dcon::nation_id target, sys::player_name& name) {
 	assert(source && source != state.world.national_identity_get_nation_from_identity_holder(state.national_definitions.rebel_id));
-	network::switch_player(state, target, source);
-	state.world.nation_set_is_player_controlled(source, false);
-	state.world.nation_set_is_player_controlled(target, true);
+	auto player = network::find_mp_player(state, name);
+	assert(player);
+	if(player) {
+		network::switch_mp_player_country(state, target, source, player);
 
-	if(state.local_player_nation == source) {
-		state.local_player_nation = target;
+		if(state.network_state.nickname.is_equal(name)) {
+			state.local_player_nation = target;
+		}
+		// We will also re-assign all chat messages from this nation to the new one
+		for(auto& msg : state.ui_state.chat_messages)
+			if(bool(msg.source) && msg.source == source)
+				msg.source = target;
 	}
-	// We will also re-assign all chat messages from this nation to the new one
-	for(auto& msg : state.ui_state.chat_messages)
-		if(bool(msg.source) && msg.source == source)
-			msg.source = target;
+	
 }
 
-void notify_player_oos(sys::state& state, dcon::nation_id source) {
+void notify_player_oos(sys::state& state, dcon::nation_id source, sys::player_name& name) {
 	payload p;
 	memset(&p, 0, sizeof(payload));
 	p.type = command_type::notify_player_oos;
 	p.source = source;
+	p.data.notify_player_oos.player_name = name;
 	add_to_command_queue(state, p);
 
 #ifndef NDEBUG
@@ -5570,13 +5596,13 @@ void notify_player_oos(sys::state& state, dcon::nation_id source) {
 
 	network::log_player_nations(state);
 }
-void execute_notify_player_oos(sys::state& state, dcon::nation_id source) {
+void execute_notify_player_oos(sys::state& state, dcon::nation_id source, sys::player_name& name) {
 	state.actual_game_speed = 0; //pause host immediately
 	state.debug_save_oos_dump();
 
 	network::log_player_nations(state);
 
-	auto player = network::find_country_player(state, source);
+	auto player = network::find_mp_player(state, name);
 	assert(player);
 	if(player) {
 		state.world.mp_player_set_is_oos(player, true);
@@ -5585,8 +5611,7 @@ void execute_notify_player_oos(sys::state& state, dcon::nation_id source) {
 	ui::chat_message m{};
 	m.source = source;
 	text::substitution_map sub{};
-	auto p = network::find_country_player(state, source);
-	auto nickname = state.world.mp_player_get_nickname(p);
+	auto nickname = state.world.mp_player_get_nickname(player);
 	text::add_to_substitution_map(sub, text::variable_type::playername, sys::player_name{nickname }.to_string_view());
 	m.body = text::resolve_string_substitution(state, "chat_player_oos", sub);
 	post_chat_message(state, m);
@@ -5751,8 +5776,7 @@ void execute_notify_player_is_loading(sys::state& state, dcon::nation_id source,
 	assert(player);
 	// if it is a valid player
 	if(player) {
-		state.world.mp_player_set_fully_loaded(player, false);
-		state.network_state.num_client_loading++;
+		network::mp_player_set_fully_loaded(state, player, false);
 		
 	};
 }
@@ -5773,12 +5797,8 @@ void execute_notify_player_fully_loaded(sys::state& state, dcon::nation_id sourc
 	assert(player);
 	// if it is a valid player
 	if(player) {
-		state.world.mp_player_set_fully_loaded(player, true);
+		network::mp_player_set_fully_loaded(state, player, true);
 		state.world.mp_player_set_is_oos(player, false);
-		assert(state.network_state.num_client_loading != 0);
-		if(state.network_state.num_client_loading != 0) {
-			state.network_state.num_client_loading--;
-		}
 	};
 }
 
@@ -6177,19 +6197,19 @@ bool can_perform_command(sys::state& state, payload& c) {
 
 	}
 	case command_type::notify_player_ban:
-		return can_notify_player_ban(state, c.source, c.data.nation_pick.target);
+		return can_notify_player_ban(state, c.source, c.data.notify_player_ban.player_name);
 
 	case command_type::notify_player_kick:
-		return can_notify_player_kick(state, c.source, c.data.nation_pick.target);
+		return can_notify_player_kick(state, c.source, c.data.notify_player_kick.player_name);
 
 	case command_type::notify_player_joins:
 		return can_notify_player_joins(state, c.source, c.data.notify_join.player_name);
 
 	case command_type::notify_player_leaves:
-		return can_notify_player_leaves(state, c.source, c.data.notify_leave.make_ai);
+		return can_notify_player_leaves(state, c.source, c.data.notify_leave.make_ai, c.data.notify_leave.player_name);
 
 	case command_type::notify_player_picks_nation:
-		return can_notify_player_picks_nation(state, c.source, c.data.nation_pick.target);
+		return can_notify_player_picks_nation(state, c.source, c.data.nation_pick.target, c.data.nation_pick.player_name);
 
 	case command_type::notify_player_oos:
 		return true; //return can_notify_player_oos(state, c.source);
@@ -6218,6 +6238,8 @@ bool can_perform_command(sys::state& state, payload& c) {
 	case command_type::notify_player_fully_loaded:
 		return true;
 	case command_type::notify_player_is_loading:
+		return true;
+	case command_type::change_ai_nation_state:
 		return true;
 	}
 	return false;
@@ -6572,22 +6594,22 @@ bool execute_command(sys::state& state, payload& c) {
 		break;
 	}
 	case command_type::notify_player_ban:
-		execute_notify_player_ban(state, c.source, c.data.nation_pick.target);
+		execute_notify_player_ban(state, c.source, c.data.notify_player_ban.make_ai, c.data.notify_player_ban.player_name);
 		break;
 	case command_type::notify_player_kick:
-		execute_notify_player_kick(state, c.source, c.data.nation_pick.target);
+		execute_notify_player_kick(state, c.source, c.data.notify_player_kick.make_ai, c.data.notify_player_kick.player_name);
 		break;
 	case command_type::notify_player_joins:
 		execute_notify_player_joins(state, c.source, c.data.notify_join.player_name, c.data.notify_join.player_password, c.data.notify_join.needs_loading);
 		break;
 	case command_type::notify_player_leaves:
-		execute_notify_player_leaves(state, c.source, c.data.notify_leave.make_ai);
+		execute_notify_player_leaves(state, c.source, c.data.notify_leave.make_ai, c.data.notify_leave.player_name);
 		break;
 	case command_type::notify_player_picks_nation:
-		execute_notify_player_picks_nation(state, c.source, c.data.nation_pick.target);
+		execute_notify_player_picks_nation(state, c.source, c.data.nation_pick.target, c.data.nation_pick.player_name);
 		break;
 	case command_type::notify_player_oos:
-		execute_notify_player_oos(state, c.source);
+		execute_notify_player_oos(state, c.source, c.data.notify_player_oos.player_name);
 		break;
 	case command_type::advance_tick:
 		execute_advance_tick(state, c.source, c.data.advance_tick.checksum, c.data.advance_tick.speed, c.data.advance_tick.date);
@@ -6623,6 +6645,8 @@ bool execute_command(sys::state& state, payload& c) {
 	case command_type::notify_player_is_loading:
 		execute_notify_player_is_loading(state, c.source, c.data.notify_player_fully_loaded.name);
 		break;
+	case command_type::change_ai_nation_state:
+		execute_change_ai_nation_state(state, c.source, c.data.change_ai_nation_state.no_ai);
 	}
 	return true;
 }

--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -5468,11 +5468,6 @@ void execute_notify_player_ban(sys::state& state, dcon::nation_id source, bool m
 	if(player) {
 		network::delete_mp_player(state, player, make_ai);
 	}
-	// if the leaving player was loading, decrement num of loading clients
-	/*if(player && !state.world.mp_player_get_fully_loaded(player) && state.network_state.num_client_loading != 0) {
-		state.network_state.num_client_loading--;
-		state.world.mp_player_set_is_oos(player, false);
-	}*/
 
 	if(state.network_mode == sys::network_mode_type::host) {
 		for(auto& client : state.network_state.clients) {
@@ -5481,7 +5476,6 @@ void execute_notify_player_ban(sys::state& state, dcon::nation_id source, bool m
 			}
 		}
 	}
-	/*state.world.nation_set_is_player_controlled(target, false);*/
 
 
 	ui::chat_message m{};
@@ -5514,11 +5508,6 @@ void execute_notify_player_kick(sys::state& state, dcon::nation_id source, bool 
 	if(player) {
 		network::delete_mp_player(state, player, make_ai);
 	}
-	// if the leaving player was loading, decrement num of loading clients
-	/*if(player && !state.world.mp_player_get_fully_loaded(player) && state.network_state.num_client_loading != 0) {
-		state.network_state.num_client_loading--;
-		state.world.mp_player_set_is_oos(player, false);
-	}*/
 	if(state.network_mode == sys::network_mode_type::host) {
 		for(auto& client : state.network_state.clients) {
 			if(client.is_active() && client.hshake_buffer.nickname.is_equal(name)) {
@@ -5526,7 +5515,6 @@ void execute_notify_player_kick(sys::state& state, dcon::nation_id source, bool 
 			}
 		}
 	}
-	/*state.world.nation_set_is_player_controlled(target, false);*/
 
 	ui::chat_message m{};
 	m.source = source;

--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -5702,10 +5702,10 @@ void execute_notify_reload(sys::state& state, dcon::nation_id source, sys::check
 
 	window::change_cursor(state, window::cursor_type::busy);
 	state.ui_lock.lock();
-	std::vector<dcon::nation_id> players;
+	std::vector<dcon::nation_id> no_ai_nations;
 	for(const auto n : state.world.in_nation)
 		if(state.world.nation_get_is_player_controlled(n))
-			players.push_back(n);
+			no_ai_nations.push_back(n);
 	dcon::nation_id old_local_player_nation = state.local_player_nation;
 	/* Save the buffer before we fill the unsaved data */
 	size_t length = sizeof_save_section(state);
@@ -5715,7 +5715,7 @@ void execute_notify_reload(sys::state& state, dcon::nation_id source, sys::check
 	/* Then reload as if we loaded the save data */
 	state.reset_state();
 	sys::read_save_section(save_buffer.get(), save_buffer.get() + length, state);
-	network::place_players_after_reload(state, players, old_local_player_nation);
+	network::place_players_after_reload(state, no_ai_nations, old_local_player_nation);
 	state.fill_unsaved_data();
 	state.ui_lock.unlock();
 	window::change_cursor(state, window::cursor_type::normal);

--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -5552,13 +5552,13 @@ bool can_notify_player_picks_nation(sys::state& state, dcon::nation_id source, d
 	auto player = network::find_mp_player(state, name);
 	if(source == target || !player) //redundant
 		return false;
-	if(!bool(target) || target == state.world.national_identity_get_nation_from_identity_holder(state.national_definitions.rebel_id)) //Invalid OR rebel nation
+	if(!bool(target)) //Invalid nation
 		return false;
 	// Should support co-op now. Make sure the source nation for the player is the same as the one being sent
 	return state.world.mp_player_get_nation_from_player_nation(player) == source;
 }
 void execute_notify_player_picks_nation(sys::state& state, dcon::nation_id source, dcon::nation_id target, sys::player_name& name) {
-	assert(source && source != state.world.national_identity_get_nation_from_identity_holder(state.national_definitions.rebel_id));
+	assert(source);
 	auto player = network::find_mp_player(state, name);
 	assert(player);
 	if(player) {
@@ -5717,7 +5717,7 @@ void execute_notify_reload(sys::state& state, dcon::nation_id source, sys::check
 	/* Then reload as if we loaded the save data */
 	state.reset_state();
 	sys::read_save_section(save_buffer.get(), save_buffer.get() + length, state);
-	network::place_players_after_reload(state, no_ai_nations, old_local_player_nation);
+	network::set_no_ai_nations_after_reload(state, no_ai_nations, old_local_player_nation);
 	state.fill_unsaved_data();
 	state.ui_lock.unlock();
 	window::change_cursor(state, window::cursor_type::normal);

--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -2182,6 +2182,64 @@ void execute_take_decision(sys::state& state, dcon::nation_id source, dcon::deci
 	});
 }
 
+bool can_make_event_choice(sys::state& state, dcon::nation_id source, pending_human_n_event_data const& e) {
+	for(auto i = state.pending_n_event.size(); i-- > 0;) {
+		if(event::pending_human_n_event{e.r_lo, e.r_hi, e.primary_slot, e.from_slot, e.date, e.e, source, e.pt, e.ft} == state.pending_n_event[i]) {
+			if(e.opt_choice > state.world.national_event_get_options(e.e).size() || !event::is_valid_option(state.world.national_event_get_options(e.e)[e.opt_choice])) {
+				return false; // invalid option
+			}
+			else {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+bool can_make_event_choice(sys::state& state, dcon::nation_id source, pending_human_f_n_event_data const& e) {
+	for(auto i = state.pending_f_n_event.size(); i-- > 0;) {
+		if(event::pending_human_f_n_event{e.r_lo, e.r_hi, e.date, e.e, source } == state.pending_f_n_event[i]) {
+			if(e.opt_choice > state.world.free_national_event_get_options(e.e).size() || !event::is_valid_option(state.world.free_national_event_get_options(e.e)[e.opt_choice])) {
+				return false;
+			}
+			else {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+bool can_make_event_choice(sys::state& state, dcon::nation_id source, pending_human_p_event_data const& e) {
+	for(auto i = state.pending_p_event.size(); i-- > 0;) {
+		if(event::pending_human_p_event{e.r_lo, e.r_hi, e.from_slot, e.date, e.e, e.p, e.ft } == state.pending_p_event[i]) {
+			if(e.opt_choice > state.world.provincial_event_get_options(e.e).size() || !event::is_valid_option(state.world.provincial_event_get_options(e.e)[e.opt_choice])) {
+				return false;
+			} else {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+
+bool can_make_event_choice(sys::state& state, dcon::nation_id source, pending_human_f_p_event_data const& e) {
+	for(auto i = state.pending_f_p_event.size(); i-- > 0;) {
+		if(event::pending_human_f_p_event{e.r_lo, e.r_hi, e.date, e.e, e.p } == state.pending_f_p_event[i]) {
+			if(e.opt_choice > state.world.free_provincial_event_get_options(e.e).size() || !event::is_valid_option(state.world.free_provincial_event_get_options(e.e)[e.opt_choice])) {
+				return false;
+			} else {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+
+
+
 void make_event_choice(sys::state& state, event::pending_human_n_event const& e, uint8_t option_id) {
 	payload p;
 	memset(&p, 0, sizeof(payload));
@@ -5994,16 +6052,16 @@ bool can_perform_command(sys::state& state, payload& c) {
 		return can_take_decision(state, c.source, c.data.decision.d);
 
 	case command_type::make_n_event_choice:
-		return true; //can_make_event_choice(state, c.source, c.data.pending_human_n_event);
+		return can_make_event_choice(state, c.source, c.data.pending_human_n_event);
 
 	case command_type::make_f_n_event_choice:
-		return true; // can_make_event_choice(state, c.source, c.data.pending_human_f_n_event);
+		return can_make_event_choice(state, c.source, c.data.pending_human_f_n_event);
 
 	case command_type::make_p_event_choice:
-		return true; // can_make_event_choice(state, c.source, c.data.pending_human_p_event);
+		return can_make_event_choice(state, c.source, c.data.pending_human_p_event);
 
 	case command_type::make_f_p_event_choice:
-		return true; // can_make_event_choice(state, c.source, c.data.pending_human_f_p_event);
+		return can_make_event_choice(state, c.source, c.data.pending_human_f_p_event);
 
 	case command_type::cancel_cb_fabrication:
 		return can_cancel_cb_fabrication(state, c.source);

--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -1028,18 +1028,13 @@ void execute_release_and_play_as(sys::state& state, dcon::nation_id source, dcon
 	nations::remove_cores_from_owned(state, holder, state.world.nation_get_identity_from_identity_holder(source));
 
 	if(state.network_mode == sys::network_mode_type::single_player) {
-		network::switch_all_players(state, holder, source);
+		nations::switch_all_players(state, holder, source);
 	}
 	else {
 		auto player = network::find_mp_player(state, player_name);
 		network::switch_one_player(state, holder, source, player);
 	}
 
-	
-	if(state.world.nation_get_is_player_controlled(holder))
-		ai::remove_ai_data(state, holder);
-	if(state.world.nation_get_is_player_controlled(source))
-		ai::remove_ai_data(state, source);
 
 	for(auto p : state.world.nation_get_province_ownership(holder)) {
 		auto pid = p.get_province();
@@ -5401,28 +5396,6 @@ void execute_notify_player_joins(sys::state& state, dcon::nation_id source, sys:
 
 	network::create_mp_player(state, name, password, !needs_loading, false, source);
 
-	//auto p = network::find_mp_player(state, name);
-	//if(p) {
-	//	auto oldnation = state.world.mp_player_get_nation_from_player_nation(p);
-
-	//	if (oldnation != source && oldnation) // check for old nation validity before setting it to be not player controlled
-	//		state.world.nation_set_is_player_controlled(oldnation, false);
-
-	//	// Server already validated password by this point
-	//	// Client always receives empty passwords
-	//	if(!password.empty()) {
-	//		network::update_mp_player_password(state, p, password);
-	//	}
-	//	// update mp player with the joining players loading state
-	//	state.world.mp_player_set_fully_loaded(p, !needs_loading);
-	//	state.world.mp_player_set_is_oos(p, false);
-	//}
-	//else {
-	//	p = network::create_mp_player(state, name, password, !needs_loading, false);
-	//}
- //	state.world.nation_set_is_player_controlled(source, true);
-	//state.world.force_create_player_nation(source, p);
-
 	if(needs_loading) {
 		payload cmd;
 		memset(&cmd, 0, sizeof(cmd));
@@ -5467,16 +5440,6 @@ void execute_notify_player_leaves(sys::state& state, dcon::nation_id source, boo
 
 		network::delete_mp_player(state, p, make_ai);
 	}
-
-	//if(make_ai) {
-	//	state.world.nation_set_is_player_controlled(source, false);
-	//}
-	//auto player = network::find_country_player(state, source);
-	//// if the leaving player was loading, decrement num of loading clients
-	//if(player && !state.world.mp_player_get_fully_loaded(player) && state.network_state.num_client_loading != 0) {
-	//	state.network_state.num_client_loading--;
-	//	state.world.mp_player_set_is_oos(player, false);
-	//}
 
 	if(state.network_mode == sys::network_mode_type::host) {
 		for(auto& client : state.network_state.clients) {

--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -5808,14 +5808,14 @@ void execute_notify_player_fully_loaded(sys::state& state, dcon::nation_id sourc
 }
 
 bool can_notify_stop_game(sys::state& state, dcon::nation_id source) {
+	if(state.current_scene.is_lobby) {
+		return false;
+	}
 	if(state.network_mode == sys::network_mode_type::single_player) {
 		return true;
 	} else if(state.network_mode == sys::network_mode_type::client) {
 		return true;
 	} else {
-		if(state.current_scene.is_lobby) {
-			return false;
-		}
 		return !network::check_any_players_loading(state);
 	}
 }

--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -5588,6 +5588,10 @@ void notify_player_picks_nation(sys::state& state, dcon::nation_id source, dcon:
 	add_to_command_queue(state, p);
 }
 bool can_notify_player_picks_nation(sys::state& state, dcon::nation_id source, dcon::nation_id target, sys::player_name& name) {
+	// cannot pick a new nation whilst not in the looby
+	if(!state.current_scene.is_lobby) {
+		return false;
+	}
 	auto player = network::find_mp_player(state, name);
 	if(source == target || !player) //redundant
 		return false;

--- a/src/gamestate/commands.hpp
+++ b/src/gamestate/commands.hpp
@@ -210,6 +210,7 @@ struct factory_data {
 
 struct tag_target_data {
 	dcon::national_identity_id ident;
+	sys::player_name player_name;
 };
 
 struct influence_action_data {
@@ -641,8 +642,8 @@ bool can_change_factory_settings(sys::state& state, dcon::nation_id source, dcon
 void make_vassal(sys::state& state, dcon::nation_id source, dcon::national_identity_id t);
 bool can_make_vassal(sys::state& state, dcon::nation_id source, dcon::national_identity_id t);
 
-void release_and_play_as(sys::state& state, dcon::nation_id source, dcon::national_identity_id t);
-bool can_release_and_play_as(sys::state& state, dcon::nation_id source, dcon::national_identity_id t);
+void release_and_play_as(sys::state& state, dcon::nation_id source, dcon::national_identity_id t, sys::player_name& player_name);
+bool can_release_and_play_as(sys::state& state, dcon::nation_id source, dcon::national_identity_id t, sys::player_name& player_name);
 
 void give_war_subsidies(sys::state& state, dcon::nation_id source, dcon::nation_id target);
 bool can_give_war_subsidies(sys::state& state, dcon::nation_id source, dcon::nation_id target);

--- a/src/gamestate/commands.hpp
+++ b/src/gamestate/commands.hpp
@@ -34,105 +34,106 @@ enum class command_type : uint8_t {
 	add_to_sphere = 24,
 	remove_from_sphere = 25,
 	upgrade_colony_to_state = 26,
-	invest_in_colony = 27,
-	abandon_colony = 28,
-	finish_colonization = 29,
-	intervene_in_war = 30,
-	suppress_movement = 31,
-	civilize_nation = 32,
-	appoint_ruling_party = 33,
-	change_issue_option = 34,
-	change_reform_option = 35,
-	become_interested_in_crisis = 36,
-	take_sides_in_crisis = 37,
-	begin_land_unit_construction = 38,
-	cancel_land_unit_construction = 39,
-	change_stockpile_settings = 40,
-	take_decision = 41,
-	make_n_event_choice = 42,
-	make_f_n_event_choice = 43,
-	make_p_event_choice = 44,
-	make_f_p_event_choice = 45,
-	fabricate_cb = 46,
-	cancel_cb_fabrication = 47,
-	ask_for_military_access = 48,
-	ask_for_alliance = 49,
-	call_to_arms = 50,
-	respond_to_diplomatic_message = 51,
-	cancel_military_access = 52,
-	cancel_alliance = 53,
-	cancel_given_military_access = 54,
-	declare_war = 55,
-	add_war_goal = 56,
-	start_peace_offer = 58,
-	add_peace_offer_term = 59,
-	send_peace_offer = 60,
-	move_army = 61,
-	move_navy = 62,
-	embark_army = 63,
-	merge_armies = 64,
-	merge_navies = 65,
-	split_army = 66,
-	split_navy = 67,
-	delete_army = 68,
-	delete_navy = 69,
-	designate_split_regiments = 70,
-	designate_split_ships = 71,
-	naval_retreat = 72,
-	land_retreat = 73,
-	start_crisis_peace_offer = 74,
-	invite_to_crisis = 75,
-	add_wargoal_to_crisis_offer = 76,
-	send_crisis_peace_offer = 77,
-	change_admiral = 78,
-	change_general = 79,
-	toggle_mobilization = 80,
-	give_military_access = 81,
-	set_rally_point = 82,
-	save_game = 83,
-	cancel_factory_building_construction = 84,
-	disband_undermanned = 85,
-	even_split_army = 86,
-	even_split_navy = 87,
-	toggle_hunt_rebels = 88,
-	toggle_select_province = 89,
-	toggle_immigrator_province = 90,
-	state_transfer = 91,
-	release_subject = 92,
-	enable_debt = 93,
-	move_capital = 94,
-	toggle_unit_ai_control = 95,
-	toggle_mobilized_is_ai_controlled = 96,
-	toggle_interested_in_alliance = 97,
-	pbutton_script = 98,
-	nbutton_script = 99,
-	set_factory_type_priority = 100,
-	crisis_add_wargoal = 101,
-	change_unit_type = 102,
-	take_province = 103,
-	grant_province = 104,
-	ask_for_free_trade_agreement = 105,
-	switch_embargo_status = 106,
-	revoke_trade_rights = 107,
-	toggle_local_administration = 108,
+		invest_in_colony = 27,
+		abandon_colony = 28,
+		finish_colonization = 29,
+		intervene_in_war = 30,
+		suppress_movement = 31,
+		civilize_nation = 32,
+		appoint_ruling_party = 33,
+		change_issue_option = 34,
+		change_reform_option = 35,
+		become_interested_in_crisis = 36,
+		take_sides_in_crisis = 37,
+		begin_land_unit_construction = 38,
+		cancel_land_unit_construction = 39,
+		change_stockpile_settings = 40,
+		take_decision = 41,
+		make_n_event_choice = 42,
+		make_f_n_event_choice = 43,
+		make_p_event_choice = 44,
+		make_f_p_event_choice = 45,
+		fabricate_cb = 46,
+		cancel_cb_fabrication = 47,
+		ask_for_military_access = 48,
+		ask_for_alliance = 49,
+		call_to_arms = 50,
+		respond_to_diplomatic_message = 51,
+		cancel_military_access = 52,
+		cancel_alliance = 53,
+		cancel_given_military_access = 54,
+		declare_war = 55,
+		add_war_goal = 56,
+		start_peace_offer = 58,
+		add_peace_offer_term = 59,
+		send_peace_offer = 60,
+		move_army = 61,
+		move_navy = 62,
+		embark_army = 63,
+		merge_armies = 64,
+		merge_navies = 65,
+		split_army = 66,
+		split_navy = 67,
+		delete_army = 68,
+		delete_navy = 69,
+		designate_split_regiments = 70,
+		designate_split_ships = 71,
+		naval_retreat = 72,
+		land_retreat = 73,
+		start_crisis_peace_offer = 74,
+		invite_to_crisis = 75,
+		add_wargoal_to_crisis_offer = 76,
+		send_crisis_peace_offer = 77,
+		change_admiral = 78,
+		change_general = 79,
+		toggle_mobilization = 80,
+		give_military_access = 81,
+		set_rally_point = 82,
+		save_game = 83,
+		cancel_factory_building_construction = 84,
+		disband_undermanned = 85,
+		even_split_army = 86,
+		even_split_navy = 87,
+		toggle_hunt_rebels = 88,
+		toggle_select_province = 89,
+		toggle_immigrator_province = 90,
+		state_transfer = 91,
+		release_subject = 92,
+		enable_debt = 93,
+		move_capital = 94,
+		toggle_unit_ai_control = 95,
+		toggle_mobilized_is_ai_controlled = 96,
+		toggle_interested_in_alliance = 97,
+		pbutton_script = 98,
+		nbutton_script = 99,
+		set_factory_type_priority = 100,
+		crisis_add_wargoal = 101,
+		change_unit_type = 102,
+		take_province = 103,
+		grant_province = 104,
+		ask_for_free_trade_agreement = 105,
+		switch_embargo_status = 106,
+		revoke_trade_rights = 107,
+		toggle_local_administration = 108,
 
-	// network
-	notify_player_ban = 110,
-	notify_player_kick = 111,
-	notify_player_picks_nation = 112,
-	notify_player_joins = 113,
-	notify_player_leaves = 114,
-	notify_player_oos = 115,
-	notify_save_loaded = 116,
-	notify_start_game = 117, // for synchronized "start game"
-	notify_stop_game = 118, // "go back to lobby"
-	notify_pause_game = 119, // visual aid mostly
-	notify_reload = 120,
-	advance_tick = 121,
-	chat_message = 122,
-	network_inactivity_ping = 123,
-	notify_player_fully_loaded = 124, // client sends this to the host to notify that they are fully loaded in, and host transmits it to all clients
-	notify_player_is_loading = 125, // host sends this to all clients to notify that a specific client has begun loading
+		// network
+		notify_player_ban = 110,
+		notify_player_kick = 111,
+		notify_player_picks_nation = 112,
+		notify_player_joins = 113,
+		notify_player_leaves = 114,
+		notify_player_oos = 115,
+		notify_save_loaded = 116,
+		notify_start_game = 117, // for synchronized "start game"
+		notify_stop_game = 118, // "go back to lobby"
+		notify_pause_game = 119, // visual aid mostly
+		notify_reload = 120,
+		advance_tick = 121,
+		chat_message = 122,
+		network_inactivity_ping = 123,
+		notify_player_fully_loaded = 124, // client sends this to the host to notify that they are fully loaded in, and host transmits it to all clients
+		notify_player_is_loading = 125, // host sends this to all clients to notify that a specific client has begun loading
+		change_ai_nation_state = 126, // host sends this to new clients to inform them of no-ai nations, which arent players. 
 
 	// console cheats
 	network_populate = 254,
@@ -461,6 +462,7 @@ struct chat_message_data {
 
 struct nation_pick_data {
 	dcon::nation_id target;
+	sys::player_name player_name;
 };
 
 struct advance_tick_data {
@@ -484,12 +486,27 @@ struct notify_reload_data {
 };
 struct notify_leaves_data {
 	bool make_ai;
+	sys::player_name player_name;
 };
 struct notify_player_fully_loaded_data {
 	sys::player_name name;
 };
 struct notify_player_is_loading_data {
 	sys::player_name name;
+};
+struct notify_player_ban_data {
+	bool make_ai;
+	sys::player_name player_name;
+};
+struct notify_player_kick_data {
+	bool make_ai;
+	sys::player_name player_name;
+};
+struct notify_player_oos_data {
+	sys::player_name player_name;
+};
+struct change_ai_nation_state_data {
+	bool no_ai;
 };
 
 struct payload {
@@ -559,6 +576,10 @@ struct payload {
 		pbutton_data pbutton;
 		cheat_invention_data_t cheat_invention_data;
 		set_factory_priority_data set_factory_priority;
+		notify_player_ban_data notify_player_ban;
+		notify_player_kick_data notify_player_kick;
+		notify_player_oos_data notify_player_oos;
+		change_ai_nation_state_data change_ai_nation_state;
 
 		dtype() { }
 	} data;
@@ -930,17 +951,17 @@ void state_transfer(sys::state& state, dcon::nation_id asker, dcon::nation_id ta
 bool can_state_transfer(sys::state& state, dcon::nation_id asker, dcon::nation_id target, dcon::state_definition_id sid);
 
 void advance_tick(sys::state& state, dcon::nation_id source);
-void notify_player_ban(sys::state& state, dcon::nation_id source, dcon::nation_id target);
-bool can_notify_player_ban(sys::state& state, dcon::nation_id source, dcon::nation_id target);
-void notify_player_kick(sys::state& state, dcon::nation_id source, dcon::nation_id target);
-bool can_notify_player_kick(sys::state& state, dcon::nation_id source, dcon::nation_id target);
+void notify_player_ban(sys::state& state, dcon::nation_id source, bool make_ai, sys::player_name& name);
+bool can_notify_player_ban(sys::state& state, dcon::nation_id source, sys::player_name& name);
+void notify_player_kick(sys::state& state, dcon::nation_id source, bool make_ai, sys::player_name& name);
+bool can_notify_player_kick(sys::state& state, dcon::nation_id source, sys::player_name& name);
 void notify_player_joins(sys::state& state, dcon::nation_id source, sys::player_name& name, sys::player_password_raw& password);
 bool can_notify_player_joins(sys::state& state, dcon::nation_id source, sys::player_name& name);
-void notify_player_leaves(sys::state& state, dcon::nation_id source, bool make_ai);
-bool can_notify_player_leaves(sys::state& state, dcon::nation_id source, bool make_ai);
-void notify_player_picks_nation(sys::state& state, dcon::nation_id source, dcon::nation_id target);
-bool can_notify_player_picks_nation(sys::state& state, dcon::nation_id source, dcon::nation_id target);
-void notify_player_oos(sys::state& state, dcon::nation_id source);
+void notify_player_leaves(sys::state& state, dcon::nation_id source, bool make_ai, sys::player_name& player_name);
+bool can_notify_player_leaves(sys::state& state, dcon::nation_id source, bool make_ai, sys::player_name& player_name);
+void notify_player_picks_nation(sys::state& state, dcon::nation_id source, dcon::nation_id target, sys::player_name& name);
+bool can_notify_player_picks_nation(sys::state& state, dcon::nation_id source, dcon::nation_id target, sys::player_name& name);
+void notify_player_oos(sys::state& state, dcon::nation_id source, sys::player_name& name);
 void notify_save_loaded(sys::state& state, dcon::nation_id source);
 void notify_reload(sys::state& state, dcon::nation_id source);
 void notify_start_game(sys::state& state, dcon::nation_id source);

--- a/src/gamestate/commands.hpp
+++ b/src/gamestate/commands.hpp
@@ -965,10 +965,12 @@ bool can_notify_player_picks_nation(sys::state& state, dcon::nation_id source, d
 void notify_player_oos(sys::state& state, dcon::nation_id source, sys::player_name& name);
 void notify_save_loaded(sys::state& state, dcon::nation_id source);
 void notify_reload(sys::state& state, dcon::nation_id source);
+bool can_notify_start_game(sys::state& state, dcon::nation_id source);
 void notify_start_game(sys::state& state, dcon::nation_id source);
 void notify_player_is_loading(sys::state& state, dcon::nation_id source, sys::player_name& name);
 void execute_notify_player_is_loading(sys::state& state, dcon::nation_id source, sys::player_name& name);
 void notify_player_fully_loaded(sys::state& state, dcon::nation_id source, sys::player_name& name);
+bool can_notify_stop_game(sys::state& state, dcon::nation_id source);
 void notify_stop_game(sys::state& state, dcon::nation_id source);
 void notify_pause_game(sys::state& state, dcon::nation_id source);
 // returns true if the command was performed, false if not

--- a/src/gamestate/commands.hpp
+++ b/src/gamestate/commands.hpp
@@ -458,6 +458,7 @@ struct set_factory_priority_data {
 struct chat_message_data {
 	char body[ui::max_chat_message_len];
 	dcon::nation_id target;
+	sys::player_name sender;
 };
 
 struct nation_pick_data {
@@ -941,8 +942,8 @@ void toggle_immigrator_province(sys::state& state, dcon::nation_id source, dcon:
 bool can_toggle_immigrator_province(sys::state& state, dcon::nation_id source, dcon::province_id prov);
 
 void post_chat_message(sys::state& state, ui::chat_message& m);
-void chat_message(sys::state& state, dcon::nation_id source, std::string_view body, dcon::nation_id target);
-bool can_chat_message(sys::state& state, dcon::nation_id source, std::string_view body, dcon::nation_id target);
+void chat_message(sys::state& state, dcon::nation_id source, std::string_view body, dcon::nation_id target, sys::player_name& sender);
+bool can_chat_message(sys::state& state, dcon::nation_id source, std::string_view body, dcon::nation_id target, sys::player_name& sender);
 
 void release_subject(sys::state& state, dcon::nation_id source, dcon::nation_id target);
 bool can_release_subject(sys::state& state, dcon::nation_id source, dcon::nation_id target);

--- a/src/gamestate/dcon_generated.txt
+++ b/src/gamestate/dcon_generated.txt
@@ -5775,7 +5775,7 @@ relationship{
 	link{
 		object{nation}
 		name{nation}
-		type{unique}
+		type{many}
 	}
 	link{
 		object{mp_player}

--- a/src/gamestate/game_scene.cpp
+++ b/src/gamestate/game_scene.cpp
@@ -171,7 +171,7 @@ void select_player_nation_from_selected_province(sys::state& state) {
 		// on multiplayer we wait until we get a confirmation that we are
 		// allowed to pick the specified nation as no two players can get on
 		// a nation, at the moment
-		// TODO: Allow Co-op
+		// Co-op should work
 		if(state.network_mode == sys::network_mode_type::single_player) {
 			if(state.local_player_nation) {
 				state.world.nation_set_is_player_controlled(state.local_player_nation, false);
@@ -181,8 +181,8 @@ void select_player_nation_from_selected_province(sys::state& state) {
 			if(state.ui_state.nation_picker) {
 				state.ui_state.nation_picker->impl_on_update(state);
 			}
-		} else if(command::can_notify_player_picks_nation(state, state.local_player_nation, owner)) {
-			command::notify_player_picks_nation(state, state.local_player_nation, owner);
+		} else if(command::can_notify_player_picks_nation(state, state.local_player_nation, owner, state.network_state.nickname)) {
+			command::notify_player_picks_nation(state, state.local_player_nation, owner, state.network_state.nickname);
 		}
 	}
 }

--- a/src/gui/gui_chat_window.hpp
+++ b/src/gui/gui_chat_window.hpp
@@ -211,9 +211,14 @@ class chat_player_ready_state : public color_text_element {
 class chat_player_flag_button : public flag_button {
 public:
 	dcon::national_identity_id get_current_nation(sys::state& state) noexcept override {
-		auto player = retrieve<dcon::mp_player_id>(state, parent);
-		auto nation = state.world.mp_player_get_nation_from_player_nation(player);
-		return state.world.nation_get_identity_from_identity_holder(nation);
+		if(state.network_mode == sys::network_mode_type::single_player) {
+			return state.world.nation_get_identity_from_identity_holder(state.local_player_nation);
+		}
+		else {
+			auto player = retrieve<dcon::mp_player_id>(state, parent);
+			auto nation = state.world.mp_player_get_nation_from_player_nation(player);
+			return state.world.nation_get_identity_from_identity_holder(nation);
+		}
 	}
 
 };
@@ -251,9 +256,15 @@ protected:
 public:
 	void on_update(sys::state& state) noexcept override {
 		row_contents.clear();
-		state.world.for_each_mp_player([&](dcon::mp_player_id p) {
+		if(state.network_mode == sys::network_mode_type::single_player) {
+			row_contents.push_back(dcon::mp_player_id{ });
+		}
+		else {
+			state.world.for_each_mp_player([&](dcon::mp_player_id p) {
 				row_contents.push_back(p);
-		});
+			});
+		}
+		
 		update(state);
 	}
 };

--- a/src/gui/gui_chat_window.hpp
+++ b/src/gui/gui_chat_window.hpp
@@ -301,11 +301,16 @@ public:
 		set_button_text(state, text::produce_simple_string(state, "alice_lobby_back"));
 	}
 	void on_update(sys::state& state) noexcept override {
-		disabled = (state.network_mode == sys::network_mode_type::client) || (state.current_scene.is_lobby) || (network::check_any_players_loading(state));
+		disabled = (state.network_mode == sys::network_mode_type::client) || !command::can_notify_stop_game(state, state.local_player_nation);
 	}
 	void button_action(sys::state& state) noexcept override {
-		map_mode::set_map_mode(state, map_mode::mode::political);
-		command::notify_stop_game(state, state.local_player_nation);
+		if(state.network_mode == sys::network_mode_type::client) {
+			return;
+		}
+		if(command::can_notify_stop_game(state, state.local_player_nation)) {
+			map_mode::set_map_mode(state, map_mode::mode::political);
+			command::notify_stop_game(state, state.local_player_nation);
+		}
 	}
 	tooltip_behavior has_tooltip(sys::state& state) noexcept override {
 		return tooltip_behavior::variable_tooltip;

--- a/src/gui/gui_chat_window.hpp
+++ b/src/gui/gui_chat_window.hpp
@@ -24,17 +24,17 @@ public:
 				color,
 				false });
 
-		std::array<uint8_t, 24> nickname;
-		std::vector<dcon::mp_player_id> players = network::find_country_players(state, content.source);
-		// display the first player on the nation's name in text messages, if there are any players on it
-		if(!players.empty()) {
-			nickname = state.world.mp_player_get_nickname(players.front());
-		}
-		else {
-			nickname.fill(0);
-		}
+		//std::array<uint8_t, 24> nickname;
+		//std::vector<dcon::mp_player_id> players = network::find_country_players(state, content.source);
+		//// display the first player on the nation's name in text messages, if there are any players on it
+		//if(!players.empty()) {
+		//	nickname = state.world.mp_player_get_nickname(players.front());
+		//}
+		//else {
+		//	nickname.fill(0);
+		//}
 
-		std::string sender_name = sys::player_name{nickname }.to_string() + ": ";
+		std::string sender_name = sys::player_name{content.get_sender_name() }.to_string() + ": ";
 		std::string text_form_msg = std::string(content.body);
 		auto box = text::open_layout_box(container);
 		text::add_to_layout_box(state, container, box, sender_name, IsShadow ? text::text_color::black : text::text_color::orange);
@@ -285,7 +285,7 @@ public:
 		memcpy(body, s.data(), len);
 		body[len] = '\0';
 
-		command::chat_message(state, state.local_player_nation, body, target);
+		command::chat_message(state, state.local_player_nation, body, target, state.network_state.nickname);
 
 		Cyto::Any payload = this;
 		impl_get(state, payload);

--- a/src/gui/gui_chat_window.hpp
+++ b/src/gui/gui_chat_window.hpp
@@ -25,8 +25,10 @@ public:
 				false });
 
 
-		auto p = network::find_country_player(state, content.source);
-		auto nickname = state.world.mp_player_get_nickname(p);
+		std::vector<dcon::mp_player_id> players = network::find_country_players(state, content.source);
+		assert(!players.empty());
+		// display the first player on the nation in text messages
+		auto nickname = state.world.mp_player_get_nickname(players.front());
 
 		std::string sender_name = sys::player_name{nickname }.to_string() + ": ";
 		std::string text_form_msg = std::string(content.body);
@@ -115,15 +117,17 @@ public:
 class player_kick_button : public button_element_base {
 public:
 	void on_update(sys::state& state) noexcept override {
-		auto n = retrieve<dcon::nation_id>(state, parent);
-		disabled = !command::can_notify_player_kick(state, state.local_player_nation, n);
+		auto player = retrieve<dcon::mp_player_id>(state, parent);
+		auto nickname = sys::player_name{ state.world.mp_player_get_nickname(player) };
+		disabled = !command::can_notify_player_kick(state, state.local_player_nation, nickname);
 		if(state.network_mode != sys::network_mode_type::host)
 			disabled = true;
 	}
 
 	void button_action(sys::state& state) noexcept override {
-		auto n = retrieve<dcon::nation_id>(state, parent);
-		command::notify_player_kick(state, state.local_player_nation, n);
+		auto player = retrieve<dcon::mp_player_id>(state, parent);
+		auto nickname = sys::player_name{ state.world.mp_player_get_nickname(player) };
+		command::notify_player_kick(state, state.local_player_nation, true, nickname);
 	}
 
 	tooltip_behavior has_tooltip(sys::state& state) noexcept override {
@@ -140,15 +144,17 @@ public:
 class player_ban_button : public button_element_base {
 public:
 	void on_update(sys::state& state) noexcept override {
-		auto n = retrieve<dcon::nation_id>(state, parent);
-		disabled = !command::can_notify_player_ban(state, state.local_player_nation, n);
+		auto player = retrieve<dcon::mp_player_id>(state, parent);
+		auto nickname = sys::player_name{ state.world.mp_player_get_nickname(player) };
+		disabled = !command::can_notify_player_ban(state, state.local_player_nation, nickname);
 		if(state.network_mode != sys::network_mode_type::host)
 			disabled = true;
 	}
 
 	void button_action(sys::state& state) noexcept override {
-		auto n = retrieve<dcon::nation_id>(state, parent);
-		command::notify_player_ban(state, state.local_player_nation, n);
+		auto player =  retrieve<dcon::mp_player_id>(state, parent);
+		auto nickname = sys::player_name{ state.world.mp_player_get_nickname(player) };
+		command::notify_player_ban(state, state.local_player_nation, true, nickname);
 	}
 
 	tooltip_behavior has_tooltip(sys::state& state) noexcept override {
@@ -168,9 +174,8 @@ public:
 		if(state.network_mode == sys::network_mode_type::single_player) {
 			set_text(state, text::produce_simple_string(state, "player"));
 		} else {
-			auto n = retrieve<dcon::nation_id>(state, parent);
+			auto p = retrieve<dcon::mp_player_id>(state, parent);
 
-			auto p = network::find_country_player(state, n);
 			auto nickname = state.world.mp_player_get_nickname(p);
 			set_text(state, sys::player_name{nickname }.to_string());
 		}
@@ -179,14 +184,13 @@ public:
 
 class chat_player_ready_state : public color_text_element {
 	void on_update(sys::state& state) noexcept override {
-		auto n = retrieve<dcon::nation_id>(state, parent);
+		auto player = retrieve<dcon::mp_player_id>(state, parent);
 
 		if(state.network_mode == sys::network_mode_type::single_player) {
 			color = text::text_color::dark_green;
 			set_text(state, text::produce_simple_string(state, "ready"));
 		}
 		else {
-			auto player = network::find_country_player(state, n);
 			if(state.world.mp_player_get_fully_loaded(player)) {
 				color = text::text_color::dark_green;
 				set_text(state, text::produce_simple_string(state, "ready"));
@@ -200,16 +204,26 @@ class chat_player_ready_state : public color_text_element {
 
 };
 
-class chat_player_entry : public listbox_row_element_base<dcon::nation_id> {
+class chat_player_flag_button : public flag_button {
+public:
+	dcon::national_identity_id get_current_nation(sys::state& state) noexcept override {
+		auto player = retrieve<dcon::mp_player_id>(state, parent);
+		auto nation = state.world.mp_player_get_nation_from_player_nation(player);
+		return state.world.nation_get_identity_from_identity_holder(nation);
+	}
+
+};
+
+class chat_player_entry : public listbox_row_element_base<dcon::mp_player_id> {
 public:
 	void on_create(sys::state& state) noexcept override {
-		listbox_row_element_base<dcon::nation_id>::on_create(state);
+		listbox_row_element_base<dcon::mp_player_id>::on_create(state);
 		base_data.size.y -= 6; //nudge
 	}
 
 	std::unique_ptr<element_base> make_child(sys::state& state, std::string_view name, dcon::gui_def_id id) noexcept override {
 		if(name == "player_shield") {
-			return make_element_by_type<flag_button>(state, id);
+			return make_element_by_type<chat_player_flag_button>(state, id);
 		} else if(name == "name") {
 			return make_element_by_type<player_name_text>(state, id);
 		} else if(name == "button_kick") {
@@ -225,7 +239,7 @@ public:
 	}
 };
 
-class chat_player_listbox : public listbox_element_base<chat_player_entry, dcon::nation_id> {
+class chat_player_listbox : public listbox_element_base<chat_player_entry, dcon::mp_player_id> {
 protected:
 	std::string_view get_row_element_name() override {
 		return "ingame_multiplayer_entry";
@@ -233,9 +247,8 @@ protected:
 public:
 	void on_update(sys::state& state) noexcept override {
 		row_contents.clear();
-		state.world.for_each_nation([&](dcon::nation_id n) {
-			if(state.world.nation_get_is_player_controlled(n))
-				row_contents.push_back(n);
+		state.world.for_each_mp_player([&](dcon::mp_player_id p) {
+				row_contents.push_back(p);
 		});
 		update(state);
 	}
@@ -284,7 +297,7 @@ public:
 		set_button_text(state, text::produce_simple_string(state, "alice_lobby_back"));
 	}
 	void on_update(sys::state& state) noexcept override {
-		disabled = (state.network_mode == sys::network_mode_type::client) || (state.current_scene.is_lobby) || (state.network_state.num_client_loading != 0);
+		disabled = (state.network_mode == sys::network_mode_type::client) || (state.current_scene.is_lobby) || (network::check_any_players_loading(state));
 	}
 	void button_action(sys::state& state) noexcept override {
 		map_mode::set_map_mode(state, map_mode::mode::political);
@@ -294,7 +307,7 @@ public:
 		return tooltip_behavior::variable_tooltip;
 	}
 	void update_tooltip(sys::state& state, int32_t x, int32_t y, text::columnar_layout& contents) noexcept override {
-		if(state.network_state.num_client_loading != 0) {
+		if(network::check_any_players_loading(state)) {
 			text::add_line(state, contents, "alice_lobby_back_player_loading");
 		}
 		if(state.current_scene.is_lobby) {
@@ -317,7 +330,7 @@ public:
 	}
 	void on_update(sys::state& state) noexcept override {
 		disabled = true;
-		if(state.network_state.num_client_loading != 0 || state.network_mode != sys::network_mode_type::host) {
+		if(network::check_any_players_loading(state) || state.network_mode != sys::network_mode_type::host) {
 			return;
 		}
 		disabled = !network::any_player_oos(state);
@@ -332,7 +345,7 @@ public:
 		return tooltip_behavior::variable_tooltip;
 	}
 	void update_tooltip(sys::state& state, int32_t x, int32_t y, text::columnar_layout& contents) noexcept override {
-		if(state.network_state.num_client_loading != 0) {
+		if(network::check_any_players_loading(state)) {
 			text::add_line(state, contents, "alice_lobby_resync_players_loading");
 		}
 		if(!network::any_player_oos(state)) {

--- a/src/gui/gui_chat_window.hpp
+++ b/src/gui/gui_chat_window.hpp
@@ -24,11 +24,15 @@ public:
 				color,
 				false });
 
-
+		std::array<uint8_t, 24> nickname;
 		std::vector<dcon::mp_player_id> players = network::find_country_players(state, content.source);
-		assert(!players.empty());
-		// display the first player on the nation in text messages
-		auto nickname = state.world.mp_player_get_nickname(players.front());
+		// display the first player on the nation's name in text messages, if there are any players on it
+		if(!players.empty()) {
+			nickname = state.world.mp_player_get_nickname(players.front());
+		}
+		else {
+			nickname.fill(0);
+		}
 
 		std::string sender_name = sys::player_name{nickname }.to_string() + ": ";
 		std::string text_form_msg = std::string(content.body);

--- a/src/gui/gui_graphics.hpp
+++ b/src/gui/gui_graphics.hpp
@@ -381,19 +381,47 @@ struct chat_message {
 	dcon::nation_id source{};
 	dcon::nation_id target{};
 	std::string body;
+	// the reason the sender name is a unique_ptr and not a string or simple array is cause the Cyto:Any has a space limit of 64 bytes which it becomes encapsulated in later, and together with the body the struct will overflow with a array of size 24.
+	std::unique_ptr<uint8_t> sender_name;
 
-	chat_message() = default;
-	chat_message(const chat_message&) = default;
+	chat_message() {
+		sender_name = std::unique_ptr<uint8_t>(new uint8_t[24]);
+	}
+	chat_message(const chat_message& m) {
+		sender_name = std::unique_ptr<uint8_t>(new uint8_t[24]);
+		source = m.source;
+		target = m.target;
+		body = m.body;
+		memcpy(sender_name.get(), m.sender_name.get(), 24);
+	}
 	chat_message(chat_message&&) = default;
-	chat_message& operator=(const chat_message&) = default;
+	chat_message& operator=(const chat_message& m) {
+		if(this == &m)
+			return *this;
+		source = m.source;
+		target = m.target;
+		body = m.body;
+		memcpy(sender_name.get(), m.sender_name.get(), 24);
+		return *this;
+	}
 	chat_message& operator=(chat_message&&) = default;
-	~chat_message() = default;
+	~chat_message() { }
 
 	bool operator==(chat_message const& o) const {
 		return source == o.source && target == o.target && body == o.body;
 	}
 	bool operator!=(chat_message const& o) const {
 		return !(*this == o);
+	}
+	void set_sender_name(const std::array<uint8_t, 24>& name) {
+		for(uint16_t i = 0; i < 24; i++) {
+			sender_name.get()[i] = name[i];
+		}
+	}
+	std::array<uint8_t, 24> get_sender_name() {
+		std::array<uint8_t, 24> result;
+		memcpy(&result, sender_name.get(), sizeof(result));
+		return result;
 	}
 };
 

--- a/src/gui/gui_nation_picker.hpp
+++ b/src/gui/gui_nation_picker.hpp
@@ -712,7 +712,12 @@ public:
 	}
 	void on_update(sys::state& state) noexcept override {
 		auto observer_nation = state.world.national_identity_get_nation_from_identity_holder(state.national_definitions.rebel_id);
-		disabled = !command::can_notify_player_picks_nation(state, state.local_player_nation, observer_nation, state.network_state.nickname);
+		if(state.network_mode == sys::network_mode_type::single_player) {
+			disabled = state.local_player_nation == observer_nation;
+		}
+		else {
+			disabled = !command::can_notify_player_picks_nation(state, state.local_player_nation, observer_nation, state.network_state.nickname);
+		}
 	}
 	tooltip_behavior has_tooltip(sys::state& state) noexcept override {
 		return tooltip_behavior::tooltip;
@@ -783,9 +788,14 @@ public:
 class lobby_player_flag_button : public flag_button {
 	public:
 		dcon::national_identity_id get_current_nation(sys::state& state) noexcept override {
-			auto player = retrieve<dcon::mp_player_id>(state, parent);
-			auto nation = state.world.mp_player_get_nation_from_player_nation(player);
-			return state.world.nation_get_identity_from_identity_holder(nation);
+			if(state.network_mode == sys::network_mode_type::single_player) {
+				return state.world.nation_get_identity_from_identity_holder(state.local_player_nation);
+			}
+			else {
+				auto player = retrieve<dcon::mp_player_id>(state, parent);
+				auto nation = state.world.mp_player_get_nation_from_player_nation(player);
+				return state.world.nation_get_identity_from_identity_holder(nation);
+			}
 		}
 
 };

--- a/src/gui/gui_nation_picker.hpp
+++ b/src/gui/gui_nation_picker.hpp
@@ -178,10 +178,10 @@ public:
 		ui::clear_event_windows(state);
 
 		state.network_state.save_slock.lock();
-		std::vector<dcon::nation_id> players;
+		std::vector<dcon::nation_id> no_ai_nations;
 		for(const auto n : state.world.in_nation)
 			if(state.world.nation_get_is_player_controlled(n))
-				players.push_back(n);
+				no_ai_nations.push_back(n);
 		dcon::nation_id old_local_player_nation = state.local_player_nation;
 		/*state.preload();*/
 		/*state.render_semaphore.acquire();*/
@@ -230,7 +230,7 @@ public:
 				//network::place_host_player_after_saveload(state);
 
 				network::write_network_save(state);
-				network::place_players_after_reload(state, players, old_local_player_nation);
+				network::place_players_after_reload(state, no_ai_nations, old_local_player_nation);
 				state.fill_unsaved_data();
 				state.network_state.current_mp_state_checksum = state.get_mp_state_checksum();
 

--- a/src/gui/gui_topbar.hpp
+++ b/src/gui/gui_topbar.hpp
@@ -984,10 +984,7 @@ public:
 				}
 				text::substitution_map sub{};
 
-				auto mppl = dcon::fatten(state.world, network::find_country_player(state, pl.playing_as));
-				auto pln = sys::player_name{ mppl.get_nickname() };
-
-				text::add_to_substitution_map(sub, text::variable_type::name, pln.to_string_view());
+				text::add_to_substitution_map(sub, text::variable_type::name, pl.hshake_buffer.nickname.to_string_view());
 				text::add_to_substitution_map(sub, text::variable_type::country, pl.playing_as);
 				text::add_to_substitution_map(sub, text::variable_type::date, pl.last_seen);
 

--- a/src/gui/map_tooltip.cpp
+++ b/src/gui/map_tooltip.cpp
@@ -1212,33 +1212,42 @@ void players_map_tt_box(sys::state& state, text::columnar_layout& contents, dcon
 		auto n = state.world.province_get_nation_from_province_ownership(prov);
 		if(n) {
 			auto box = text::open_layout_box(contents);
-			
-			auto players = network::find_country_players(state, n);
 			text::substitution_map sub;
-			for(auto player : players) {
-				sub.clear();
-				auto player_name = sys::player_name{ state.world.mp_player_get_nickname(player) }.to_string_view();
-				text::add_to_substitution_map(sub, text::variable_type::x, player_name);
-				if(state.world.mp_player_get_nickname(player) == state.network_state.nickname.data) {
-					if(state.network_mode == sys::network_mode_type::single_player) {
-						text::localised_format_box(state, contents, box, std::string_view("mapmode_tooltip_34_you_sp"), sub);
-					} else {
-						text::localised_format_box(state, contents, box, std::string_view("mapmode_tooltip_34_you"), sub);
-					}
-				} else {
-					text::localised_format_box(state, contents, box, std::string_view("mapmode_tooltip_34"), sub);
-				}
-				text::add_line_break_to_layout_box(state, contents, box);
-			}
-			if(players.empty()) {
+			if(state.network_mode == sys::network_mode_type::single_player) {
 				if(state.world.nation_get_is_player_controlled(n)) {
-					text::localised_format_box(state, contents, box, std::string_view("mapmode_tooltip_34_no_ai"), sub);
+					if(n == state.local_player_nation) {
+						text::localised_format_box(state, contents, box, std::string_view("mapmode_tooltip_34_you_sp"), sub);
+					}
+					else {
+						text::localised_format_box(state, contents, box, std::string_view("mapmode_tooltip_34_no_ai"), sub);
+					}
 				}
 				else {
 					text::localised_format_box(state, contents, box, std::string_view("mapmode_tooltip_34_ai"), sub);
-				}			
+				}
 			}
-			
+			else {
+				auto players = network::find_country_players(state, n);
+
+				for(auto player : players) {
+					sub.clear();
+					auto player_name = sys::player_name{ state.world.mp_player_get_nickname(player) }.to_string_view();
+					text::add_to_substitution_map(sub, text::variable_type::x, player_name);
+					if(state.world.mp_player_get_nickname(player) == state.network_state.nickname.data) {
+						text::localised_format_box(state, contents, box, std::string_view("mapmode_tooltip_34_you"), sub);
+					} else {
+						text::localised_format_box(state, contents, box, std::string_view("mapmode_tooltip_34"), sub);
+					}
+					text::add_line_break_to_layout_box(state, contents, box);
+				}
+				if(players.empty()) {
+					if(state.world.nation_get_is_player_controlled(n)) {
+						text::localised_format_box(state, contents, box, std::string_view("mapmode_tooltip_34_no_ai"), sub);
+					} else {
+						text::localised_format_box(state, contents, box, std::string_view("mapmode_tooltip_34_ai"), sub);
+					}
+				}
+			}	
 			text::close_layout_box(contents, box);
 		}
 	}

--- a/src/gui/topbar_subwindows/politics_subwindows/gui_release_nation_window.hpp
+++ b/src/gui/topbar_subwindows/politics_subwindows/gui_release_nation_window.hpp
@@ -20,12 +20,12 @@ class release_play_as_button : public button_element_base {
 public:
 	void on_update(sys::state& state) noexcept override {
 		const dcon::national_identity_id niid = retrieve<dcon::national_identity_id>(state, parent);
-		disabled = !command::can_release_and_play_as(state, state.local_player_nation, niid);
+		disabled = !command::can_release_and_play_as(state, state.local_player_nation, niid, state.network_state.nickname);
 	}
 
 	void button_action(sys::state& state) noexcept override {
 		const dcon::national_identity_id niid = retrieve<dcon::national_identity_id>(state, parent);
-		command::release_and_play_as(state, state.local_player_nation, niid);
+		command::release_and_play_as(state, state.local_player_nation, niid, state.network_state.nickname);
 		parent->set_visible(state, false);
 	}
 };

--- a/src/military/military.cpp
+++ b/src/military/military.cpp
@@ -2823,7 +2823,7 @@ void add_to_war(sys::state& state, dcon::war_id w, dcon::nation_id n, bool as_at
 	if(!on_war_creation && state.world.nation_get_is_player_controlled(n) == false) {
 		ai::add_free_ai_cbs_to_war(state, n, w);
 	}
-	// update flag black status before we check for collitions with enemy armies
+	// update flag black status before we check for collisions with enemy armies
 	state.military_definitions.pending_blackflag_update = true;
 	military::update_blackflag_status(state);
 	for(auto o : state.world.nation_get_army_control(n)) {

--- a/src/military/military.hpp
+++ b/src/military/military.hpp
@@ -544,6 +544,7 @@ dcon::leader_trait_id get_leader_personality_wrapper(sys::state& state, dcon::le
 void update_battle_leaders(sys::state& state, dcon::land_battle_id b);
 void update_battle_leaders(sys::state& state, dcon::naval_battle_id b);
 
+void delete_regiment_safe_wrapper(sys::state& state, dcon::regiment_id reg); // safely deletes the regiment even if the army is currently in a battle
 bool rebel_army_in_province(sys::state& state, dcon::province_id p);
 dcon::province_id find_land_rally_pt(sys::state& state, dcon::nation_id by, dcon::province_id start);
 dcon::province_id find_naval_rally_pt(sys::state& state, dcon::nation_id by, dcon::province_id start);

--- a/src/nations/nations.hpp
+++ b/src/nations/nations.hpp
@@ -329,6 +329,7 @@ bool is_losing_colonial_race(sys::state& state, dcon::nation_id n);
 bool sphereing_progress_is_possible(sys::state& state, dcon::nation_id n); // can increase opinion or add to sphere
 bool is_involved_in_crisis(sys::state const& state, dcon::nation_id n);
 bool is_committed_in_crisis(sys::state const& state, dcon::nation_id n);
+void switch_all_players(sys::state& state, dcon::nation_id new_n, dcon::nation_id old_n); // switches all players who are on one country to another. Can be called in either SP or MP
 bool can_put_flashpoint_focus_in_state(sys::state& state, dcon::state_instance_id s, dcon::nation_id fp_nation);
 int64_t get_monthly_pop_increase_of_nation(sys::state& state, dcon::nation_id n);
 bool can_accumulate_influence_with(sys::state& state, dcon::nation_id gp, dcon::nation_id target, dcon::gp_relationship_id rel);

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -1862,51 +1862,8 @@ void ban_player(sys::state& state, client_data& client) {
 	}
 }
 
-void switch_all_players(sys::state& state, dcon::nation_id new_n, dcon::nation_id old_n) {
-	if(state.network_mode == sys::network_mode_type::single_player) {
-		state.world.nation_set_is_player_controlled(new_n, true);
-		state.world.nation_set_is_player_controlled(old_n, false);
-		state.local_player_nation = new_n;
-	}
-	else {
-		auto p = find_country_players(state, old_n);
-		// move ALL players which are on the current nation, to the new nation
-		for(auto player : p) {
-			state.world.force_create_player_nation(new_n, player);
-		}
-		if(!p.empty()) {
-			state.world.nation_set_is_player_controlled(new_n, true);
-			state.world.nation_set_is_player_controlled(old_n, false);
-		}
-
-		if(state.network_mode == sys::network_mode_type::host) {
-			for(auto& client : state.network_state.clients) {
-				if(!client.is_active())
-					continue;
-				if(client.playing_as == old_n) {
-					client.playing_as = new_n;
-				}
-			}
-
-			write_player_nations(state);
-		}
-		if(state.local_player_nation == old_n) {
-			state.local_player_nation = new_n;
-		}
-		// We will also re-assign all chat messages from this nation to the new one
-		for(auto& msg : state.ui_state.chat_messages)
-			if(bool(msg.source) && msg.source == old_n)
-				msg.source = new_n;
-	}
-	
-}
 void switch_one_player(sys::state& state, dcon::nation_id new_n, dcon::nation_id old_n, dcon::mp_player_id player) {
-	if(state.network_mode == sys::network_mode_type::single_player) {
-		state.world.nation_set_is_player_controlled(new_n, true);
-		state.world.nation_set_is_player_controlled(old_n, false);
-		state.local_player_nation = new_n;
-		return;
-	}
+	assert(state.network_mode != sys::network_mode_type::single_player);
 	assert(old_n == state.world.mp_player_get_nation_from_player_nation(player));
 	assert(player);
 	state.world.force_create_player_nation(new_n, player);

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -1330,7 +1330,7 @@ void full_reset_after_oos(sys::state& state) {
 		broadcast_to_clients(state, c);
 
 		// send message to everyone letting them know that the lobby has been resync'd
-		command::chat_message(state, state.local_player_nation, text::produce_simple_string(state, "alice_host_has_resync"), dcon::nation_id{ });
+		command::chat_message(state, state.local_player_nation, text::produce_simple_string(state, "alice_host_has_resync"), dcon::nation_id{ }, state.network_state.nickname);
 #ifndef NDEBUG
 		state.console_log("host:broadcast:cmd | (new->start_game)");
 #endif

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -675,6 +675,17 @@ void mp_player_set_fully_loaded(sys::state& state, dcon::mp_player_id player, bo
 	
 }
 
+bool any_player_on_invalid_nation(sys::state& state) {
+	assert(state.network_mode == sys::network_mode_type::host);
+	for(auto player : state.world.in_mp_player) {
+		auto nation = state.world.mp_player_get_nation_from_player_nation(player);
+		if(bool(player) && (!nation || state.world.nation_get_owned_province_count(nation) == 0)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 bool nation_has_any_players_on_it(sys::state& state, dcon::nation_id nation) {
 	auto iterator = state.world.nation_get_player_nation(nation);
 	if(iterator.begin() == iterator.end()) {

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -690,13 +690,15 @@ bool check_any_players_loading(sys::state& state) {
 	if(state.network_state.clients_loading_state_changed.exchange(false)) {
 		for(auto player : state.world.in_mp_player) {
 			if(player && !player.get_fully_loaded()) {
+				state.network_state.any_client_loading_flag.store(true);
 				return true;
 			}
 		}
+		state.network_state.any_client_loading_flag.store(false);
 		return false;
 	}
 	else {
-		return false;
+		return state.network_state.any_client_loading_flag.load();
 	}
 }
 

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -1703,6 +1703,8 @@ void send_and_receive_commands(sys::state& state) {
 
 				state.railroad_built.store(true, std::memory_order::release);
 				state.game_state_updated.store(true, std::memory_order::release);
+				state.map_state.unhandled_province_selection = true;
+				state.sprawl_update_requested.store(true, std::memory_order::release);
 				state.network_state.save_data.clear();
 				state.network_state.save_stream = false; // go back to normal command loop stuff
 				window::change_cursor(state, window::cursor_type::normal);

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -1102,10 +1102,10 @@ void notify_player_joins_discovery(sys::state& state, network::client_data& clie
 // loads the save from network which is currently in the save buffer
 void load_network_save(sys::state& state, const uint8_t* save_buffer) {
 	state.ui_lock.lock();
-	std::vector<dcon::nation_id> players;
+	std::vector<dcon::nation_id> no_ai_nations;
 	for(const auto n : state.world.in_nation)
 		if(state.world.nation_get_is_player_controlled(n))
-			players.push_back(n);
+			no_ai_nations.push_back(n);
 	dcon::nation_id old_local_player_nation = state.local_player_nation;
 	state.local_player_nation = dcon::nation_id{ };
 	// Then reload from network
@@ -1113,7 +1113,7 @@ void load_network_save(sys::state& state, const uint8_t* save_buffer) {
 	with_network_decompressed_section(save_buffer, [&state](uint8_t const* ptr_in, uint32_t length) {
 		read_save_section(ptr_in, ptr_in + length, state);
 	});
-	network::place_players_after_reload(state, players, old_local_player_nation);
+	network::place_players_after_reload(state, no_ai_nations, old_local_player_nation);
 	state.fill_unsaved_data();
 	state.ui_lock.unlock();
 	assert(state.world.nation_get_is_player_controlled(state.local_player_nation));

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -957,7 +957,7 @@ void init(sys::state& state) {
 		load_player_nations(state);
 
 		auto nid = get_player_nation(state, state.network_state.nickname);
-		state.local_player_nation = state.world.national_identity_get_nation_from_identity_holder(state.national_definitions.rebel_id);
+		state.local_player_nation = nid ? nid : choose_nation_for_player(state);
 
 		assert(bool(state.local_player_nation));
 

--- a/src/network/network.hpp
+++ b/src/network/network.hpp
@@ -110,14 +110,13 @@ struct network_state {
 	network_state() : outgoing_commands(1024) {}
 	~network_state() {}
 };
-
+inline void write_player_nations(sys::state& state) noexcept;
 void init(sys::state& state);
 void send_and_receive_commands(sys::state& state);
 void finish(sys::state& state, bool notify_host);
 void ban_player(sys::state& state, client_data& client);
 void kick_player(sys::state& state, client_data& client);
-void switch_all_players(sys::state& state, dcon::nation_id new_n, dcon::nation_id old_n); // switches all players who are on one country to another. Can be called in either SP or MP
-void switch_one_player(sys::state& state, dcon::nation_id new_n, dcon::nation_id old_n, dcon::mp_player_id player); // switches only one player from one country, to another. Can be called in SP or MP, but when called in SP, it does the same as "switch_all_players"
+void switch_one_player(sys::state& state, dcon::nation_id new_n, dcon::nation_id old_n, dcon::mp_player_id player); // switches only one player from one country, to another. Can only be called in MP.
 void write_network_save(sys::state& state);
 void broadcast_save_to_clients(sys::state& state, command::payload& c, uint8_t const* buffer, uint32_t length, sys::checksum_key const& k);
 void broadcast_save_to_single_client(sys::state& state, command::payload& c, client_data& client, uint8_t const* buffer, uint32_t length);

--- a/src/network/network.hpp
+++ b/src/network/network.hpp
@@ -102,9 +102,9 @@ struct network_state {
 	bool reported_oos = false; // has oos been reported to host yet?
 	bool handshake = true; // if in handshake mode -> expect handshake data
 	bool finished = false; //game can run after disconnection but only to show error messages
-	uint16_t num_client_loading = 0; // the number of clients loading
 	sys::checksum_key last_save_checksum; // the last save checksum which was written to the network
 	bool full_reload_needed = true; // whether or not a full host&lobby reload is needed when a new client connects, or a partial reload. Generally after an ingame command is issued a full reload becomes needed
+	std::atomic<bool> clients_loading_state_changed; // flag to indicate if any client loading state has changed (client has started loading, finished loading, or left the game)
 
 	network_state() : outgoing_commands(1024) {}
 	~network_state() {}
@@ -115,7 +115,8 @@ void send_and_receive_commands(sys::state& state);
 void finish(sys::state& state, bool notify_host);
 void ban_player(sys::state& state, client_data& client);
 void kick_player(sys::state& state, client_data& client);
-void switch_player(sys::state& state, dcon::nation_id new_n, dcon::nation_id old_n);
+void switch_player(sys::state& state, dcon::nation_id new_n, dcon::nation_id old_n); // switches all players who are on one country to another (for use in country-specific effects that dosent care about mp players)
+void switch_mp_player_country(sys::state& state, dcon::nation_id new_n, dcon::nation_id old_n, dcon::mp_player_id player); // switches only one player from one country, to another.
 void write_network_save(sys::state& state);
 void broadcast_save_to_clients(sys::state& state, command::payload& c, uint8_t const* buffer, uint32_t length, sys::checksum_key const& k);
 void broadcast_save_to_single_client(sys::state& state, command::payload& c, client_data& client, uint8_t const* buffer, uint32_t length);
@@ -123,12 +124,16 @@ void broadcast_to_clients(sys::state& state, command::payload& c);
 void clear_socket(sys::state& state, client_data& client);
 void full_reset_after_oos(sys::state& state);
 
-dcon::mp_player_id create_mp_player(sys::state& state, sys::player_name& name, sys::player_password_raw& password, bool fully_loaded, bool is_oos);
+
+bool check_any_players_loading(sys::state& state); // returns true if any players are loading. If the loading state has not changed, it will not iterate though the players and simply return false
+void delete_mp_player(sys::state& state, dcon::mp_player_id player, bool make_ai);
+void mp_player_set_fully_loaded(sys::state& state, dcon::mp_player_id player, bool fully_loaded); // wrapper for setting a mp player to being fully loaded or not
+dcon::mp_player_id create_mp_player(sys::state& state, sys::player_name& name, sys::player_password_raw& password, bool fully_loaded, bool is_oos, dcon::nation_id nation_to_play = dcon::nation_id{} );
 void notify_player_is_loading(sys::state& state, sys::player_name name, dcon::nation_id nation, bool execute_self); // wrapper for notiying clients are loading
 dcon::mp_player_id load_mp_player(sys::state& state, sys::player_name& name, sys::player_password_hash& password_hash, sys::player_password_salt& password_salt);
 void update_mp_player_password(sys::state& state, dcon::mp_player_id player_id, sys::player_name& password);
 dcon::mp_player_id find_mp_player(sys::state& state, sys::player_name name);
-dcon::mp_player_id find_country_player(sys::state& state, dcon::nation_id nation);
+std::vector<dcon::mp_player_id> find_country_players(sys::state& state, dcon::nation_id nation);
 dcon::nation_id get_first_available_ai_nation(sys::state& state); // returns the first available nation from dcon which is ai controlled, should be deterministic with saves to use on client+host and not break synch
 void place_players_after_reload(sys::state& state, std::vector<dcon::nation_id>& players, dcon::nation_id old_local_player_nation); // places the players back on their nations, or new ones if the old ones are no longer valid
 bool any_player_oos(sys::state& state);

--- a/src/network/network.hpp
+++ b/src/network/network.hpp
@@ -125,7 +125,7 @@ void broadcast_to_clients(sys::state& state, command::payload& c);
 void clear_socket(sys::state& state, client_data& client);
 void full_reset_after_oos(sys::state& state);
 
-
+bool any_player_on_invalid_nation(sys::state& state);
 bool check_any_players_loading(sys::state& state); // returns true if any players are loading. If the loading state has not changed, it will not iterate though the players and simply return false
 void delete_mp_player(sys::state& state, dcon::mp_player_id player, bool make_ai);
 void mp_player_set_fully_loaded(sys::state& state, dcon::mp_player_id player, bool fully_loaded); // wrapper for setting a mp player to being fully loaded or not

--- a/src/network/network.hpp
+++ b/src/network/network.hpp
@@ -116,8 +116,8 @@ void send_and_receive_commands(sys::state& state);
 void finish(sys::state& state, bool notify_host);
 void ban_player(sys::state& state, client_data& client);
 void kick_player(sys::state& state, client_data& client);
-void switch_player(sys::state& state, dcon::nation_id new_n, dcon::nation_id old_n); // switches all players who are on one country to another (for use in country-specific effects that dosent care about mp players)
-void switch_mp_player_country(sys::state& state, dcon::nation_id new_n, dcon::nation_id old_n, dcon::mp_player_id player); // switches only one player from one country, to another.
+void switch_all_players(sys::state& state, dcon::nation_id new_n, dcon::nation_id old_n); // switches all players who are on one country to another. Can be called in either SP or MP
+void switch_one_player(sys::state& state, dcon::nation_id new_n, dcon::nation_id old_n, dcon::mp_player_id player); // switches only one player from one country, to another. Can be called in SP or MP, but when called in SP, it does the same as "switch_all_players"
 void write_network_save(sys::state& state);
 void broadcast_save_to_clients(sys::state& state, command::payload& c, uint8_t const* buffer, uint32_t length, sys::checksum_key const& k);
 void broadcast_save_to_single_client(sys::state& state, command::payload& c, client_data& client, uint8_t const* buffer, uint32_t length);

--- a/src/network/network.hpp
+++ b/src/network/network.hpp
@@ -135,8 +135,7 @@ dcon::mp_player_id load_mp_player(sys::state& state, sys::player_name& name, sys
 void update_mp_player_password(sys::state& state, dcon::mp_player_id player_id, sys::player_name& password);
 dcon::mp_player_id find_mp_player(sys::state& state, sys::player_name name);
 std::vector<dcon::mp_player_id> find_country_players(sys::state& state, dcon::nation_id nation);
-dcon::nation_id get_first_available_ai_nation(sys::state& state); // returns the first available nation from dcon which is ai controlled, should be deterministic with saves to use on client+host and not break synch
-void place_players_after_reload(sys::state& state, std::vector<dcon::nation_id>& players, dcon::nation_id old_local_player_nation); // places the players back on their nations, or new ones if the old ones are no longer valid
+void set_no_ai_nations_after_reload(sys::state& state, std::vector<dcon::nation_id>& no_ai_nations, dcon::nation_id old_local_player_nation); // places the players back on their nations, or new ones if the old ones are no longer valid
 bool any_player_oos(sys::state& state);
 void log_player_nations(sys::state& state);
 

--- a/src/network/network.hpp
+++ b/src/network/network.hpp
@@ -105,6 +105,7 @@ struct network_state {
 	sys::checksum_key last_save_checksum; // the last save checksum which was written to the network
 	bool full_reload_needed = true; // whether or not a full host&lobby reload is needed when a new client connects, or a partial reload. Generally after an ingame command is issued a full reload becomes needed
 	std::atomic<bool> clients_loading_state_changed; // flag to indicate if any client loading state has changed (client has started loading, finished loading, or left the game)
+	std::atomic<bool> any_client_loading_flag; // flag to signal if any clients are currently loading. If "clients_loading_state_changed" is false, it will use this instead, otherwise compute it manually by iterating over the players.
 
 	network_state() : outgoing_commands(1024) {}
 	~network_state() {}

--- a/src/network/persistent_server_extensions.hpp
+++ b/src/network/persistent_server_extensions.hpp
@@ -50,7 +50,7 @@ inline void read_player_nations(sys::state& state, char const* start, char const
 					text::substitution_map sub{};
 					text::add_to_substitution_map(sub, text::variable_type::playername, name.to_string_view());
 					auto msg = text::resolve_string_substitution(state, "chat_player_joins", sub);
-					command::chat_message(state, source, msg, dcon::nation_id{});
+					command::chat_message(state, source, msg, dcon::nation_id{}, state.network_state.nickname);
 
 #ifndef NDEBUG
 					network::log_player_nations(state);

--- a/src/provinces/province.cpp
+++ b/src/provinces/province.cpp
@@ -1265,13 +1265,20 @@ void change_province_owner(sys::state& state, dcon::province_id id, dcon::nation
 				&& !src.get_regiment().get_army_from_army_membership().get_battle_from_army_battle_participation()
 				&& !src.get_regiment().get_army_from_army_membership().get_controller_from_army_rebel_control()) {
 					auto loc = src.get_regiment().get_army_from_army_membership().get_location_from_army_location();
+					auto old_army = src.get_regiment().get_army_from_army_membership();
 					auto new_u = fatten(state.world, state.world.create_army());
 					new_u.set_controller_from_army_control(new_owner);
 					src.get_regiment().set_army_from_army_membership(new_u);
-					src.get_regiment().set_org(0.01f);
+					// if the previous army is now empty, clean it up early so incoming collitions with enemy armies on the same day can be handled properly
+					if(old_army.get_army_membership().begin() == old_army.get_army_membership().end()) {
+						military::cleanup_army(state, old_army);
+					}
+					//src.get_regiment().set_org(0.01f); // remove this so regiments keeps the same org as previously, otherwise civil wars/seceding nations have no chance as they start on 0 org.
 					military::army_arrives_in_province(state, new_u, loc, military::crossing_type::none);
 				} else {
-					src.get_regiment().set_strength(0.f);
+					// if the army is in a battle, is retreating, is on a transport, or is controlled by rebels, safely delete the regiment instead of transferring it to the new owner
+					military::delete_regiment_safe_wrapper(state, src.get_regiment());
+					/*src.get_regiment().set_strength(0.f);*/
 				}
 			}
 			auto lc = p.get_pop().get_province_land_construction();

--- a/src/provinces/province.cpp
+++ b/src/provinces/province.cpp
@@ -1278,7 +1278,6 @@ void change_province_owner(sys::state& state, dcon::province_id id, dcon::nation
 				} else {
 					// if the army is in a battle, is retreating, is on a transport, or is controlled by rebels, safely delete the regiment instead of transferring it to the new owner
 					military::delete_regiment_safe_wrapper(state, src.get_regiment());
-					/*src.get_regiment().set_strength(0.f);*/
 				}
 			}
 			auto lc = p.get_pop().get_province_land_construction();

--- a/src/scripting/effects.cpp
+++ b/src/scripting/effects.cpp
@@ -2000,9 +2000,9 @@ uint32_t ef_change_tag_no_core_switch(EFFECT_PARAMTERS) {
 		return 0;
 
 	if(ws.world.nation_get_is_player_controlled(trigger::to_nation(primary_slot))) {
-		network::switch_all_players(ws, holder, trigger::to_nation(primary_slot));
+		nations::switch_all_players(ws, holder, trigger::to_nation(primary_slot));
 	} else if(ws.world.nation_get_is_player_controlled(holder)) {
-		network::switch_all_players(ws, trigger::to_nation(primary_slot), holder);
+		nations::switch_all_players(ws, trigger::to_nation(primary_slot), holder);
 	}
 
 	/*auto old_controller = ws.world.nation_get_is_player_controlled(holder);
@@ -2025,9 +2025,9 @@ uint32_t ef_change_tag_no_core_switch_culture(EFFECT_PARAMTERS) {
 		return 0;
 
 	if(ws.world.nation_get_is_player_controlled(trigger::to_nation(primary_slot))) {
-		network::switch_all_players(ws, holder, trigger::to_nation(primary_slot));
+		nations::switch_all_players(ws, holder, trigger::to_nation(primary_slot));
 	} else if(ws.world.nation_get_is_player_controlled(holder)) {
-		network::switch_all_players(ws, trigger::to_nation(primary_slot), holder);
+		nations::switch_all_players(ws, trigger::to_nation(primary_slot), holder);
 	}
 
 	/*auto old_controller = ws.world.nation_get_is_player_controlled(holder);

--- a/src/scripting/effects.cpp
+++ b/src/scripting/effects.cpp
@@ -2000,25 +2000,20 @@ uint32_t ef_change_tag_no_core_switch(EFFECT_PARAMTERS) {
 		return 0;
 
 	if(ws.world.nation_get_is_player_controlled(trigger::to_nation(primary_slot))) {
-		network::switch_player(ws, holder, trigger::to_nation(primary_slot));
+		network::switch_all_players(ws, holder, trigger::to_nation(primary_slot));
 	} else if(ws.world.nation_get_is_player_controlled(holder)) {
-		network::switch_player(ws, trigger::to_nation(primary_slot), holder);
+		network::switch_all_players(ws, trigger::to_nation(primary_slot), holder);
 	}
 
-	auto old_controller = ws.world.nation_get_is_player_controlled(holder);
+	/*auto old_controller = ws.world.nation_get_is_player_controlled(holder);
 	ws.world.nation_set_is_player_controlled(holder, ws.world.nation_get_is_player_controlled(trigger::to_nation(primary_slot)));
-	ws.world.nation_set_is_player_controlled(trigger::to_nation(primary_slot), old_controller);
+	ws.world.nation_set_is_player_controlled(trigger::to_nation(primary_slot), old_controller);*/
 
 	if(ws.world.nation_get_is_player_controlled(trigger::to_nation(primary_slot)))
 		ai::remove_ai_data(ws, trigger::to_nation(primary_slot));
 	if(ws.world.nation_get_is_player_controlled(holder))
 		ai::remove_ai_data(ws, holder);
 
-	if(ws.local_player_nation == trigger::to_nation(primary_slot)) {
-		ws.local_player_nation = holder;
-	} else if(ws.local_player_nation == holder) {
-		ws.local_player_nation = trigger::to_nation(primary_slot);
-	}
 	return 0;
 }
 uint32_t ef_change_tag_no_core_switch_culture(EFFECT_PARAMTERS) {
@@ -2030,25 +2025,20 @@ uint32_t ef_change_tag_no_core_switch_culture(EFFECT_PARAMTERS) {
 		return 0;
 
 	if(ws.world.nation_get_is_player_controlled(trigger::to_nation(primary_slot))) {
-		network::switch_player(ws, holder, trigger::to_nation(primary_slot));
+		network::switch_all_players(ws, holder, trigger::to_nation(primary_slot));
 	} else if(ws.world.nation_get_is_player_controlled(holder)) {
-		network::switch_player(ws, trigger::to_nation(primary_slot), holder);
+		network::switch_all_players(ws, trigger::to_nation(primary_slot), holder);
 	}
 
-	auto old_controller = ws.world.nation_get_is_player_controlled(holder);
+	/*auto old_controller = ws.world.nation_get_is_player_controlled(holder);
 	ws.world.nation_set_is_player_controlled(holder, ws.world.nation_get_is_player_controlled(trigger::to_nation(primary_slot)));
-	ws.world.nation_set_is_player_controlled(trigger::to_nation(primary_slot), old_controller);
+	ws.world.nation_set_is_player_controlled(trigger::to_nation(primary_slot), old_controller);*/
 
 	if(ws.world.nation_get_is_player_controlled(trigger::to_nation(primary_slot)))
 		ai::remove_ai_data(ws, trigger::to_nation(primary_slot));
 	if(ws.world.nation_get_is_player_controlled(holder))
 		ai::remove_ai_data(ws, holder);
 
-	if(ws.local_player_nation == trigger::to_nation(primary_slot)) {
-		ws.local_player_nation = holder;
-	} else if(ws.local_player_nation == holder) {
-		ws.local_player_nation = trigger::to_nation(primary_slot);
-	}
 	return 0;
 }
 uint32_t ef_set_country_flag(EFFECT_PARAMTERS) {

--- a/src/scripting/events.cpp
+++ b/src/scripting/events.cpp
@@ -13,10 +13,7 @@ bool is_valid_option(sys::event_option const& opt) {
 
 void take_option(sys::state& state, pending_human_n_event const& e, uint8_t opt) {
 	for(auto i = state.pending_n_event.size(); i-- > 0;) {
-		if(state.pending_n_event[i].date == e.date && state.pending_n_event[i].e == e.e &&
-				state.pending_n_event[i].from_slot == e.from_slot && state.pending_n_event[i].n == e.n &&
-				state.pending_n_event[i].primary_slot == e.primary_slot && state.pending_n_event[i].r_hi == e.r_hi &&
-				state.pending_n_event[i].r_lo == e.r_lo) {
+		if(state.pending_n_event[i] == e) {
 
 			if(opt > state.world.national_event_get_options(e.e).size() || !is_valid_option(state.world.national_event_get_options(e.e)[opt]))
 				return; // invalid option
@@ -35,8 +32,7 @@ void take_option(sys::state& state, pending_human_n_event const& e, uint8_t opt)
 
 void take_option(sys::state& state, pending_human_f_n_event const& e, uint8_t opt) {
 	for(auto i = state.pending_f_n_event.size(); i-- > 0;) {
-		if(state.pending_f_n_event[i].date == e.date && state.pending_f_n_event[i].e == e.e && state.pending_f_n_event[i].n == e.n &&
-				state.pending_f_n_event[i].r_hi == e.r_hi && state.pending_f_n_event[i].r_lo == e.r_lo) {
+		if(state.pending_f_n_event[i] == e) {
 
 			if(opt > state.world.free_national_event_get_options(e.e).size() || !is_valid_option(state.world.free_national_event_get_options(e.e)[opt]))
 				return; // invalid option
@@ -55,9 +51,7 @@ void take_option(sys::state& state, pending_human_f_n_event const& e, uint8_t op
 
 void take_option(sys::state& state, pending_human_p_event const& e, uint8_t opt) {
 	for(auto i = state.pending_p_event.size(); i-- > 0;) {
-		if(state.pending_p_event[i].date == e.date && state.pending_p_event[i].e == e.e &&
-				state.pending_p_event[i].from_slot == e.from_slot && state.pending_p_event[i].p == e.p &&
-				state.pending_p_event[i].r_hi == e.r_hi && state.pending_p_event[i].r_lo == e.r_lo) {
+		if(state.pending_p_event[i] == e) {
 
 			if(opt > state.world.provincial_event_get_options(e.e).size() || !is_valid_option(state.world.provincial_event_get_options(e.e)[opt]))
 				return; // invalid option
@@ -76,8 +70,7 @@ void take_option(sys::state& state, pending_human_p_event const& e, uint8_t opt)
 }
 void take_option(sys::state& state, pending_human_f_p_event const& e, uint8_t opt) {
 	for(auto i = state.pending_f_p_event.size(); i-- > 0;) {
-		if(state.pending_f_p_event[i].date == e.date && state.pending_f_p_event[i].e == e.e && state.pending_f_p_event[i].p == e.p &&
-				state.pending_f_p_event[i].r_hi == e.r_hi && state.pending_f_p_event[i].r_lo == e.r_lo) {
+		if(state.pending_f_p_event[i] == e) {
 
 			if(opt > state.world.free_provincial_event_get_options(e.e).size() || !is_valid_option(state.world.free_provincial_event_get_options(e.e)[opt]))
 				return; // invalid option

--- a/src/scripting/events.hpp
+++ b/src/scripting/events.hpp
@@ -26,6 +26,9 @@ struct pending_human_n_event {
 			primary_slot == other.primary_slot && r_hi == other.r_hi &&
 			r_lo == other.r_lo;
 	}
+	bool operator !=(const pending_human_n_event& other) const {
+		return !((*this) == other);
+	}
 };
 static_assert(sizeof(pending_human_n_event) ==
 	sizeof(pending_human_n_event::r_lo)
@@ -47,6 +50,9 @@ struct pending_human_f_n_event {
 
 	bool operator ==(const pending_human_f_n_event& other) const {
 		return r_lo == other.r_lo && r_hi == other.r_hi && date == other.date && e == other.e && n == other.n;
+	}
+	bool operator !=(const pending_human_f_n_event& other) const {
+		return !((*this) == other);
 	}
 
 
@@ -73,6 +79,9 @@ struct pending_human_p_event {
 	bool operator ==(const pending_human_p_event& other) const {
 		return r_lo == other.r_lo && r_hi == other.r_hi && from_slot == other.from_slot && date == other.date && e == other.e && p == other.p;
 	}
+	bool operator !=(const pending_human_p_event& other) const {
+		return !((*this) == other);
+	}
 
 
 };
@@ -95,6 +104,9 @@ struct pending_human_f_p_event {
 
 	bool operator ==(const pending_human_f_p_event& other) const {
 		return date == other.date && e == other.e && p == other.p && r_hi == other.r_hi && r_lo == other.r_lo;
+	}
+	bool operator !=(const pending_human_f_p_event& other) const {
+		return !((*this) == other);
 	}
 
 

--- a/src/scripting/events.hpp
+++ b/src/scripting/events.hpp
@@ -18,6 +18,14 @@ struct pending_human_n_event {
 	dcon::nation_id n; //18,2
 	slot_type pt; //20,1
 	slot_type ft; //21,1
+
+
+	bool operator ==(const pending_human_n_event& other) const {
+		return date == other.date && e == other.e &&
+			from_slot == other.from_slot && n == other.n &&
+			primary_slot == other.primary_slot && r_hi == other.r_hi &&
+			r_lo == other.r_lo;
+	}
 };
 static_assert(sizeof(pending_human_n_event) ==
 	sizeof(pending_human_n_event::r_lo)
@@ -36,6 +44,13 @@ struct pending_human_f_n_event {
 	dcon::free_national_event_id e; //10,2
 	dcon::nation_id n; //12,2
 	uint16_t padding = 0;
+
+	bool operator ==(const pending_human_f_n_event& other) const {
+		return r_lo == other.r_lo && r_hi == other.r_hi && date == other.date && e == other.e && n == other.n;
+	}
+
+
+
 };
 static_assert(sizeof(pending_human_f_n_event) ==
 	sizeof(pending_human_f_n_event::r_lo)
@@ -53,6 +68,13 @@ struct pending_human_p_event {
 	dcon::province_id p; //2
 	slot_type ft; //1
 	uint8_t padding = 0;
+
+
+	bool operator ==(const pending_human_p_event& other) const {
+		return r_lo == other.r_lo && r_hi == other.r_hi && from_slot == other.from_slot && date == other.date && e == other.e && p == other.p;
+	}
+
+
 };
 static_assert(sizeof(pending_human_p_event) ==
 	sizeof(pending_human_p_event::r_lo)
@@ -70,6 +92,12 @@ struct pending_human_f_p_event {
 	dcon::free_provincial_event_id e; //10,2
 	dcon::province_id p; //12,2
 	uint16_t padding = 0;
+
+	bool operator ==(const pending_human_f_p_event& other) const {
+		return date == other.date && e == other.e && p == other.p && r_hi == other.r_hi && r_lo == other.r_lo;
+	}
+
+
 };
 static_assert(sizeof(pending_human_f_p_event) ==
 	sizeof(pending_human_f_p_event::r_lo)

--- a/tests/determinism_tests.cpp
+++ b/tests/determinism_tests.cpp
@@ -1581,7 +1581,7 @@ void test_load_save(sys::state& state, uint8_t* ptr_in, uint32_t length) {
 	// Then reload from network
 	state.reset_state();
 	read_save_section(ptr_in, ptr_in + length, state);
-	network::place_players_after_reload(state, players, old_local_player_nation);
+	network::set_no_ai_nations_after_reload(state, players, old_local_player_nation);
 	state.fill_unsaved_data();
 }
 

--- a/tests/network_tests.cpp
+++ b/tests/network_tests.cpp
@@ -13,7 +13,7 @@ TEST_CASE("run_fresh_lobby", "[determinism]") {
 	host_game_state->cheat_data.daily_oos_check = true;
 	network::init(*host_game_state);
 	std::thread update_thread_host([&]() { host_game_state->game_loop(); });
-	command::notify_player_picks_nation(*host_game_state, host_game_state->local_player_nation, dcon::nation_id{ 1 });
+	command::notify_player_picks_nation(*host_game_state, host_game_state->local_player_nation, dcon::nation_id{ 1 }, host_game_state->network_state.nickname);
 
 
 
@@ -27,7 +27,7 @@ TEST_CASE("run_fresh_lobby", "[determinism]") {
 	network::init(*client_game_state);
 	std::thread update_thread_client([&]() { client_game_state->game_loop(); });
 	std::this_thread::sleep_for(std::chrono::milliseconds(5000));
-	command::notify_player_picks_nation(*client_game_state, client_game_state->local_player_nation, dcon::nation_id{5 });
+	command::notify_player_picks_nation(*client_game_state, client_game_state->local_player_nation, dcon::nation_id{5 }, client_game_state->network_state.nickname);
 	command::notify_start_game(*host_game_state, host_game_state->local_player_nation);
 	
 	while(true) {


### PR DESCRIPTION
This PR refactors much of the MP-related code to make the "mp_player_id" the main entity representing a player in MP, instead of the nation_id being the identifier. The nickname is used for identification when sent from client to server, or vice versa.
In the process refactors many things such as ingame messages, nation picking, and joining/leaving. 

As a result, coop is now supported. Events get sent to both players on the same nation, and its first-come-first-server on who clicks the event option first. I also added some server-level checks in commands to ensure no event is executed twice. I also added a server-side check on player_pick_nation to avoid a bad actor abusing coop to silently get on someone else's nation.

Also refactored code around the "swap player" effects to be able to work with the possibility of having multiple players on the same nation.

Added a non-console way of playing as the spectator nation (rebels) with a button in the nation picker screen. It can be used for both SP and MP, and if there are no nations left in MP new players will be put on the spectator tag. Currently FOW is still on for the spectator tag in MP. This could become a host setting later, but for now im leaving it as-is.

Made it so regiments that are in a battle or retreating when the source province changes owner will get safely deleted (from any battles aswell). Previously its strength was set to 0, but could still reinforce and still "stole" the brigade slot&pops from the new owner untill deleted manually.

Added a blackflag update when a nation joins a war, so that army collitions are immedately detected, instead of the two armies being on the same tile with no battle. Also set the organiation of a regiment that has changed owner to be the previous org instead of 0, as in my testing it was leading to some pretty loopsided fights in secessions.





