### PR TITLE
Refactor & fix war exhastion from attrition, fix invalid writes and implement reinforcement buffer for land&navy units

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -550,6 +550,7 @@ These relate to naval battles:
 These relate to army attrition
 - `alice_army_sea_transport_attrition = 2.5f`: The monthly attrition (in percent) for armies on the sea in transports to take. Can be reduced by national "land_attrition" modifiers
 - `alice_fort_siege_attrition_per_level = 0.35f`: Additional attrition (in percent) per fort level for armies sieging the province, stacking with the base siege attrition.
+- `alice_attrition_war_exhaustion = 1.5`: Multiplier to the war exhaustion gained from taking attrition losses. Works similar to the "COMBATLOSS_WAR_EXHAUSTION" define, but for attrition losses instead. Set to 0 to disable all attrition war exhaustion.
 
 
 ### Support for reforms based on party issues

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -543,8 +543,8 @@ These relate to the added ability for reserve regiments to reinforce while in ba
 
 
 These relate to naval battles:
-`alice_naval_combat_enemy_stacking_target_select_bonus = 0.5f`: The target-picking bonus a ship gets if they are outnumbered in a battle. This is added to the base, which by default is 0.5. It makes outnumbered navies find a target faster
-`alice_naval_combat_stacking_damage_penalty = 0.5f`: The max damage reduction to org and str applied to a fleet which outnumbers the enemy by define:NAVAL_COMBAT_MAX_TARGETS or more. The penalty will scale up starting when a side is outnumbered, and will max out at the given value when outnumbered by NAVAL_COMBAT_MAX_TARGETS times.
+- `alice_naval_combat_enemy_stacking_target_select_bonus = 0.5f`: The target-picking bonus a ship gets if they are outnumbered in a battle. This is added to the base, which by default is 0.5. It makes outnumbered navies find a target faster
+- `alice_naval_combat_stacking_damage_penalty = 0.5f`: The max damage reduction to org and str applied to a fleet which outnumbers the enemy by define:NAVAL_COMBAT_MAX_TARGETS or more. The penalty will scale up starting when a side is outnumbered, and will max out at the given value when outnumbered by NAVAL_COMBAT_MAX_TARGETS times.
 
 
 These relate to army attrition

--- a/src/ai/ai.cpp
+++ b/src/ai/ai.cpp
@@ -414,7 +414,6 @@ void update_ships(sys::state& state) {
 				if(!v.get_navy().get_battle_from_navy_battle_participation()) {
 					for(auto shp : v.get_navy().get_navy_membership()) {
 						to_delete.push_back(shp.get_ship().id);
-						state.world.delete_ship(shp.get_ship());
 					}
 				}
 			}

--- a/src/economy/economy.cpp
+++ b/src/economy/economy.cpp
@@ -1057,7 +1057,7 @@ void populate_army_consumption(sys::state& state) {
 					if(reinforcement > 0) {
 						// Regiment needs reinforcement - add extra consumption. Every 1% of reinforcement demands 1% of unit cost. Divide by 28 to spread the demand out over the month
 						auto& curr_demand = state.world.market_get_army_demand(market, build_cost.commodity_type[i]);
-						state.world.market_set_army_demand(market, build_cost.commodity_type[i], curr_demand + (build_cost.commodity_amounts[i] * reinforcement) / 28.0f);
+						state.world.market_set_army_demand(market, build_cost.commodity_type[i], curr_demand + (build_cost.commodity_amounts[i] * reinforcement) / unit_reinforcement_demand_divisor);
 					}
 				} else {
 					break;
@@ -1109,9 +1109,9 @@ void populate_navy_consumption(sys::state& state) {
 					auto reinforcement = military::unit_calculate_reinforcement(state, shp);
 					if(reinforcement > 0) {
 						// Ship needs repair - add extra consumption. Every 1% of reinforcement demands 1% of unit cost
-
+						// add only a fraction of the build cost per day, to spread it out over the month
 						auto& curr_demand = state.world.market_get_navy_demand(market, build_cost.commodity_type[i]);
-						state.world.market_set_navy_demand(market, build_cost.commodity_type[i], curr_demand + build_cost.commodity_amounts[i] * reinforcement);
+						state.world.market_set_navy_demand(market, build_cost.commodity_type[i], curr_demand + (build_cost.commodity_amounts[i] * reinforcement) / unit_reinforcement_demand_divisor);
 					}
 				} else {
 					break;

--- a/src/economy/economy.cpp
+++ b/src/economy/economy.cpp
@@ -2696,7 +2696,7 @@ void daily_update(sys::state& state, bool presimulation, float presimulation_sta
 			state.world.nation_set_effective_naval_spending(
 				n, nations_commodity_spending * max_sp * spending_level);
 			auto& current_buf = state.world.nation_get_naval_reinforcement_buffer(n);
-			state.world.nation_set_naval_reinforcement_buffer(n, current_buf + nations_commodity_spending * max_sp * spending_level);
+			state.world.nation_set_naval_reinforcement_buffer(n, current_buf + state.world.nation_get_effective_naval_spending(n));
 			assert(current_buf >= 0.0f);
 		}
 		{
@@ -2730,7 +2730,7 @@ void daily_update(sys::state& state, bool presimulation, float presimulation_sta
 			state.world.nation_set_effective_land_spending(
 				n, nations_commodity_spending * max_sp * spending_level);
 			auto& current_buf = state.world.nation_get_land_reinforcement_buffer(n);
-			state.world.nation_set_land_reinforcement_buffer(n, current_buf + nations_commodity_spending * max_sp * spending_level);
+			state.world.nation_set_land_reinforcement_buffer(n, current_buf + state.world.nation_get_effective_land_spending(n));
 			assert(current_buf >= 0.0f);
 		}
 		{

--- a/src/economy/economy.cpp
+++ b/src/economy/economy.cpp
@@ -1053,9 +1053,9 @@ void populate_army_consumption(sys::state& state) {
 
 			for(uint32_t i = 0; i < commodity_set::set_size; ++i) {
 				if(build_cost.commodity_type[i]) {
-					auto reinforcement = military::unit_calculate_reinforcement<military::reinforcement_estimation_type::monthly>(state, reg);
+					auto reinforcement = military::unit_calculate_reinforcement<military::reinforcement_estimation_type::full_supplies>(state, reg);
 					if(reinforcement > 0) {
-						// Regiment needs reinforcement - add extra consumption. Every 1% of reinforcement demands 1% of unit cost. Divide by 28 to spread the demand out over the month
+						// Regiment needs reinforcement - add extra consumption. Every 1% of reinforcement demands 1% of unit cost. Divide to spread the demand out over the month
 						auto& curr_demand = state.world.market_get_army_demand(market, build_cost.commodity_type[i]);
 						state.world.market_set_army_demand(market, build_cost.commodity_type[i], curr_demand + (build_cost.commodity_amounts[i] * reinforcement) / unit_reinforcement_demand_divisor);
 					}
@@ -1106,7 +1106,7 @@ void populate_navy_consumption(sys::state& state) {
 
 			for(uint32_t i = 0; i < commodity_set::set_size; ++i) {
 				if(build_cost.commodity_type[i]) {
-					auto reinforcement = military::unit_calculate_reinforcement<military::reinforcement_estimation_type::monthly>(state, shp);
+					auto reinforcement = military::unit_calculate_reinforcement<military::reinforcement_estimation_type::full_supplies>(state, shp);
 					if(reinforcement > 0) {
 						// Ship needs repair - add extra consumption. Every 1% of reinforcement demands 1% of unit cost
 						// add only a fraction of the build cost per day, to spread it out over the month

--- a/src/economy/economy.cpp
+++ b/src/economy/economy.cpp
@@ -1053,7 +1053,7 @@ void populate_army_consumption(sys::state& state) {
 
 			for(uint32_t i = 0; i < commodity_set::set_size; ++i) {
 				if(build_cost.commodity_type[i]) {
-					auto reinforcement = military::unit_calculate_reinforcement(state, reg);
+					auto reinforcement = military::unit_calculate_reinforcement<military::reinforcement_estimation_type::monthly>(state, reg);
 					if(reinforcement > 0) {
 						// Regiment needs reinforcement - add extra consumption. Every 1% of reinforcement demands 1% of unit cost. Divide by 28 to spread the demand out over the month
 						auto& curr_demand = state.world.market_get_army_demand(market, build_cost.commodity_type[i]);
@@ -1106,7 +1106,7 @@ void populate_navy_consumption(sys::state& state) {
 
 			for(uint32_t i = 0; i < commodity_set::set_size; ++i) {
 				if(build_cost.commodity_type[i]) {
-					auto reinforcement = military::unit_calculate_reinforcement(state, shp);
+					auto reinforcement = military::unit_calculate_reinforcement<military::reinforcement_estimation_type::monthly>(state, shp);
 					if(reinforcement > 0) {
 						// Ship needs repair - add extra consumption. Every 1% of reinforcement demands 1% of unit cost
 						// add only a fraction of the build cost per day, to spread it out over the month

--- a/src/economy/economy.cpp
+++ b/src/economy/economy.cpp
@@ -1055,9 +1055,9 @@ void populate_army_consumption(sys::state& state) {
 				if(build_cost.commodity_type[i]) {
 					auto reinforcement = military::unit_calculate_reinforcement(state, reg);
 					if(reinforcement > 0) {
-						// Regiment needs reinforcement - add extra consumption. Every 1% of reinforcement demands 1% of unit cost
+						// Regiment needs reinforcement - add extra consumption. Every 1% of reinforcement demands 1% of unit cost. Divide by 28 to spread the demand out over the month
 						auto& curr_demand = state.world.market_get_army_demand(market, build_cost.commodity_type[i]);
-						state.world.market_set_army_demand(market, build_cost.commodity_type[i], curr_demand + build_cost.commodity_amounts[i] * reinforcement);
+						state.world.market_set_army_demand(market, build_cost.commodity_type[i], curr_demand + (build_cost.commodity_amounts[i] * reinforcement) / 28.0f);
 					}
 				} else {
 					break;
@@ -2695,6 +2695,9 @@ void daily_update(sys::state& state, bool presimulation, float presimulation_sta
 				max_sp /= total;
 			state.world.nation_set_effective_naval_spending(
 				n, nations_commodity_spending * max_sp * spending_level);
+			auto& current_buf = state.world.nation_get_naval_reinforcement_buffer(n);
+			state.world.nation_set_naval_reinforcement_buffer(n, current_buf + nations_commodity_spending * max_sp * spending_level);
+			assert(current_buf >= 0.0f);
 		}
 		{
 			float max_sp = 0.0f;
@@ -2726,6 +2729,9 @@ void daily_update(sys::state& state, bool presimulation, float presimulation_sta
 			assert(std::isfinite(nations_commodity_spending* max_sp* spending_level));
 			state.world.nation_set_effective_land_spending(
 				n, nations_commodity_spending * max_sp * spending_level);
+			auto& current_buf = state.world.nation_get_land_reinforcement_buffer(n);
+			state.world.nation_set_land_reinforcement_buffer(n, current_buf + nations_commodity_spending * max_sp * spending_level);
+			assert(current_buf >= 0.0f);
 		}
 		{
 			state.world.nation_set_effective_construction_spending(

--- a/src/economy/economy.hpp
+++ b/src/economy/economy.hpp
@@ -260,6 +260,8 @@ struct employment_record {
 	float satisfaction;
 	float actual_employment;
 };
+// descides the divisor for the army demand from reinforcements. It is set to 28 to spread out the reinforcement demand over 28 days, as reinforce ticks only happen once a month
+constexpr inline float unit_reinforcement_demand_divisor = 28.0f;
 
 float unit_construction_progress(sys::state& state, dcon::province_land_construction_id c);
 float unit_construction_progress(sys::state& state, dcon::province_naval_construction_id c);

--- a/src/economy/economy_pops.cpp
+++ b/src/economy/economy_pops.cpp
@@ -112,7 +112,7 @@ void update_consumption(
 			float potentially_free,
 			float paid_only
 			) {
-				if(state.world.province_is_valid(pid)) {
+				if(bool(pid)) {
 					{
 						auto old_value = state.world.province_get_service_demand_allowed_public_supply(pid, services::list::education);
 						state.world.province_set_service_demand_allowed_public_supply(pid, services::list::education, old_value + potentially_free);

--- a/src/economy/economy_pops.cpp
+++ b/src/economy/economy_pops.cpp
@@ -112,14 +112,17 @@ void update_consumption(
 			float potentially_free,
 			float paid_only
 			) {
-				{
-					auto old_value = state.world.province_get_service_demand_allowed_public_supply(pid, services::list::education);
-					state.world.province_set_service_demand_allowed_public_supply(pid, services::list::education, old_value + potentially_free);
+				if(state.world.province_is_valid(pid)) {
+					{
+						auto old_value = state.world.province_get_service_demand_allowed_public_supply(pid, services::list::education);
+						state.world.province_set_service_demand_allowed_public_supply(pid, services::list::education, old_value + potentially_free);
+					}
+					{
+						auto old_value = state.world.province_get_service_demand_forbidden_public_supply(pid, services::list::education);
+						state.world.province_set_service_demand_forbidden_public_supply(pid, services::list::education, old_value + paid_only);
+					}
 				}
-				{
-					auto old_value = state.world.province_get_service_demand_forbidden_public_supply(pid, services::list::education);
-					state.world.province_set_service_demand_forbidden_public_supply(pid, services::list::education, old_value + paid_only);
-				}
+				
 		},
 			provs, final_demand_scale_education_free_allowed, final_demand_scale_education_free_not_allowed
 		);
@@ -171,7 +174,9 @@ void update_consumption(
 #endif
 		ve::apply(
 			[&](float transfer, dcon::nation_id n) {
-				state.world.nation_set_national_bank(n, state.world.nation_get_national_bank(n) + transfer);
+				if(state.world.nation_is_valid(n)) {
+					state.world.nation_set_national_bank(n, state.world.nation_get_national_bank(n) + transfer);
+				}
 				return 0;
 			}, bank_deposits, nations
 		);

--- a/src/economy/economy_production.cpp
+++ b/src/economy/economy_production.cpp
@@ -1332,8 +1332,8 @@ void update_rgo_production(sys::state& state) {
 			auto amount = state.world.province_get_rgo_output(province, c);
 			register_domestic_supply(state, local_market, c, amount, economy_reason::rgo);
 
-
-			if(state.world.commodity_get_money_rgo(c)) {
+			// if the rgo is a money RGO and it is not rebel controlled, give the controller the cash from it
+			if(state.world.commodity_get_money_rgo(c) && bool(controller)) {
 				assert(
 					std::isfinite(
 						amount

--- a/src/gamestate/dcon_generated.txt
+++ b/src/gamestate/dcon_generated.txt
@@ -1927,10 +1927,12 @@ object {
 		tag{ save }
 	}
 	property{	
-		name{ pending_damage }
+		name{ pending_combat_damage }
 		type{ float }
-		
-		
+	}
+	property{	
+		name{ pending_attrition_damage }
+		type{ float }
 	}
 	property{	
 		name{ org }

--- a/src/gamestate/dcon_generated.txt
+++ b/src/gamestate/dcon_generated.txt
@@ -4024,6 +4024,16 @@ object {
 		tag{ save }
 	}
 	property {
+		name{ land_reinforcement_buffer }
+		type{ float }
+		tag{ save }
+	}
+	property {
+		name{ naval_reinforcement_buffer }
+		type{ float }
+		tag{ save }
+	}
+	property {
 		name{ effective_land_spending }
 		type{ float }
 		tag{ save }

--- a/src/gui/gui_unit_panel_subwindow.hpp
+++ b/src/gui/gui_unit_panel_subwindow.hpp
@@ -190,7 +190,7 @@ public:
 			);
 
 			//auto a = state.world.regiment_get_army_from_army_membership(reg_id);
-			auto reinf = state.defines.pop_size_per_regiment * military::unit_calculate_reinforcement(state, reg_id, true);
+			auto reinf = state.defines.pop_size_per_regiment * military::unit_calculate_reinforcement<military::reinforcement_estimation_type::monthly>(state, reg_id, true);
 			if(reinf >= 2.0f) {
 				text::add_line(state, contents, "reinforce_rate", text::variable_type::x, int64_t(reinf));
 			} else {

--- a/src/gui/province_tiles/gui_province_tiles_tiles.hpp
+++ b/src/gui/province_tiles/gui_province_tiles_tiles.hpp
@@ -185,7 +185,7 @@ public:
 			);
 
 			auto a = state.world.regiment_get_army_from_army_membership(target.regiment);
-			auto reinf = state.defines.pop_size_per_regiment * military::calculate_army_combined_reinforce(state, a);
+			auto reinf = state.defines.pop_size_per_regiment * military::calculate_army_combined_reinforce<military::reinforcement_estimation_type::monthly>(state, a);
 			if(reinf >= 2.0f) {
 				text::add_line(state, contents, "reinforce_rate", text::variable_type::x, int64_t(reinf));
 			} else {

--- a/src/military/military.cpp
+++ b/src/military/military.cpp
@@ -8709,7 +8709,7 @@ float calculate_army_combined_reinforce(sys::state& state, dcon::army_id a) {
 	auto in_nation = ar.get_controller_from_army_control();
 	auto tech_nation = in_nation ? in_nation : ar.get_controller_from_army_rebel_control().get_ruler_from_rebellion_within();
 
-	auto reinf_fufillment = (in_nation ? std::clamp(state.world.nation_get_land_reinforcement_buffer(in_nation) / 28.0f, 0.f, 1.f) : 1.0f);
+	auto reinf_fufillment = (in_nation ? std::clamp(state.world.nation_get_land_reinforcement_buffer(in_nation) / economy::unit_reinforcement_demand_divisor, 0.f, 1.f) : 1.0f);
 
 	float location_modifier;
 	if(ar.get_battle_from_army_battle_participation()) {
@@ -8717,9 +8717,7 @@ float calculate_army_combined_reinforce(sys::state& state, dcon::army_id a) {
 	} else {
 		location_modifier = calculate_location_reinforce_modifier_no_battle(state, ar.get_location_from_army_location(), in_nation);
 	}
-	auto combined = state.defines.reinforce_speed * reinf_fufillment * location_modifier *
-		(1.0f + tech_nation.get_modifier_values(sys::national_mod_offsets::reinforce_speed)) *
-		(1.0f + tech_nation.get_modifier_values(sys::national_mod_offsets::reinforce_rate));
+	auto combined = state.defines.reinforce_speed * reinf_fufillment * location_modifier * (1.0f + tech_nation.get_modifier_values(sys::national_mod_offsets::reinforce_speed) + tech_nation.get_modifier_values(sys::national_mod_offsets::reinforce_rate));
 
 	assert(std::isfinite(combined));
 	return std::clamp(combined, 0.f, 1.f);
@@ -8890,7 +8888,7 @@ float calculate_navy_combined_reinforce(sys::state& state, dcon::navy_id navy_id
 		? std::min(float(in_nation.get_used_naval_supply_points()) / float(in_nation.get_naval_supply_points()), 1.75f)
 		: 1.75f;
 	float over_size_penalty = oversize_amount > 1.0f ? 2.0f - oversize_amount : 1.0f;
-	auto reinf_fufillment = std::clamp(state.world.nation_get_land_reinforcement_buffer(in_nation) / 28.0f, 0.f, 1.f) * over_size_penalty;
+	auto reinf_fufillment = std::clamp(state.world.nation_get_land_reinforcement_buffer(in_nation) / economy::unit_reinforcement_demand_divisor, 0.f, 1.f) * over_size_penalty;
 
 	auto rr_mod = n.get_location_from_navy_location().get_modifier_values(sys::provincial_mod_offsets::local_repair) + 1.0f;
 	auto reinf_mod = in_nation.get_modifier_values(sys::national_mod_offsets::reinforce_speed) + 1.0f;

--- a/src/military/military.cpp
+++ b/src/military/military.cpp
@@ -6174,8 +6174,7 @@ void apply_attrition_to_army(sys::state& state, dcon::army_id army) {
 }
 
 void apply_attrition(sys::state& state) {
-	concurrency::parallel_for(uint32_t(0), state.world.province_size(), [&](int32_t i) {
-		dcon::province_id prov{ dcon::province_id::value_base_t(i) };
+	state.world.for_each_province([&](dcon::province_id prov) {
 		assert(state.world.province_is_valid(prov));
 
 		for(auto ar : state.world.province_get_army_location(prov)) {

--- a/src/military/military.cpp
+++ b/src/military/military.cpp
@@ -7555,6 +7555,7 @@ void update_naval_battles(sys::state& state) {
 			case ship_in_battle::mode_approaching:
 			{
 				assert(naval_slot_index_valid(slots[j].target_slot));
+				assert(state.world.ship_is_valid(slots[j].ship));
 
 				auto target_mode = slots[slots[j].target_slot].flags & ship_in_battle::mode_mask;
 				if(target_mode == ship_in_battle::mode_retreated || target_mode == ship_in_battle::mode_sunk) {
@@ -7594,6 +7595,7 @@ void update_naval_battles(sys::state& state) {
 			case ship_in_battle::mode_engaged:
 			{
 				assert(naval_slot_index_valid(slots[j].target_slot));
+				assert(state.world.ship_is_valid(slots[j].ship));
 				auto target_mode = slots[slots[j].target_slot].flags & ship_in_battle::mode_mask;
 				if(target_mode == ship_in_battle::mode_retreated || target_mode == ship_in_battle::mode_sunk) {
 					slots[j].flags &= ~ship_in_battle::mode_mask;
@@ -7615,7 +7617,7 @@ void update_naval_battles(sys::state& state) {
 				A retreating ship will increase its distance by define:NAVAL_COMBAT_RETREAT_SPEED_MOD x
 				define:NAVAL_COMBAT_SPEED_TO_DISTANCE_FACTOR x (random value in the range \[0.0 - 0.5) + 0.5) x ship-max-speed.
 				*/
-
+				assert(state.world.ship_is_valid(slots[j].ship));
 				float speed = ship_stats.maximum_speed * 1000.0f * state.defines.naval_combat_retreat_speed_mod *
 					state.defines.naval_combat_speed_to_distance_factor *
 					(0.5f + float(rng::get_random(state, uint32_t(slots[j].ship.value)) & 0x7FFF) / float(0xFFFF));
@@ -7647,6 +7649,7 @@ void update_naval_battles(sys::state& state) {
 				NAVAL_COMBAT_SHIFT_BACK_ON_NEXT_TARGET to a maximum of 1000, and the ship switches to approaching.
 				*/
 				int16_t target_index = get_naval_battle_target(state, slots[j], b, defender_ships, attacker_ships);
+				assert(state.world.ship_is_valid(slots[j].ship));
 				// get ship target, put into target_index variable
 				if(naval_slot_index_valid(target_index)) {
 
@@ -7666,11 +7669,11 @@ void update_naval_battles(sys::state& state) {
 					slots[j].flags &= ~ship_in_battle::distance_mask;
 					slots[j].flags |= ship_in_battle::distance_mask & new_distance;
 
-					break;
 				}
-				
+				break;
 			}
 			default:
+				// if the ship is sunk, make sure no ships are still targeting it
 				break;
 			}
 		}

--- a/src/military/military.hpp
+++ b/src/military/military.hpp
@@ -267,6 +267,9 @@ constexpr inline int32_t days_before_retreat = 11;
 enum class battle_result {
 	indecisive, attacker_won, defender_won
 };
+enum class regiment_dmg_source {
+	combat, attrition
+};
 
 void reset_unit_stats(sys::state& state);
 void apply_base_unit_stat_modifiers(sys::state& state);
@@ -475,6 +478,8 @@ float calculate_army_combined_reinforce(sys::state& state, dcon::army_id a);
 
 void reduce_regiment_strength_safe(sys::state& state, dcon::regiment_id reg, float value);
 void reduce_ship_strength_safe(sys::state& state, dcon::ship_id reg, float value);
+
+template<regiment_dmg_source damage_source>
 void regiment_take_damage(sys::state& state, dcon::regiment_id reg, float value);
 
 int32_t movement_time_from_to(sys::state& state, dcon::army_id a, dcon::province_id from, dcon::province_id to);
@@ -567,6 +572,7 @@ void move_land_to_merge(sys::state& state, dcon::nation_id by, dcon::army_id a, 
 void move_navy_to_merge(sys::state& state, dcon::nation_id by, dcon::navy_id a, dcon::province_id start, dcon::province_id dest);
 bool pop_eligible_for_mobilization(sys::state& state, dcon::pop_id p);
 
+template<regiment_dmg_source damage_source>
 void disband_regiment_w_pop_death(sys::state& state, dcon::regiment_id reg_id);
 
 } // namespace military

--- a/src/military/military.hpp
+++ b/src/military/military.hpp
@@ -474,6 +474,13 @@ float local_enemy_army_weight_max(sys::state& state, dcon::province_id prov, dco
 float attrition_amount(sys::state& state, dcon::navy_id a);
 float attrition_amount(sys::state& state, dcon::army_id a);
 float peacetime_attrition_limit(sys::state& state, dcon::nation_id n, dcon::province_id prov);
+
+enum class reinforcement_estimation_type {
+	today, monthly, full_supplies
+};
+
+
+template<reinforcement_estimation_type reinf_est_type>
 float calculate_army_combined_reinforce(sys::state& state, dcon::army_id a);
 
 void reduce_regiment_strength_safe(sys::state& state, dcon::regiment_id reg, float value);
@@ -497,6 +504,7 @@ enum class apply_attrition_on_arrival {
 	no, yes
 
 };
+
 
 template <apply_attrition_on_arrival attrition_tick = apply_attrition_on_arrival::no>
 void army_arrives_in_province(sys::state& state, dcon::army_id a, dcon::province_id p, crossing_type crossing, dcon::land_battle_id from = dcon::land_battle_id{}); // only for land provinces
@@ -540,7 +548,11 @@ float calculate_battle_reinforcement(sys::state& state, dcon::land_battle_id b, 
 float calculate_average_battle_supply_spending(sys::state& state, dcon::land_battle_id b, bool attacker);
 float calculate_average_battle_location_modifier(sys::state& state, dcon::land_battle_id b, bool attacker);
 float calculate_average_battle_national_modifiers(sys::state& state, dcon::land_battle_id b, bool attacker);
+
+template<reinforcement_estimation_type reinf_estimation>
 float unit_calculate_reinforcement(sys::state& state, dcon::regiment_id reg, bool potential_reinf = false);
+
+template<reinforcement_estimation_type reinf_estimation>
 float unit_calculate_reinforcement(sys::state& state, dcon::ship_id reg);
 void reinforce_regiments(sys::state& state);
 void repair_ships(sys::state& state);

--- a/src/nations/nations.cpp
+++ b/src/nations/nations.cpp
@@ -3489,6 +3489,8 @@ void adjust_influence_with_overflow(sys::state& state, dcon::nation_id great_pow
 			state.world.gp_relationship_set_influence(rel, inf - state.defines.removefromsphere_influence_cost);
 			auto affected_gp = state.world.nation_get_in_sphere_of(target);
 			state.world.nation_set_in_sphere_of(target, dcon::nation_id{});
+			// if the target was in a previous GP's sphere, update their state
+			if(bool(affected_gp))
 			{
 				auto orel = state.world.get_gp_relationship_by_gp_influence_pair(target, affected_gp);
 				auto& l = state.world.gp_relationship_get_status(orel);

--- a/src/parsing/defines.hpp
+++ b/src/parsing/defines.hpp
@@ -752,6 +752,7 @@
 	LUA_DEFINES_LIST_ELEMENT(alice_max_starvation_degrowth, 0.0012) \
 	LUA_DEFINES_LIST_ELEMENT(alice_army_sea_transport_attrition, 2.5) \
 	LUA_DEFINES_LIST_ELEMENT(alice_fort_siege_attrition_per_level, 0.35) \
+	LUA_DEFINES_LIST_ELEMENT(alice_attrition_war_exhaustion, 1.5) \
 
 // scales the needs values so that they are needs per this many pops
 // this value was arrived at by looking at farmers: 40'000 farmers produces enough grain to satisfy about 2/3


### PR DESCRIPTION
- Fixes the war exhaustion from 0 strength armies by refactoring the code and changing it so that war exhaustion is applied directly when a army unit takes damage (from pending damage) and on stackwipes instead of triggering on 0 strength. Also splits up the pending_damage into pending_combat_damage and pending_attrition_damage, to have seperate defines for the amount of war exhaustion they cause.

- Implement a monthly "reinforcement buffer" for navy and land armies. Previously the amount of army demand added by needing reinforcement was too high (It tried to add the entire unit cost per day, multiplied by reinforce rate). Now it spreads out the cost over the month (or specifically, 28 days), and uses the reinforcement buffer to add up the total amount of army demand satisfied over the month. This effectively means you will get a reinforce tick equal to your average spending during the last month.


- Fixed some bugs such as navies being double-deleted, mobilization units not being cleaned up after demob, and stackwiped units not causing pop death in the wiped regiments.
- Fixed some invalid writes.
