### PR TITLE
oos fix and expanding/refactoring oos tests

### DIFF
--- a/src/common_types/date_interface.hpp
+++ b/src/common_types/date_interface.hpp
@@ -9,6 +9,13 @@ struct year_month_day {
 	int32_t year;
 	uint16_t month;
 	uint16_t day;
+
+	bool operator== (const year_month_day& other) {
+		return year == other.year && month == other.month && day == other.day;
+	}
+	bool operator!= (const year_month_day& other) {
+		return !(*this == other);
+	}
 };
 
 class absolute_time_point {

--- a/src/common_types/date_interface.hpp
+++ b/src/common_types/date_interface.hpp
@@ -10,12 +10,8 @@ struct year_month_day {
 	uint16_t month;
 	uint16_t day;
 
-	bool operator== (const year_month_day& other) {
-		return year == other.year && month == other.month && day == other.day;
-	}
-	bool operator!= (const year_month_day& other) {
-		return !(*this == other);
-	}
+	bool operator== (const year_month_day& other) const = default;
+	bool operator!= (const year_month_day& other) const = default;
 };
 
 class absolute_time_point {

--- a/src/economy/economy.cpp
+++ b/src/economy/economy.cpp
@@ -2261,7 +2261,7 @@ void daily_update(sys::state& state, bool presimulation, float presimulation_sta
 
 	// rgo/factories/artisans consumption
 	update_production_consumption(state);
-	
+
 	state.world.for_each_commodity([&](auto cid) {
 		bool is_potential_rgo = state.world.commodity_get_rgo_amount(cid) > 0.f;
 		bool already_known_to_exist = state.world.commodity_get_actually_exists_in_nature(cid);
@@ -2321,7 +2321,7 @@ void daily_update(sys::state& state, bool presimulation, float presimulation_sta
 	// we have to recalculate loan related variables every new round, because they depend on themselves
 
 	static auto spent_on_construction_buffer = state.world.nation_make_vectorizable_float_buffer();
-	
+
 	for(auto n : state.nations_by_rank) {
 		if(!n) {
 			continue;

--- a/src/economy/economy_production.cpp
+++ b/src/economy/economy_production.cpp
@@ -1953,7 +1953,7 @@ void update_production_consumption(sys::state& state) {
 		update_artisan_consumption(state, ids, mobilization_impact);
 	});
 
-	state.world.execute_parallel_over_market([&](auto markets) {
+	state.world.execute_serial_over_market([&](auto markets) {
 		auto states = state.world.market_get_zone_from_local_market(markets);
 		auto nations = state.world.state_instance_get_nation_from_state_ownership(states);
 		auto mobilization_impact =

--- a/src/economy/economy_production.cpp
+++ b/src/economy/economy_production.cpp
@@ -1953,7 +1953,7 @@ void update_production_consumption(sys::state& state) {
 		update_artisan_consumption(state, ids, mobilization_impact);
 	});
 
-	state.world.execute_serial_over_market([&](auto markets) {
+	state.world.execute_parallel_over_market([&](auto markets) {
 		auto states = state.world.market_get_zone_from_local_market(markets);
 		auto nations = state.world.state_instance_get_nation_from_state_ownership(states);
 		auto mobilization_impact =

--- a/src/gamestate/serialization.cpp
+++ b/src/gamestate/serialization.cpp
@@ -996,7 +996,7 @@ std::string make_time_string(uint64_t value) {
 	return result;
 }
 
-void write_save_file(sys::state& state, save_type type, std::string const& name) {
+void write_save_file(sys::state& state, save_type type, std::string const& name, const std::string& file_name) {
 	save_header header;
 	header.count = state.scenario_counter;
 	//header.timestamp = state.scenario_time_stamp;
@@ -1042,9 +1042,15 @@ void write_save_file(sys::state& state, save_type type, std::string const& name)
 		auto base_str = "bookmark_" + make_time_string(uint64_t(std::time(nullptr))) + "-" + std::to_string(ymd_date.year) + "-" + std::to_string(ymd_date.month) + "-" + std::to_string(ymd_date.day) + ".bin";
 		simple_fs::write_file(sdir, simple_fs::utf8_to_native(base_str), reinterpret_cast<char*>(temp_buffer), uint32_t(total_size_used));
 	} else {
-		auto ymd_date = state.current_date.to_ymd(state.start_date);
-		auto base_str = make_time_string(uint64_t(std::time(nullptr))) + "-" + nations::int_to_tag(state.world.national_identity_get_identifying_int(header.tag)) + "-" + std::to_string(ymd_date.year) + "-" + std::to_string(ymd_date.month) + "-" + std::to_string(ymd_date.day) + ".bin";
-		simple_fs::write_file(sdir, simple_fs::utf8_to_native(base_str), reinterpret_cast<char*>(temp_buffer), uint32_t(total_size_used));
+		if(!file_name.empty()) {
+			auto base_str = file_name + ".bin";
+			simple_fs::write_file(sdir, simple_fs::utf8_to_native(base_str), reinterpret_cast<char*>(temp_buffer), uint32_t(total_size_used));
+		}
+		else {
+			auto ymd_date = state.current_date.to_ymd(state.start_date);
+			auto base_str = make_time_string(uint64_t(std::time(nullptr))) + "-" + nations::int_to_tag(state.world.national_identity_get_identifying_int(header.tag)) + "-" + std::to_string(ymd_date.year) + "-" + std::to_string(ymd_date.month) + "-" + std::to_string(ymd_date.day) + ".bin";
+			simple_fs::write_file(sdir, simple_fs::utf8_to_native(base_str), reinterpret_cast<char*>(temp_buffer), uint32_t(total_size_used));
+		}
 	}
 	delete[] temp_buffer;
 

--- a/src/gamestate/serialization.hpp
+++ b/src/gamestate/serialization.hpp
@@ -212,7 +212,7 @@ bool try_read_scenario_file(sys::state& state, native_string_view name);
 bool try_read_scenario_and_save_file(sys::state& state, native_string_view name);
 bool try_read_scenario_as_save_file(sys::state& state, native_string_view name);
 
-void write_save_file(sys::state& state, sys::save_type type = sys::save_type::normal, std::string const& name = std::string(""));
+void write_save_file(sys::state& state, sys::save_type type = sys::save_type::normal, std::string const& name = std::string(""), const std::string& file_name = std::string(""));
 bool try_read_save_file(sys::state& state, native_string_view name);
 
 } // namespace sys

--- a/tests/determinism_tests.cpp
+++ b/tests/determinism_tests.cpp
@@ -350,14 +350,178 @@ TEST_CASE("populate_test_saves", "[determinism]") {
 }
 
 
-TEST_CASE("sim_game_solo", "[determinism]") {
+TEST_CASE("sim_game_solo_1", "[determinism][sim_solo_tests]") {
 	// Test that the game states are equal after playing
-	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file_with_save(sys::network_mode_type::host);
 
 
 	game_state_1->game_seed = test_game_seed;
 
-	for(int i = 0; i <= 36530; i++) {
+	for(int i = 0; i <= 3653; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+	}
+}
+
+TEST_CASE("sim_game_solo_2", "[determinism][sim_solo_tests]") {
+	// Test that the game states are equal after playing
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("184611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+
+	game_state_1->game_seed = test_game_seed;
+
+	for(int i = 0; i <= 3653; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+	}
+}
+TEST_CASE("sim_game_solo_3", "[determinism][sim_solo_tests]") {
+	// Test that the game states are equal after playing
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("185611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+
+	game_state_1->game_seed = test_game_seed;
+
+	for(int i = 0; i <= 3653; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+	}
+}
+TEST_CASE("sim_game_solo_4", "[determinism][sim_solo_tests]") {
+	// Test that the game states are equal after playing
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("186611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+
+	game_state_1->game_seed = test_game_seed;
+
+	for(int i = 0; i <= 3653; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+	}
+}
+TEST_CASE("sim_game_solo_5", "[determinism][sim_solo_tests]") {
+	// Test that the game states are equal after playing
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("187611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+
+	game_state_1->game_seed = test_game_seed;
+
+	for(int i = 0; i <= 3653; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+	}
+}
+
+TEST_CASE("sim_game_solo_6", "[determinism][sim_solo_tests]") {
+	// Test that the game states are equal after playing
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("188611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+
+	game_state_1->game_seed = test_game_seed;
+
+	for(int i = 0; i <= 3653; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+	}
+}
+TEST_CASE("sim_game_solo_7", "[determinism][sim_solo_tests]") {
+	// Test that the game states are equal after playing
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("189611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+
+	game_state_1->game_seed = test_game_seed;
+
+	for(int i = 0; i <= 3653; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+	}
+}
+TEST_CASE("sim_game_solo_8", "[determinism][sim_solo_tests]") {
+	// Test that the game states are equal after playing
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("190611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+
+	game_state_1->game_seed = test_game_seed;
+
+	for(int i = 0; i <= 3653; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+	}
+}
+TEST_CASE("sim_game_solo_9", "[determinism][sim_solo_tests]") {
+	// Test that the game states are equal after playing
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("191611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+
+	game_state_1->game_seed = test_game_seed;
+
+	for(int i = 0; i <= 3653; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+	}
+}
+TEST_CASE("sim_game_solo_10", "[determinism][sim_solo_tests]") {
+	// Test that the game states are equal after playing
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("192611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+
+	game_state_1->game_seed = test_game_seed;
+
+	for(int i = 0; i <= 3653; i++) {
 		game_state_1->console_log(std::to_string(i));
 		game_state_1->single_game_tick();
 	}
@@ -368,8 +532,8 @@ TEST_CASE("sim_game_solo", "[determinism]") {
 
 TEST_CASE("sim_game_1", "[determinism][sim_game_tests]") {
 	// Test that the game states are equal after playing
-	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
-	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file_with_save(sys::network_mode_type::host);
+	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file_with_save(sys::network_mode_type::client);
 
 
 	game_state_2->game_seed = game_state_1->game_seed = test_game_seed;
@@ -674,7 +838,7 @@ TEST_CASE("sim_game_10", "[determinism][sim_game_tests]") {
 }
 
 TEST_CASE("fill_unsaved_values_determinism_1", "[determinism][fill_unsaved_tests]") {
-	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file_with_save(sys::network_mode_type::host);
 
 	game_state_1->game_seed = test_game_seed;
 
@@ -1010,8 +1174,8 @@ TEST_CASE("fill_unsaved_values_determinism_10", "[determinism][fill_unsaved_test
 TEST_CASE("sim_game_with_saveload_1", "[determinism][sim_with_saveload_tests]") {
 
 
-	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
-	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file_with_save(sys::network_mode_type::host);
+	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file_with_save(sys::network_mode_type::client);
 
 	game_state_2->game_seed = game_state_1->game_seed = test_game_seed;
 

--- a/tests/determinism_tests.cpp
+++ b/tests/determinism_tests.cpp
@@ -1638,9 +1638,9 @@ TEST_CASE("sim_game_solo", "[determinism]") {
 }
 
 
+//All of the following tests from first to tenth is running the entire game in 10 year intervals with a save for each to test for desync's.
 
-
-TEST_CASE("sim_game", "[determinism]") {
+TEST_CASE("sim_game_first", "[determinism]") {
 	// Test that the game states are equal after playing
 	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
 	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
@@ -1649,13 +1649,307 @@ TEST_CASE("sim_game", "[determinism]") {
 	game_state_2->game_seed = game_state_1->game_seed = 808080;
 
 	compare_game_states(*game_state_1, *game_state_2);
-	for(int i = 0; i <= 3650; i++) {
+	for(int i = 0; i <= 3653; i++) {
 		game_state_1->console_log(std::to_string(i));
 		game_state_1->single_game_tick();
 		game_state_2->single_game_tick();
 		compare_game_states(*game_state_1, *game_state_2);
 	}
 }
+
+TEST_CASE("sim_game_second", "[determinism]") {
+	// Test that the game states are equal after playing
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("1846_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	}
+	else {
+		game_state_1->fill_unsaved_data();
+	}
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("1846_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	}
+	else {
+		game_state_2->fill_unsaved_data();
+	}
+
+
+	game_state_2->game_seed = game_state_1->game_seed = 808080;
+
+	compare_game_states(*game_state_1, *game_state_2);
+	for(int i = 0; i <= 3653; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+		game_state_2->single_game_tick();
+		compare_game_states(*game_state_1, *game_state_2);
+	}
+}
+
+TEST_CASE("sim_game_third", "[determinism]") {
+	// Test that the game states are equal after playing
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("1856_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	}
+	else {
+		game_state_1->fill_unsaved_data();
+	}
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("1856_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	}
+	else {
+		game_state_2->fill_unsaved_data();
+	}
+
+
+	game_state_2->game_seed = game_state_1->game_seed = 808080;
+
+	compare_game_states(*game_state_1, *game_state_2);
+	for(int i = 0; i <= 3653; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+		game_state_2->single_game_tick();
+		compare_game_states(*game_state_1, *game_state_2);
+	}
+}
+TEST_CASE("sim_game_fourth", "[determinism]") {
+	// Test that the game states are equal after playing
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("1866_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	}
+	else {
+		game_state_1->fill_unsaved_data();
+	}
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("1866_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	}
+	else {
+		game_state_2->fill_unsaved_data();
+	}
+
+
+	game_state_2->game_seed = game_state_1->game_seed = 808080;
+
+	compare_game_states(*game_state_1, *game_state_2);
+	for(int i = 0; i <= 3653; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+		game_state_2->single_game_tick();
+		compare_game_states(*game_state_1, *game_state_2);
+	}
+}
+TEST_CASE("sim_game_fifth", "[determinism]") {
+	// Test that the game states are equal after playing
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("1876_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	}
+	else {
+		game_state_1->fill_unsaved_data();
+	}
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("1876_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	}
+	else {
+		game_state_2->fill_unsaved_data();
+	}
+
+
+	game_state_2->game_seed = game_state_1->game_seed = 808080;
+
+	compare_game_states(*game_state_1, *game_state_2);
+	for(int i = 0; i <= 3653; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+		game_state_2->single_game_tick();
+		compare_game_states(*game_state_1, *game_state_2);
+	}
+}
+TEST_CASE("sim_game_sixth", "[determinism]") {
+	// Test that the game states are equal after playing
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("1886_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	}
+	else {
+		game_state_1->fill_unsaved_data();
+	}
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("1886_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	}
+	else {
+		game_state_2->fill_unsaved_data();
+	}
+
+
+	game_state_2->game_seed = game_state_1->game_seed = 808080;
+
+	compare_game_states(*game_state_1, *game_state_2);
+	for(int i = 0; i <= 3653; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+		game_state_2->single_game_tick();
+		compare_game_states(*game_state_1, *game_state_2);
+	}
+}
+TEST_CASE("sim_game_seventh", "[determinism]") {
+	// Test that the game states are equal after playing
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("1896_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	}
+	else {
+		game_state_1->fill_unsaved_data();
+	}
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("1896_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	}
+	else {
+		game_state_2->fill_unsaved_data();
+	}
+
+
+	game_state_2->game_seed = game_state_1->game_seed = 808080;
+
+	compare_game_states(*game_state_1, *game_state_2);
+	for(int i = 0; i <= 3653; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+		game_state_2->single_game_tick();
+		compare_game_states(*game_state_1, *game_state_2);
+	}
+}
+TEST_CASE("sim_game_eigth", "[determinism]") {
+	// Test that the game states are equal after playing
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("1906_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	}
+	else {
+		game_state_1->fill_unsaved_data();
+	}
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("1906_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	}
+	else {
+		game_state_2->fill_unsaved_data();
+	}
+
+
+	game_state_2->game_seed = game_state_1->game_seed = 808080;
+
+	compare_game_states(*game_state_1, *game_state_2);
+	for(int i = 0; i <= 3653; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+		game_state_2->single_game_tick();
+		compare_game_states(*game_state_1, *game_state_2);
+	}
+}
+TEST_CASE("sim_game_ninth", "[determinism]") {
+	// Test that the game states are equal after playing
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("1916_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	}
+	else {
+		game_state_1->fill_unsaved_data();
+	}
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("1916_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	}
+	else {
+		game_state_2->fill_unsaved_data();
+	}
+
+
+	game_state_2->game_seed = game_state_1->game_seed = 808080;
+
+	compare_game_states(*game_state_1, *game_state_2);
+	for(int i = 0; i <= 3653; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+		game_state_2->single_game_tick();
+		compare_game_states(*game_state_1, *game_state_2);
+	}
+}
+TEST_CASE("sim_game_tenth", "[determinism]") {
+	// Test that the game states are equal after playing
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("1926_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	}
+	else {
+		game_state_1->fill_unsaved_data();
+	}
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("1926_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	}
+	else {
+		game_state_2->fill_unsaved_data();
+	}
+
+
+	game_state_2->game_seed = game_state_1->game_seed = 808080;
+
+	compare_game_states(*game_state_1, *game_state_2);
+	for(int i = 0; i <= 3653; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+		game_state_2->single_game_tick();
+		compare_game_states(*game_state_1, *game_state_2);
+	}
+}
+
+
+
+
 // this one uses the slower, but more accurate checked tick
 TEST_CASE("sim_game_advanced", "[determinism]") {
 	// Test that the game states are equal after playing

--- a/tests/determinism_tests.cpp
+++ b/tests/determinism_tests.cpp
@@ -271,1295 +271,6 @@ void checked_pop_update(sys::state& ws) {
 	}
 }
 
-void checked_single_tick(sys::state& ws1, sys::state& ws2) {
-	// do update logic
-	province::update_connected_regions(ws1);
-	province::update_connected_regions(ws2);
-	compare_game_states(ws1, ws2);
-	province::update_cached_values(ws1);
-	province::update_cached_values(ws2);
-	compare_game_states(ws1, ws2);
-	nations::update_cached_values(ws1);
-	nations::update_cached_values(ws1);
-	compare_game_states(ws1, ws2);
-
-	ws1.current_date += 1;
-	ws2.current_date += 1;
-
-	auto ymd_date = ws1.current_date.to_ymd(ws1.start_date);
-
-	diplomatic_message::update_pending(ws1);
-	diplomatic_message::update_pending(ws2);
-	compare_game_states(ws1, ws2);
-
-	auto month_start = sys::year_month_day{ ymd_date.year, ymd_date.month, uint16_t(1) };
-	auto next_month_start = sys::year_month_day{ ymd_date.year, uint16_t(ymd_date.month + 1), uint16_t(1) };
-	auto const days_in_month = uint32_t(sys::days_difference(month_start, next_month_start));
-
-	demographics::remove_size_zero_pops(ws1);
-	demographics::remove_size_zero_pops(ws2);
-	compare_game_states(ws1, ws2);
-
-	// basic repopulation of demographics derived values
-	demographics::regenerate_from_pop_data<true>(ws1);
-	demographics::regenerate_from_pop_data<true>(ws2);
-	compare_game_states(ws1, ws2);
-
-	// values updates pass 1 (mostly trivial things, can be done in parallel)
-	concurrency::parallel_for(0, 16, [&](int32_t index) {
-		switch(index) {
-		case 0:
-			ai::refresh_home_ports(ws1);
-			ai::refresh_home_ports(ws2);
-			break;
-		case 1:
-			nations::update_research_points(ws1);
-			nations::update_research_points(ws2);
-			break;
-		case 2:
-			military::regenerate_land_unit_average(ws1);
-			military::regenerate_land_unit_average(ws2);
-			break;
-		case 3:
-			military::regenerate_ship_scores(ws1);
-			military::regenerate_ship_scores(ws2);
-			break;
-		case 4:
-			nations::update_industrial_scores(ws1);
-			nations::update_industrial_scores(ws2);
-			break;
-		case 5:
-			military::update_naval_supply_points(ws1);
-			military::update_naval_supply_points(ws2);
-			break;
-		case 6:
-			military::update_all_recruitable_regiments(ws1);
-			military::update_all_recruitable_regiments(ws2);
-			break;
-		case 7:
-			military::regenerate_total_regiment_counts(ws1);
-			military::regenerate_total_regiment_counts(ws2);
-			break;
-		case 8:
-			break;
-		case 9:
-			economy::update_employment(ws1);
-			economy::update_employment(ws2);
-			break;
-		case 10:
-			nations::update_national_administrative_efficiency(ws1);
-			nations::update_administrative_efficiency(ws1);
-			rebel::daily_update_rebel_organization(ws1);
-
-			nations::update_national_administrative_efficiency(ws2);
-			nations::update_administrative_efficiency(ws2);
-			rebel::daily_update_rebel_organization(ws2);
-			break;
-		case 11:
-			military::daily_leaders_update(ws1);
-			military::daily_leaders_update(ws2);
-			break;
-		case 12:
-			politics::daily_party_loyalty_update(ws1);
-			politics::daily_party_loyalty_update(ws2);
-			break;
-		case 13:
-			nations::daily_update_flashpoint_tension(ws1);
-			nations::daily_update_flashpoint_tension(ws2);
-			break;
-		case 14:
-			military::update_ticking_war_score(ws1);
-			military::update_ticking_war_score(ws2);
-			break;
-		case 15:
-			military::increase_dig_in(ws1);
-			military::increase_dig_in(ws2);
-			break;
-		case 16:
-			military::recover_org(ws1);
-			military::recover_org(ws2);
-			break;
-		}
-	});
-	compare_game_states(ws1, ws2);
-
-	economy::daily_update(ws1, false, 1.f);
-	economy::daily_update(ws2, false, 1.f);
-	compare_game_states(ws1, ws2);
-
-	military::update_siege_progress(ws1);
-	military::update_siege_progress(ws2);
-	compare_game_states(ws1, ws2);
-	military::update_movement(ws1);
-	military::update_movement(ws2);
-	compare_game_states(ws1, ws2);
-	military::update_naval_battles(ws1);
-	military::update_naval_battles(ws2);
-	compare_game_states(ws1, ws2);
-	military::update_land_battles(ws1);
-	military::update_land_battles(ws2);
-	compare_game_states(ws1, ws2);
-	military::advance_mobilizations(ws1);
-	military::advance_mobilizations(ws2);
-	compare_game_states(ws1, ws2);
-
-	event::update_events(ws1);
-	event::update_events(ws2);
-	compare_game_states(ws1, ws2);
-
-	culture::update_research(ws1, uint32_t(ymd_date.year));
-	culture::update_research(ws2, uint32_t(ymd_date.year));
-	compare_game_states(ws1, ws2);
-
-	nations::update_military_scores(ws1); // depends on ship score, land unit average
-	nations::update_military_scores(ws2); // depends on ship score, land unit average
-	compare_game_states(ws1, ws2);
-	nations::update_rankings(ws1);				// depends on industrial score, military scores
-	nations::update_rankings(ws2);				// depends on industrial score, military scores
-	compare_game_states(ws1, ws2);
-	nations::update_great_powers(ws1);		// depends on rankings
-	nations::update_great_powers(ws2);		// depends on rankings
-	compare_game_states(ws1, ws2);
-	nations::update_influence(ws1);				// depends on rankings, great powers
-	nations::update_influence(ws2);				// depends on rankings, great powers
-	compare_game_states(ws1, ws2);
-
-	province::update_colonization(ws1);
-	province::update_colonization(ws2);
-	compare_game_states(ws1, ws2);
-	military::update_cbs(ws1); // may add/remove cbs to a nation
-	military::update_cbs(ws2); // may add/remove cbs to a nation
-	compare_game_states(ws1, ws2);
-
-	nations::update_crisis(ws1);
-	nations::update_crisis(ws2);
-	compare_game_states(ws1, ws2);
-	politics::update_elections(ws1);
-	politics::update_elections(ws2);
-	compare_game_states(ws1, ws2);
-
-	//
-	//if(ws1.current_date.value % 4 == 0) {
-		ai::update_ai_colonial_investment(ws1);
-		ai::update_ai_colonial_investment(ws2);
-		compare_game_states(ws1, ws2);
-	//}
-
-	// Once per month updates, spread out over the month
-	//switch(ymd_date.day) {
-	for(int32_t index = 0; index <= 31; index++) {
-		switch(index) {
-		case 1:
-			nations::update_monthly_points(ws1);
-			nations::update_monthly_points(ws2);
-			break;
-		case 2:
-			sys::update_modifier_effects(ws1);
-			sys::update_modifier_effects(ws2);
-			break;
-		case 3:
-			military::monthly_leaders_update(ws1);
-			military::monthly_leaders_update(ws2);
-			compare_game_states(ws1, ws2);
-			ai::add_wargoals(ws1);
-			ai::add_wargoals(ws2);
-			break;
-		case 4:
-			military::reinforce_regiments(ws1);
-			military::reinforce_regiments(ws2);
-			compare_game_states(ws1, ws2);
-			ai::make_defense(ws1);
-			ai::make_defense(ws2);
-			break;
-		case 5:
-			rebel::update_movements(ws1);
-			rebel::update_movements(ws2);
-			compare_game_states(ws1, ws2);
-			rebel::update_factions(ws1);
-			rebel::update_factions(ws2);
-			break;
-		case 6:
-			ai::form_alliances(ws1);
-			ai::form_alliances(ws2);
-			compare_game_states(ws1, ws2);
-			ai::make_attacks(ws1);
-			ai::make_attacks(ws2);
-			break;
-		case 7:
-			ai::update_ai_general_status(ws1);
-			ai::update_ai_general_status(ws2);
-			break;
-		case 8:
-			military::apply_attrition(ws1);
-			military::apply_attrition(ws2);
-			break;
-		case 9:
-			military::repair_ships(ws1);
-			military::repair_ships(ws2);
-			break;
-		case 10:
-			province::update_crimes(ws1);
-			province::update_crimes(ws2);
-			break;
-		case 11:
-			province::update_nationalism(ws1);
-			province::update_nationalism(ws2);
-			break;
-		case 12:
-			ai::update_ai_research(ws1);
-			ai::update_ai_research(ws2);
-			compare_game_states(ws1, ws2);
-			rebel::update_armies(ws1);
-			rebel::update_armies(ws2);
-			compare_game_states(ws1, ws2);
-			rebel::rebel_hunting_check(ws1);
-			rebel::rebel_hunting_check(ws2);
-			break;
-		case 13:
-			ai::perform_influence_actions(ws1);
-			ai::perform_influence_actions(ws2);
-			break;
-		case 14:
-			ai::update_focuses(ws1);
-			ai::update_focuses(ws2);
-			break;
-		case 15:
-			culture::discover_inventions(ws1);
-			culture::discover_inventions(ws2);
-			break;
-		case 16:
-			ai::take_ai_decisions(ws1);
-			ai::take_ai_decisions(ws2);
-			break;
-		case 17:
-			ai::build_ships(ws1);
-			ai::build_ships(ws2);
-			compare_game_states(ws1, ws2);
-			ai::update_land_constructions(ws1);
-			ai::update_land_constructions(ws2);
-			break;
-		case 18:
-			ai::update_ai_econ_construction(ws1);
-			ai::update_ai_econ_construction(ws2);
-			break;
-		case 19:
-			ai::update_budget(ws1);
-			ai::update_budget(ws2);
-		case 20:
-			nations::update_flashpoint_tags(ws1);		
-			nations::monthly_flashpoint_update(ws1);
-			nations::update_flashpoint_tags(ws2);
-			nations::monthly_flashpoint_update(ws2);
-			compare_game_states(ws1, ws2);
-			ai::make_defense(ws1);
-			ai::make_defense(ws2);
-			break;
-		case 21:
-			ai::update_ai_colony_starting(ws1);
-			ai::update_ai_colony_starting(ws2);
-			break;
-		case 22:
-			ai::take_reforms(ws1);
-			ai::take_reforms(ws2);
-			break;
-		case 23:
-			ai::civilize(ws1);
-			ai::civilize(ws2);
-			compare_game_states(ws1, ws2);
-			ai::make_war_decs(ws1);
-			ai::make_war_decs(ws2);
-			break;
-		case 24:
-			rebel::execute_rebel_victories(ws1);
-			rebel::execute_rebel_victories(ws2);
-			compare_game_states(ws1, ws2);
-			ai::make_attacks(ws1);
-			ai::make_attacks(ws2);
-			compare_game_states(ws1, ws2);
-			rebel::update_armies(ws1);
-			rebel::update_armies(ws2);
-			compare_game_states(ws1, ws2);
-			rebel::rebel_hunting_check(ws1);
-			rebel::rebel_hunting_check(ws2);
-			break;
-		case 25:
-			rebel::execute_province_defections(ws1);
-			rebel::execute_province_defections(ws2);
-			break;
-		case 26:
-			ai::make_peace_offers(ws1);
-			ai::make_peace_offers(ws2);
-			break;
-		case 27:
-			ai::update_crisis_leaders(ws1);
-			ai::update_crisis_leaders(ws2);
-			break;
-		case 28:
-			rebel::rebel_risings_check(ws1);
-			rebel::rebel_risings_check(ws2);
-			break;
-		case 29:
-			ai::update_war_intervention(ws1);
-			ai::update_war_intervention(ws2);
-			break;
-		case 30:
-			ai::update_ships(ws1);
-			ai::update_ships(ws2);
-			compare_game_states(ws1, ws2);
-			rebel::update_armies(ws1);
-			rebel::update_armies(ws2);
-			compare_game_states(ws1, ws2);
-			rebel::rebel_hunting_check(ws1);
-			rebel::rebel_hunting_check(ws2);
-			break;
-		case 31:
-			ai::update_cb_fabrication(ws1);
-			ai::update_cb_fabrication(ws2);
-			break;
-		default:
-			break;
-		}
-		compare_game_states(ws1, ws2);
-	}
-
-	military::apply_regiment_damage(ws1);
-	military::apply_regiment_damage(ws2);
-	compare_game_states(ws1, ws2);
-
-	//if(ymd_date.day == 1) {
-	//	if(ymd_date.month == 1) {
-			// yearly update : redo the upper house
-			for(auto n : ws1.world.in_nation) {
-				politics::recalculate_upper_house(ws1, n);
-			}
-			for(auto n : ws2.world.in_nation) {
-				politics::recalculate_upper_house(ws2, n);
-			}
-			compare_game_states(ws1, ws2);
-
-			ai::update_influence_priorities(ws1);
-			ai::update_influence_priorities(ws2);
-			compare_game_states(ws1, ws2);
-	//	}
-	//	if(ymd_date.month == 6) {
-			ai::update_influence_priorities(ws1);
-			ai::update_influence_priorities(ws2);
-			compare_game_states(ws1, ws2);
-	//	}
-		//if(ymd_date.month == 2) {
-			ai::upgrade_colonies(ws1);
-			ai::upgrade_colonies(ws2);
-			compare_game_states(ws1, ws2);
-		//}
-	//}
-
-	ai::general_ai_unit_tick(ws1);
-	ai::general_ai_unit_tick(ws2);
-	ai::update_ai_campaign_strategy(ws1);
-	ai::update_ai_campaign_strategy(ws2);
-	compare_game_states(ws1, ws2);
-
-	ai::daily_cleanup(ws1);
-	ai::daily_cleanup(ws2);
-	compare_game_states(ws1, ws2);
-}
-// supposed to be a as-close-as-possible clone of the real deal, with compare_game_state calls inbetween
-void checked_single_tick_advanced(sys::state& state1, sys::state& state2) {
-	// do update logic
-
-	state1.current_date += 1;
-	state2.current_date += 1;
-
-	auto ymd_date = state1.current_date.to_ymd(state1.start_date);
-
-	diplomatic_message::update_pending(state1);
-	diplomatic_message::update_pending(state2);
-
-	auto month_start = sys::year_month_day{ ymd_date.year, ymd_date.month, uint16_t(1) };
-	auto next_month_start = ymd_date.month != 12 ? sys::year_month_day{ ymd_date.year, uint16_t(ymd_date.month + 1), uint16_t(1) } : sys::year_month_day{ ymd_date.year + 1, uint16_t(1), uint16_t(1) };
-	auto const days_in_month = uint32_t(sys::days_difference(month_start, next_month_start));
-
-	compare_game_states(state1, state2);
-
-	// pop update:
-	static demographics::ideology_buffer idbuf1(state1);
-	static demographics::issues_buffer isbuf1(state1);
-	static demographics::promotion_buffer pbuf1;
-	static demographics::assimilation_buffer abuf1;
-	static demographics::migration_buffer mbuf1;
-	static demographics::migration_buffer cmbuf1;
-	static demographics::migration_buffer imbuf1;
-
-
-	static demographics::ideology_buffer idbuf2(state2);
-	static demographics::issues_buffer isbuf2(state2);
-	static demographics::promotion_buffer pbuf2;
-	static demographics::assimilation_buffer abuf2;
-	static demographics::migration_buffer mbuf2;
-	static demographics::migration_buffer cmbuf2;
-	static demographics::migration_buffer imbuf2;
-
-	// calculate complex changes in parallel where we can, but don't actually apply the results
-	// instead, the changes are saved to be applied only after all triggers have been evaluated
-
-	concurrency::parallel_for(0, 7, [&](int32_t index) {
-		switch(index) {
-		case 0:
-		{
-			auto o = uint32_t(ymd_date.day);
-			if(o >= days_in_month)
-				o -= days_in_month;
-			demographics::update_ideologies(state1, o, days_in_month, idbuf1);
-			demographics::update_ideologies(state2, o, days_in_month, idbuf2);
-			break;
-		}
-		case 1:
-		{
-			auto o = uint32_t(ymd_date.day + 1);
-			if(o >= days_in_month)
-				o -= days_in_month;
-			demographics::update_issues(state1, o, days_in_month, isbuf1);
-			demographics::update_issues(state2, o, days_in_month, isbuf2);
-			break;
-		}
-		case 2:
-		{
-			auto o = uint32_t(ymd_date.day + 6);
-			if(o >= days_in_month)
-				o -= days_in_month;
-			demographics::update_type_changes(state1, o, days_in_month, pbuf1);
-			demographics::update_type_changes(state2, o, days_in_month, pbuf2);
-			break;
-		}
-		case 3:
-		{
-			auto o = uint32_t(ymd_date.day + 7);
-			if(o >= days_in_month)
-				o -= days_in_month;
-			demographics::update_assimilation(state1, o, days_in_month, abuf1);
-			demographics::update_assimilation(state2, o, days_in_month, abuf2);
-			break;
-		}
-		case 4:
-		{
-			auto o = uint32_t(ymd_date.day + 8);
-			if(o >= days_in_month)
-				o -= days_in_month;
-			demographics::update_internal_migration(state1, o, days_in_month, mbuf1);
-			demographics::update_internal_migration(state2, o, days_in_month, mbuf2);
-			break;
-		}
-		case 5:
-		{
-			auto o = uint32_t(ymd_date.day + 9);
-			if(o >= days_in_month)
-				o -= days_in_month;
-			demographics::update_colonial_migration(state1, o, days_in_month, cmbuf1);
-			demographics::update_colonial_migration(state2, o, days_in_month, cmbuf2);
-			break;
-		}
-		case 6:
-		{
-			auto o = uint32_t(ymd_date.day + 10);
-			if(o >= days_in_month)
-				o -= days_in_month;
-			demographics::update_immigration(state1, o, days_in_month, imbuf1);
-			demographics::update_immigration(state2, o, days_in_month, imbuf2);
-			break;
-		}
-		default:
-			break;
-		}
-	});
-
-	// apply in parallel where we can
-	concurrency::parallel_for(0, 8, [&](int32_t index) {
-		switch(index) {
-		case 0:
-		{
-			auto o = uint32_t(ymd_date.day + 0);
-			if(o >= days_in_month)
-				o -= days_in_month;
-			demographics::apply_ideologies(state1, o, days_in_month, idbuf1);
-			demographics::apply_ideologies(state2, o, days_in_month, idbuf2);
-			break;
-		}
-		case 1:
-		{
-			auto o = uint32_t(ymd_date.day + 1);
-			if(o >= days_in_month)
-				o -= days_in_month;
-			demographics::apply_issues(state1, o, days_in_month, isbuf1);
-			demographics::apply_issues(state2, o, days_in_month, isbuf2);
-			break;
-		}
-		case 2:
-		{
-			auto o = uint32_t(ymd_date.day + 2);
-			if(o >= days_in_month)
-				o -= days_in_month;
-			demographics::update_militancy(state1, o, days_in_month);
-			demographics::update_militancy(state2, o, days_in_month);
-			break;
-		}
-		case 3:
-		{
-			auto o = uint32_t(ymd_date.day + 3);
-			if(o >= days_in_month)
-				o -= days_in_month;
-			demographics::update_consciousness(state1, o, days_in_month);
-			demographics::update_consciousness(state2, o, days_in_month);
-			break;
-		}
-		case 4:
-		{
-			break;
-		}
-		case 5:
-		{
-			auto o = uint32_t(ymd_date.day + 5);
-			if(o >= days_in_month)
-				o -= days_in_month;
-			demographics::update_growth(state1, o, days_in_month);
-			demographics::update_growth(state2, o, days_in_month);
-			break;
-		}
-		case 6:
-			province::ve_for_each_land_province(state1,
-					[&](auto ids) { state1.world.province_set_daily_net_migration(ids, ve::fp_vector{}); });
-			province::ve_for_each_land_province(state2,
-					[&](auto ids) { state2.world.province_set_daily_net_migration(ids, ve::fp_vector{}); });
-			break;
-		case 7:
-			province::ve_for_each_land_province(state1,
-					[&](auto ids) { state1.world.province_set_daily_net_immigration(ids, ve::fp_vector{}); });
-			province::ve_for_each_land_province(state2,
-					[&](auto ids) { state2.world.province_set_daily_net_immigration(ids, ve::fp_vector{}); });
-			break;
-		default:
-			break;
-		}
-	});
-
-	compare_game_states(state1, state2);
-
-
-
-
-
-	// because they may add pops, these changes must be applied sequentially
-	{
-		auto o = uint32_t(ymd_date.day + 6);
-		if(o >= days_in_month)
-			o -= days_in_month;
-		demographics::apply_type_changes(state1, o, days_in_month, pbuf1);
-		demographics::apply_type_changes(state2, o, days_in_month, pbuf2);
-	}
-	{
-		auto o = uint32_t(ymd_date.day + 7);
-		if(o >= days_in_month)
-			o -= days_in_month;
-		demographics::apply_assimilation(state1, o, days_in_month, abuf1);
-		demographics::apply_assimilation(state2, o, days_in_month, abuf2);
-	}
-	{
-		auto o = uint32_t(ymd_date.day + 8);
-		if(o >= days_in_month)
-			o -= days_in_month;
-		demographics::apply_internal_migration(state1, o, days_in_month, mbuf1);
-		demographics::apply_internal_migration(state2, o, days_in_month, mbuf2);
-	}
-	{
-		auto o = uint32_t(ymd_date.day + 9);
-		if(o >= days_in_month)
-			o -= days_in_month;
-		demographics::apply_colonial_migration(state1, o, days_in_month, cmbuf1);
-		demographics::apply_colonial_migration(state2, o, days_in_month, cmbuf2);
-	}
-	{
-		auto o = uint32_t(ymd_date.day + 10);
-		if(o >= days_in_month)
-			o -= days_in_month;
-		demographics::apply_immigration(state1, o, days_in_month, imbuf1);
-		demographics::apply_immigration(state2, o, days_in_month, imbuf2);
-	}
-
-	demographics::remove_size_zero_pops(state1);
-	demographics::remove_size_zero_pops(state2);
-	compare_game_states(state1, state2);
-
-	// basic repopulation of demographics derived values
-
-	int64_t pc_difference1 = 0;
-	int64_t pc_difference2 = 0;
-
-	if(state1.network_mode != sys::network_mode_type::single_player)
-		demographics::regenerate_from_pop_data_daily(state1);
-	if(state2.network_mode != sys::network_mode_type::single_player)
-		demographics::regenerate_from_pop_data_daily(state2);
-	compare_game_states(state1, state2);
-
-	//
-	// ALTERNATE PAR DEMO START POINT A
-	//
-
-	concurrency::parallel_invoke([&]() {
-		// values updates pass 1 (mostly trivial things, can be done in parallel)
-		concurrency::parallel_for(0, 15, [&](int32_t index) {
-			switch(index) {
-			case 0:
-				ai::refresh_home_ports(state1);
-				ai::refresh_home_ports(state2);
-				break;
-			case 1:
-				// Instant research cheat
-				//state 1
-				for(auto n : state1.cheat_data.instant_research_nations) {
-					auto tech = state1.world.nation_get_current_research(n);
-					if(tech.is_valid()) {
-						float points = culture::effective_technology_rp_cost(state1, state1.current_date.to_ymd(state1.start_date).year, n, tech);
-						state1.world.nation_set_research_points(n, points);
-					}
-				}
-				nations::update_research_points(state1);
-				// state 2
-				for(auto n : state2.cheat_data.instant_research_nations) {
-					auto tech = state2.world.nation_get_current_research(n);
-					if(tech.is_valid()) {
-						float points = culture::effective_technology_rp_cost(state2, state2.current_date.to_ymd(state2.start_date).year, n, tech);
-						state2.world.nation_set_research_points(n, points);
-					}
-				}
-				nations::update_research_points(state2);
-
-				break;
-			case 2:
-				military::regenerate_land_unit_average(state1);
-				military::regenerate_land_unit_average(state2);
-				break;
-			case 3:
-				military::regenerate_ship_scores(state1);
-				military::regenerate_ship_scores(state2);
-				break;
-			case 4:
-				military::update_naval_supply_points(state1);
-				military::update_naval_supply_points(state2);
-				break;
-			case 5:
-				military::update_all_recruitable_regiments(state1);
-				military::update_all_recruitable_regiments(state2);
-				break;
-			case 6:
-				military::regenerate_total_regiment_counts(state1);
-				military::regenerate_total_regiment_counts(state2);
-				break;
-			case 7:
-				economy::update_employment(state1);
-				economy::update_employment(state2);
-				break;
-			case 8:
-				nations::update_national_administrative_efficiency(state1);
-				nations::update_administrative_efficiency(state1);
-
-				nations::update_national_administrative_efficiency(state2);
-				nations::update_administrative_efficiency(state2);
-				rebel::daily_update_rebel_organization(state1);
-				rebel::daily_update_rebel_organization(state2);
-				break;
-			case 9:
-				military::daily_leaders_update(state1);
-				military::daily_leaders_update(state2);
-				break;
-			case 10:
-				politics::daily_party_loyalty_update(state1);
-				politics::daily_party_loyalty_update(state2);
-				break;
-			case 11:
-				nations::daily_update_flashpoint_tension(state1);
-				nations::daily_update_flashpoint_tension(state2);
-				break;
-			case 12:
-				military::update_ticking_war_score(state1);
-				military::update_ticking_war_score(state2);
-				break;
-			case 13:
-				military::increase_dig_in(state1);
-				military::increase_dig_in(state2);
-				break;
-			case 14:
-				military::update_blockade_status(state1);
-				military::update_blockade_status(state2);
-				break;
-			}
-		});
-		compare_game_states(state1, state2);
-
-		economy::daily_update(state1, false, 1.f);
-		economy::daily_update(state2, false, 1.f);
-		compare_game_states(state1, state2);
-
-		//
-		// ALTERNATE PAR DEMO START POINT B
-		//
-
-		military::recover_org(state1);
-		military::recover_org(state2);
-		military::update_siege_progress(state1);
-		military::update_siege_progress(state2);
-		military::update_movement(state1);
-		military::update_movement(state2);
-		military::update_naval_battles(state1);
-		military::update_naval_battles(state2);
-		military::update_land_battles(state1);
-		military::update_land_battles(state2);
-		compare_game_states(state1, state2);
-
-		military::advance_mobilizations(state1);
-		military::advance_mobilizations(state2);
-
-		province::update_colonization(state1);
-		province::update_colonization(state2);
-		military::update_cbs(state1); // may add/remove cbs to a nation
-		military::update_cbs(state2);
-
-		event::update_events(state1);
-		event::update_events(state2);
-
-		culture::update_research(state1, uint32_t(ymd_date.year));
-		culture::update_research(state2, uint32_t(ymd_date.year));
-		compare_game_states(state1, state2);
-
-		nations::update_industrial_scores(state1);
-		nations::update_industrial_scores(state2);
-		nations::update_military_scores(state1); // depends on ship score, land unit average
-		nations::update_military_scores(state2);
-		nations::update_rankings(state1);				// depends on industrial score, military scores
-		nations::update_rankings(state2);
-		nations::update_great_powers(state1);		// depends on rankings
-		nations::update_great_powers(state2);
-		nations::update_influence(state1);				// depends on rankings, great powers
-		nations::update_influence(state2);
-		compare_game_states(state1, state2);
-
-
-		nations::update_crisis(state1);
-		nations::update_crisis(state2);
-		politics::update_elections(state1);
-		politics::update_elections(state2);
-
-		if(state1.current_date.value % 4 == 0) {
-			ai::update_ai_colonial_investment(state1);
-		}
-		if(state2.current_date.value % 4 == 0) {
-			ai::update_ai_colonial_investment(state2);
-		}
-		if(state1.defines.alice_eval_ai_mil_everyday != 0.0f) {
-			ai::make_defense(state1);
-			ai::make_attacks(state1);
-			ai::update_ships(state1);
-		}
-		if(state2.defines.alice_eval_ai_mil_everyday != 0.0f) {
-			ai::make_defense(state2);
-			ai::make_attacks(state2);
-			ai::update_ships(state2);
-		}
-		ai::take_ai_decisions(state1);
-		ai::take_ai_decisions(state2);
-		compare_game_states(state1, state2);
-
-		// Once per month updates, spread out over the month
-		switch(ymd_date.day) {
-		case 1:
-			nations::update_monthly_points(state1);
-			nations::update_monthly_points(state2);
-			economy::prune_factories(state1);
-			economy::prune_factories(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 2:
-			province::update_blockaded_cache(state1);
-			province::update_blockaded_cache(state2);
-			sys::update_modifier_effects(state1);
-			sys::update_modifier_effects(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 3:
-			military::monthly_leaders_update(state1);
-			military::monthly_leaders_update(state2);
-			ai::add_wargoals(state1);
-			ai::add_wargoals(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 4:
-			military::reinforce_regiments(state1);
-			military::reinforce_regiments(state2);
-			if(!bool(state1.defines.alice_eval_ai_mil_everyday)) {
-				ai::make_defense(state1);
-			}
-			if(!bool(state2.defines.alice_eval_ai_mil_everyday)) {
-				ai::make_defense(state2);
-			}
-			compare_game_states(state1, state2);
-			break;
-		case 5:
-			rebel::update_movements(state1);
-			rebel::update_movements(state2);
-			rebel::update_factions(state1);
-			rebel::update_factions(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 6:
-			ai::form_alliances(state1);
-			ai::form_alliances(state2);
-			if(!bool(state1.defines.alice_eval_ai_mil_everyday)) {
-				ai::make_attacks(state1);
-			}
-			if(!bool(state2.defines.alice_eval_ai_mil_everyday)) {
-				ai::make_attacks(state2);
-			}
-			compare_game_states(state1, state2);
-			break;
-		case 7:
-			ai::update_ai_general_status(state1);
-			ai::update_ai_general_status(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 8:
-			military::apply_attrition(state1);
-			military::apply_attrition(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 9:
-			military::repair_ships(state1);
-			military::repair_ships(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 10:
-			province::update_crimes(state1);
-			province::update_crimes(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 11:
-			province::update_nationalism(state1);
-			province::update_nationalism(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 12:
-			ai::update_ai_research(state1);
-			ai::update_ai_research(state2);
-			rebel::update_armies(state1);
-			rebel::update_armies(state2);
-			rebel::rebel_hunting_check(state1);
-			rebel::rebel_hunting_check(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 13:
-			ai::perform_influence_actions(state1);
-			ai::perform_influence_actions(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 14:
-			ai::update_focuses(state1);
-			ai::update_focuses(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 15:
-			culture::discover_inventions(state1);
-			culture::discover_inventions(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 16:
-			ai::build_ships(state1);
-			ai::build_ships(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 17:
-			ai::update_land_constructions(state1);
-			ai::update_land_constructions(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 18:
-			ai::update_ai_econ_construction(state1);
-			ai::update_ai_econ_construction(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 19:
-			ai::update_budget(state1);
-			ai::update_budget(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 20:
-			nations::update_flashpoint_tags(state1);
-			nations::monthly_flashpoint_update(state1);
-			nations::update_flashpoint_tags(state2);
-			nations::monthly_flashpoint_update(state2);
-			if(!bool(state1.defines.alice_eval_ai_mil_everyday)) {
-				ai::make_defense(state1);
-			}
-			if(!bool(state2.defines.alice_eval_ai_mil_everyday)) {
-				ai::make_defense(state2);
-			}
-			compare_game_states(state1, state2);
-			break;
-		case 21:
-			ai::update_ai_colony_starting(state1);
-			ai::update_ai_colony_starting(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 22:
-			ai::take_reforms(state1);
-			ai::take_reforms(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 23:
-			ai::civilize(state1);
-			ai::civilize(state2);
-			ai::make_war_decs(state1);
-			ai::make_war_decs(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 24:
-			rebel::execute_rebel_victories(state1);
-			rebel::execute_rebel_victories(state2);
-			if(!bool(state1.defines.alice_eval_ai_mil_everyday)) {
-				ai::make_attacks(state1);
-			}
-			if(!bool(state2.defines.alice_eval_ai_mil_everyday)) {
-				ai::make_attacks(state2);
-			}
-			rebel::update_armies(state1);
-			rebel::update_armies(state2);
-			rebel::rebel_hunting_check(state1);
-			rebel::rebel_hunting_check(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 25:
-			rebel::execute_province_defections(state1);
-			rebel::execute_province_defections(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 26:
-			ai::make_peace_offers(state1);
-			ai::make_peace_offers(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 27:
-			ai::update_crisis_leaders(state1);
-			ai::update_crisis_leaders(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 28:
-			rebel::rebel_risings_check(state1);
-			rebel::rebel_risings_check(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 29:
-			ai::update_war_intervention(state1);
-			ai::update_war_intervention(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 30:
-			if(!bool(state1.defines.alice_eval_ai_mil_everyday)) {
-				ai::update_ships(state1);
-			}
-			if(!bool(state2.defines.alice_eval_ai_mil_everyday)) {
-				ai::update_ships(state2);
-			}
-			rebel::update_armies(state1);
-			rebel::update_armies(state2);
-			rebel::rebel_hunting_check(state1);
-			rebel::rebel_hunting_check(state2);
-			compare_game_states(state1, state2);
-			break;
-		case 31:
-			ai::update_cb_fabrication(state1);
-			ai::update_cb_fabrication(state2);
-			ai::update_ai_ruling_party(state1);
-			ai::update_ai_ruling_party(state2);
-			compare_game_states(state1, state2);
-			break;
-		default:
-			break;
-		}
-
-		military::apply_regiment_damage(state1);
-		military::apply_regiment_damage(state2);
-		compare_game_states(state1, state2);
-
-		if(ymd_date.day == 1) {
-			if(ymd_date.month == 1) {
-				state1.sprawl_update_requested.store(true);
-				state2.sprawl_update_requested.store(true);
-
-				// yearly update : redo the upper house
-				for(auto n : state1.world.in_nation) {
-					if(n.get_owned_province_count() != 0)
-						politics::recalculate_upper_house(state1, n);
-				}
-				for(auto n : state2.world.in_nation) {
-					if(n.get_owned_province_count() != 0)
-						politics::recalculate_upper_house(state2, n);
-				}
-
-				ai::update_influence_priorities(state1);
-				ai::update_influence_priorities(state2);
-				nations::generate_sea_trade_routes(state1);
-				nations::generate_sea_trade_routes(state2);
-				nations::recalculate_markets_distance(state1);
-				nations::recalculate_markets_distance(state2);
-				compare_game_states(state1, state2);
-			}
-			if(ymd_date.month == 2) {
-				ai::upgrade_colonies(state1);
-				ai::upgrade_colonies(state2);
-				compare_game_states(state1, state2);
-			}
-			if(ymd_date.month == 3) {
-				if(!state1.national_definitions.on_quarterly_pulse.empty()) {
-					for(auto n : state1.world.in_nation) {
-						if(n.get_owned_province_count() > 0) {
-							event::fire_fixed_event(state1, state1.national_definitions.on_quarterly_pulse, trigger::to_generic(n.id), event::slot_type::nation, n.id, -1, event::slot_type::none);
-						}
-					}
-				}
-				if(!state2.national_definitions.on_quarterly_pulse.empty()) {
-					for(auto n : state2.world.in_nation) {
-						if(n.get_owned_province_count() > 0) {
-							event::fire_fixed_event(state2, state2.national_definitions.on_quarterly_pulse, trigger::to_generic(n.id), event::slot_type::nation, n.id, -1, event::slot_type::none);
-						}
-					}
-				}
-				compare_game_states(state1, state2);
-			}
-
-			if(ymd_date.month == 4 && ymd_date.year % 2 == 0) { // the purge
-				demographics::remove_small_pops(state1);
-				demographics::remove_small_pops(state2);
-				compare_game_states(state1, state2);
-			}
-			if(ymd_date.month == 5) {
-				ai::prune_alliances(state1);
-				ai::prune_alliances(state2);
-				ai::update_factory_types_priority(state1);
-				ai::update_factory_types_priority(state2);
-				compare_game_states(state1, state2);
-			}
-			if(ymd_date.month == 6) {
-				if(!state1.national_definitions.on_quarterly_pulse.empty()) {
-					for(auto n : state1.world.in_nation) {
-						if(n.get_owned_province_count() > 0) {
-							event::fire_fixed_event(state1, state1.national_definitions.on_quarterly_pulse, trigger::to_generic(n.id), event::slot_type::nation, n.id, -1, event::slot_type::none);
-						}
-					}
-				}
-				if(!state2.national_definitions.on_quarterly_pulse.empty()) {
-					for(auto n : state2.world.in_nation) {
-						if(n.get_owned_province_count() > 0) {
-							event::fire_fixed_event(state2, state2.national_definitions.on_quarterly_pulse, trigger::to_generic(n.id), event::slot_type::nation, n.id, -1, event::slot_type::none);
-						}
-					}
-				}
-				compare_game_states(state1, state2);
-
-			}
-
-			if(ymd_date.month == 7) {
-				ai::update_influence_priorities(state1);
-				ai::update_influence_priorities(state2);
-				nations::recalculate_markets_distance(state1);
-				nations::recalculate_markets_distance(state2);
-				compare_game_states(state1, state2);
-			}
-			if(ymd_date.month == 9) {
-				if(!state1.national_definitions.on_quarterly_pulse.empty()) {
-					for(auto n : state1.world.in_nation) {
-						if(n.get_owned_province_count() > 0) {
-							event::fire_fixed_event(state1, state1.national_definitions.on_quarterly_pulse, trigger::to_generic(n.id), event::slot_type::nation, n.id, -1, event::slot_type::none);
-						}
-					}
-				}
-				if(!state2.national_definitions.on_quarterly_pulse.empty()) {
-					for(auto n : state2.world.in_nation) {
-						if(n.get_owned_province_count() > 0) {
-							event::fire_fixed_event(state2, state2.national_definitions.on_quarterly_pulse, trigger::to_generic(n.id), event::slot_type::nation, n.id, -1, event::slot_type::none);
-						}
-					}
-				}
-				compare_game_states(state1, state2);
-			}
-			if(ymd_date.month == 10) {
-				if(!state1.national_definitions.on_yearly_pulse.empty()) {
-					for(auto n : state1.world.in_nation) {
-						if(n.get_owned_province_count() > 0) {
-							event::fire_fixed_event(state1, state1.national_definitions.on_yearly_pulse, trigger::to_generic(n.id), event::slot_type::nation, n.id, -1, event::slot_type::none);
-						}
-					}
-				}
-				if(!state2.national_definitions.on_yearly_pulse.empty()) {
-					for(auto n : state2.world.in_nation) {
-						if(n.get_owned_province_count() > 0) {
-							event::fire_fixed_event(state2, state2.national_definitions.on_yearly_pulse, trigger::to_generic(n.id), event::slot_type::nation, n.id, -1, event::slot_type::none);
-						}
-					}
-				}
-				compare_game_states(state1, state2);
-			}
-			if(ymd_date.month == 11) {
-				ai::prune_alliances(state1);
-				ai::prune_alliances(state2);
-				compare_game_states(state1, state2);
-			}
-			if(ymd_date.month == 12) {
-				if(!state1.national_definitions.on_quarterly_pulse.empty()) {
-					for(auto n : state1.world.in_nation) {
-						if(n.get_owned_province_count() > 0) {
-							event::fire_fixed_event(state1, state1.national_definitions.on_quarterly_pulse, trigger::to_generic(n.id), event::slot_type::nation, n.id, -1, event::slot_type::none);
-						}
-					}
-				}
-				if(!state2.national_definitions.on_quarterly_pulse.empty()) {
-					for(auto n : state2.world.in_nation) {
-						if(n.get_owned_province_count() > 0) {
-							event::fire_fixed_event(state2, state2.national_definitions.on_quarterly_pulse, trigger::to_generic(n.id), event::slot_type::nation, n.id, -1, event::slot_type::none);
-						}
-					}
-				}
-				compare_game_states(state1, state2);
-
-			}
-		}
-		compare_game_states(state1, state2);
-
-		ai::general_ai_unit_tick(state1);
-		ai::general_ai_unit_tick(state2);
-		ai::update_ai_campaign_strategy(state1);
-		ai::update_ai_campaign_strategy(state2);
-
-		compare_game_states(state1, state2);
-		military::run_gc(state1);
-		military::run_gc(state2);
-		compare_game_states(state1, state2);
-
-		nations::run_gc(state1);
-		nations::run_gc(state2);
-		military::update_blackflag_status(state1);
-		military::update_blackflag_status(state2);
-		ai::daily_cleanup(state1);
-		ai::daily_cleanup(state2);
-		compare_game_states(state1, state2);
-
-		province::update_connected_regions(state1);
-		province::update_connected_regions(state2);
-		province::update_cached_values(state1);
-		province::update_cached_values(state2);
-		nations::update_cached_values(state1);
-		nations::update_cached_values(state2);
-		compare_game_states(state1, state2);
-
-	},
-	[&]() {
-		if(state1.network_mode == sys::network_mode_type::single_player)
-			demographics::alt_regenerate_from_pop_data_daily(state1);
-		if(state2.network_mode == sys::network_mode_type::single_player)
-			demographics::alt_regenerate_from_pop_data_daily(state2);
-
-	}
-	);
-	compare_game_states(state1, state2);
-
-	if(state1.network_mode == sys::network_mode_type::single_player) {
-		state1.world.nation_swap_demographics_demographics_alt();
-		state1.world.state_instance_swap_demographics_demographics_alt();
-		state1.world.province_swap_demographics_demographics_alt();
-
-		demographics::alt_demographics_update_extras(state1);
-	}
-	if(state2.network_mode == sys::network_mode_type::single_player) {
-		state2.world.nation_swap_demographics_demographics_alt();
-		state2.world.state_instance_swap_demographics_demographics_alt();
-		state2.world.province_swap_demographics_demographics_alt();
-
-		demographics::alt_demographics_update_extras(state2);
-	}
-	compare_game_states(state1, state2);
-
-	/*
-	 * END OF DAY: update cached data
-	 */
-
-	state1.player_data_cache.treasury_record[state1.current_date.value % 32] = nations::get_treasury(state1, state1.local_player_nation);
-	state2.player_data_cache.treasury_record[state2.current_date.value % 32] = nations::get_treasury(state2, state2.local_player_nation);
-
-
-	state1.player_data_cache.population_record[state1.current_date.value % 32] = state1.world.nation_get_demographics(state1.local_player_nation, demographics::total);
-	state2.player_data_cache.population_record[state2.current_date.value % 32] = state2.world.nation_get_demographics(state2.local_player_nation, demographics::total);
-
-	if((state1.current_date.value % 16) == 0) {
-		auto index = economy::most_recent_price_record_index(state1);
-		for(auto c : state1.world.in_commodity) {
-			c.set_price_record(index, economy::median_price(state1, c));
-		}
-		auto index2 = economy::most_recent_price_record_index(state2);
-		for(auto c : state2.world.in_commodity) {
-			c.set_price_record(index2, economy::median_price(state2, c));
-		}
-	}
-	compare_game_states(state1, state2);
-
-	if(((ymd_date.month % 3) == 0) && (ymd_date.day == 1)) {
-		auto index = economy::most_recent_gdp_record_index(state1);
-		for(auto n : state1.world.in_nation) {
-			n.set_gdp_record(index, economy::gdp(state1, n));
-		}
-		auto index2 = economy::most_recent_gdp_record_index(state2);
-		for(auto n : state2.world.in_nation) {
-			n.set_gdp_record(index2, economy::gdp(state2, n));
-		}
-	}
-
-	state1.ui_date = state1.current_date;
-	state2.ui_date = state2.current_date;
-
-	state1.game_state_updated.store(true, std::memory_order::release);
-	state2.game_state_updated.store(true, std::memory_order::release);
-	compare_game_states(state1, state2);
-
-	switch(state1.user_settings.autosaves) {
-	case sys::autosave_frequency::none:
-		break;
-	case sys::autosave_frequency::daily:
-		write_save_file(state1, sys::save_type::autosave);
-		break;
-	case sys::autosave_frequency::monthly:
-		if(ymd_date.day == 1)
-			write_save_file(state1, sys::save_type::autosave);
-		break;
-	case sys::autosave_frequency::yearly:
-		if(ymd_date.month == 1 && ymd_date.day == 1)
-			write_save_file(state1, sys::save_type::autosave);
-		break;
-	default:
-		break;
-	}
-	switch(state2.user_settings.autosaves) {
-	case sys::autosave_frequency::none:
-		break;
-	case sys::autosave_frequency::daily:
-		write_save_file(state2, sys::save_type::autosave);
-		break;
-	case sys::autosave_frequency::monthly:
-		if(ymd_date.day == 1)
-			write_save_file(state2, sys::save_type::autosave);
-		break;
-	case sys::autosave_frequency::yearly:
-		if(ymd_date.month == 1 && ymd_date.day == 1)
-			write_save_file(state2, sys::save_type::autosave);
-		break;
-	default:
-		break;
-	}
-}
-
 void write_test_save(sys::state& state) {
 	auto current_date = state.current_date.to_string(state.start_date);
 	sys::write_save_file(state, sys::save_type::normal, current_date + "_TEST_SAVE", current_date + "_TEST_SAVE");
@@ -1581,59 +292,26 @@ void test_load_save(sys::state& state, uint8_t* ptr_in, uint32_t length) {
 	state.fill_unsaved_data();
 }
 
+constexpr uint32_t test_game_seed = 808080;
 
 TEST_CASE("sim_none", "[determinism]") {
 	// Test that the game states are equal AFTER loading
 	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file();
 	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file();
-	game_state_2->game_seed = game_state_1->game_seed = 808080;
+	game_state_2->game_seed = game_state_1->game_seed = test_game_seed;
 	compare_game_states(*game_state_1, *game_state_2);
 }
 
-TEST_CASE("sim_day", "[determinism]") {
-	// Test that the game states are equal after loading and performing 1 tick
-	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file();
-	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file();
-	game_state_2->game_seed = game_state_1->game_seed = 808080;
-	checked_single_tick(*game_state_1, *game_state_2);
-}
 
-TEST_CASE("sim_week", "[determinism]") {
-	// Test that the game states are equal after loading and performing 7 tick
-	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file();
-	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file();
-	game_state_2->game_seed = game_state_1->game_seed = 808080;
-	for(int i = 0; i < 7; i++) {
-		checked_single_tick(*game_state_1, *game_state_2);
-	}
-}
 
-TEST_CASE("sim_month", "[determinism]") {
-	// Test that the game states are equal after loading and performing 31 tick
-	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file();
-	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file();
-	game_state_2->game_seed = game_state_1->game_seed = 808080;
-	for(int i = 0; i < 31; i++) {
-		checked_single_tick(*game_state_1, *game_state_2);
-	}
-}
 
-TEST_CASE("sim_year", "[determinism]") {
-	// Test that the game states are equal after loading and performing 1 tick
-	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file();
-	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file();
-	game_state_2->game_seed = game_state_1->game_seed = 808080;
-	for(int i = 0; i <= 400; i++) {
-		checked_single_tick(*game_state_1, *game_state_2);
-	}
-}
-
+// this test repopulates all the test saves which is used for the tests below. Each test uses a save and runs in a 10-year incremement from the start of that save-
 TEST_CASE("populate_test_saves", "[determinism]") {
-	// Test that the game states are equal after playing
+
 	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
 
 
-	game_state_1->game_seed = 808080;
+	game_state_1->game_seed = test_game_seed;
 
 	for(int i = 0; i <= 36530; i++) {
 		game_state_1->console_log(std::to_string(i));
@@ -1642,10 +320,10 @@ TEST_CASE("populate_test_saves", "[determinism]") {
 		if(current_date == sys::year_month_day{ 1846, 1, 1 }) {
 			write_test_save(*game_state_1);
 		}
-		else if(current_date == sys::year_month_day{ 1858, 1, 1 }) {
+		else if(current_date == sys::year_month_day{ 1856, 1, 1 }) {
 			write_test_save(*game_state_1);
 		}
-		else if(current_date == sys::year_month_day{ 1868, 1, 1 }) {
+		else if(current_date == sys::year_month_day{ 1866, 1, 1 }) {
 			write_test_save(*game_state_1);
 		}
 		else if(current_date == sys::year_month_day{ 1876, 1, 1 }) {
@@ -1677,7 +355,7 @@ TEST_CASE("sim_game_solo", "[determinism]") {
 	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
 
 
-	game_state_1->game_seed = 808080;
+	game_state_1->game_seed = test_game_seed;
 
 	for(int i = 0; i <= 36530; i++) {
 		game_state_1->console_log(std::to_string(i));
@@ -1688,13 +366,13 @@ TEST_CASE("sim_game_solo", "[determinism]") {
 
 //All of the following tests from first to tenth is running the entire game in 10 year intervals with a save for each to test for desync's.
 
-TEST_CASE("sim_game_first", "[determinism]") {
+TEST_CASE("sim_game_1", "[determinism][sim_game_tests]") {
 	// Test that the game states are equal after playing
 	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
 	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
 
 
-	game_state_2->game_seed = game_state_1->game_seed = 808080;
+	game_state_2->game_seed = game_state_1->game_seed = test_game_seed;
 
 	compare_game_states(*game_state_1, *game_state_2);
 	for(int i = 0; i <= 3653; i++) {
@@ -1705,7 +383,7 @@ TEST_CASE("sim_game_first", "[determinism]") {
 	}
 }
 
-TEST_CASE("sim_game_second", "[determinism]") {
+TEST_CASE("sim_game_2", "[determinism][sim_game_tests]") {
 	// Test that the game states are equal after playing
 	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
 	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
@@ -1727,7 +405,7 @@ TEST_CASE("sim_game_second", "[determinism]") {
 	}
 
 
-	game_state_2->game_seed = game_state_1->game_seed = 808080;
+	game_state_2->game_seed = game_state_1->game_seed = test_game_seed;
 
 	compare_game_states(*game_state_1, *game_state_2);
 	for(int i = 0; i <= 3653; i++) {
@@ -1738,7 +416,7 @@ TEST_CASE("sim_game_second", "[determinism]") {
 	}
 }
 
-TEST_CASE("sim_game_third", "[determinism]") {
+TEST_CASE("sim_game_3", "[determinism][sim_game_tests]") {
 	// Test that the game states are equal after playing
 	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
 	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
@@ -1760,7 +438,7 @@ TEST_CASE("sim_game_third", "[determinism]") {
 	}
 
 
-	game_state_2->game_seed = game_state_1->game_seed = 808080;
+	game_state_2->game_seed = game_state_1->game_seed = test_game_seed;
 
 	compare_game_states(*game_state_1, *game_state_2);
 	for(int i = 0; i <= 3653; i++) {
@@ -1770,7 +448,7 @@ TEST_CASE("sim_game_third", "[determinism]") {
 		compare_game_states(*game_state_1, *game_state_2);
 	}
 }
-TEST_CASE("sim_game_fourth", "[determinism]") {
+TEST_CASE("sim_game_4", "[determinism][sim_game_tests]") {
 	// Test that the game states are equal after playing
 	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
 	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
@@ -1792,7 +470,7 @@ TEST_CASE("sim_game_fourth", "[determinism]") {
 	}
 
 
-	game_state_2->game_seed = game_state_1->game_seed = 808080;
+	game_state_2->game_seed = game_state_1->game_seed = test_game_seed;
 
 	compare_game_states(*game_state_1, *game_state_2);
 	for(int i = 0; i <= 3653; i++) {
@@ -1802,7 +480,7 @@ TEST_CASE("sim_game_fourth", "[determinism]") {
 		compare_game_states(*game_state_1, *game_state_2);
 	}
 }
-TEST_CASE("sim_game_fifth", "[determinism]") {
+TEST_CASE("sim_game_5", "[determinism][sim_game_tests]") {
 	// Test that the game states are equal after playing
 	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
 	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
@@ -1824,7 +502,7 @@ TEST_CASE("sim_game_fifth", "[determinism]") {
 	}
 
 
-	game_state_2->game_seed = game_state_1->game_seed = 808080;
+	game_state_2->game_seed = game_state_1->game_seed = test_game_seed;
 
 	compare_game_states(*game_state_1, *game_state_2);
 	for(int i = 0; i <= 3653; i++) {
@@ -1834,7 +512,7 @@ TEST_CASE("sim_game_fifth", "[determinism]") {
 		compare_game_states(*game_state_1, *game_state_2);
 	}
 }
-TEST_CASE("sim_game_sixth", "[determinism]") {
+TEST_CASE("sim_game_6", "[determinism][sim_game_tests]") {
 	// Test that the game states are equal after playing
 	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
 	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
@@ -1856,7 +534,7 @@ TEST_CASE("sim_game_sixth", "[determinism]") {
 	}
 
 
-	game_state_2->game_seed = game_state_1->game_seed = 808080;
+	game_state_2->game_seed = game_state_1->game_seed = test_game_seed;
 
 	compare_game_states(*game_state_1, *game_state_2);
 	for(int i = 0; i <= 3653; i++) {
@@ -1866,7 +544,7 @@ TEST_CASE("sim_game_sixth", "[determinism]") {
 		compare_game_states(*game_state_1, *game_state_2);
 	}
 }
-TEST_CASE("sim_game_seventh", "[determinism]") {
+TEST_CASE("sim_game_7", "[determinism][sim_game_tests]") {
 	// Test that the game states are equal after playing
 	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
 	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
@@ -1888,7 +566,7 @@ TEST_CASE("sim_game_seventh", "[determinism]") {
 	}
 
 
-	game_state_2->game_seed = game_state_1->game_seed = 808080;
+	game_state_2->game_seed = game_state_1->game_seed = test_game_seed;
 
 	compare_game_states(*game_state_1, *game_state_2);
 	for(int i = 0; i <= 3653; i++) {
@@ -1898,7 +576,7 @@ TEST_CASE("sim_game_seventh", "[determinism]") {
 		compare_game_states(*game_state_1, *game_state_2);
 	}
 }
-TEST_CASE("sim_game_eigth", "[determinism]") {
+TEST_CASE("sim_game_8", "[determinism][sim_game_tests]") {
 	// Test that the game states are equal after playing
 	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
 	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
@@ -1920,7 +598,7 @@ TEST_CASE("sim_game_eigth", "[determinism]") {
 	}
 
 
-	game_state_2->game_seed = game_state_1->game_seed = 808080;
+	game_state_2->game_seed = game_state_1->game_seed = test_game_seed;
 
 	compare_game_states(*game_state_1, *game_state_2);
 	for(int i = 0; i <= 3653; i++) {
@@ -1930,7 +608,7 @@ TEST_CASE("sim_game_eigth", "[determinism]") {
 		compare_game_states(*game_state_1, *game_state_2);
 	}
 }
-TEST_CASE("sim_game_ninth", "[determinism]") {
+TEST_CASE("sim_game_9", "[determinism][sim_game_tests]") {
 	// Test that the game states are equal after playing
 	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
 	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
@@ -1952,7 +630,7 @@ TEST_CASE("sim_game_ninth", "[determinism]") {
 	}
 
 
-	game_state_2->game_seed = game_state_1->game_seed = 808080;
+	game_state_2->game_seed = game_state_1->game_seed = test_game_seed;
 
 	compare_game_states(*game_state_1, *game_state_2);
 	for(int i = 0; i <= 3653; i++) {
@@ -1962,7 +640,7 @@ TEST_CASE("sim_game_ninth", "[determinism]") {
 		compare_game_states(*game_state_1, *game_state_2);
 	}
 }
-TEST_CASE("sim_game_tenth", "[determinism]") {
+TEST_CASE("sim_game_10", "[determinism][sim_game_tests]") {
 	// Test that the game states are equal after playing
 	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
 	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
@@ -1984,7 +662,7 @@ TEST_CASE("sim_game_tenth", "[determinism]") {
 	}
 
 
-	game_state_2->game_seed = game_state_1->game_seed = 808080;
+	game_state_2->game_seed = game_state_1->game_seed = test_game_seed;
 
 	compare_game_states(*game_state_1, *game_state_2);
 	for(int i = 0; i <= 3653; i++) {
@@ -1995,35 +673,13 @@ TEST_CASE("sim_game_tenth", "[determinism]") {
 	}
 }
 
+TEST_CASE("fill_unsaved_values_determinism_1", "[determinism][fill_unsaved_tests]") {
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+
+	game_state_1->game_seed = test_game_seed;
 
 
-
-// this one uses the slower, but more accurate checked tick
-TEST_CASE("sim_game_advanced", "[determinism]") {
-	// Test that the game states are equal after playing
-	static std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
-	static std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
-
-
-	game_state_2->game_seed = game_state_1->game_seed = 808080;
-
-
-	compare_game_states(*game_state_1, *game_state_2);
-
-	for(int i = 0; i <= 400; i++) {
-		game_state_1->console_log(std::to_string(i));
-		checked_single_tick_advanced(*game_state_1, *game_state_2);
-		compare_game_states(*game_state_1, *game_state_2);
-	}
-}
-TEST_CASE("fill_unsaved_values_determinism", "[determinism]") {
-	// allocated statically untill crash fix is found
-	static std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
-
-	game_state_1->game_seed = 808080;
-
-
-	for(int i = 0; i <= 800; i++) {
+	for(int i = 0; i <= 3653; i++) {
 
 
 		game_state_1->console_log(std::to_string(i));
@@ -2040,26 +696,329 @@ TEST_CASE("fill_unsaved_values_determinism", "[determinism]") {
 	}
 }
 
-TEST_CASE("sim_game_with_saveload", "[determinism]") {
+
+TEST_CASE("fill_unsaved_values_determinism_2", "[determinism][fill_unsaved_tests]") {
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("184611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+
+
+
+	game_state_1->game_seed = test_game_seed;
+
+
+	for(int i = 0; i <= 3653; i++) {
+
+
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+
+		auto before_key1 = game_state_1->get_save_checksum();
+
+		game_state_1->fill_unsaved_data();
+
+
+		// make sure that the fill_unsaved_data does not change saved data at all
+		REQUIRE(before_key1.to_string() == game_state_1->get_save_checksum().to_string());
+
+	}
+}
+
+
+TEST_CASE("fill_unsaved_values_determinism_3", "[determinism][fill_unsaved_tests]") {
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("185611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+
+
+
+	game_state_1->game_seed = test_game_seed;
+
+
+	for(int i = 0; i <= 3653; i++) {
+
+
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+
+		auto before_key1 = game_state_1->get_save_checksum();
+
+		game_state_1->fill_unsaved_data();
+
+
+		// make sure that the fill_unsaved_data does not change saved data at all
+		REQUIRE(before_key1.to_string() == game_state_1->get_save_checksum().to_string());
+
+	}
+}
+
+TEST_CASE("fill_unsaved_values_determinism_4", "[determinism][fill_unsaved_tests]") {
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("186611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+
+
+
+	game_state_1->game_seed = test_game_seed;
+
+
+	for(int i = 0; i <= 3653; i++) {
+
+
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+
+		auto before_key1 = game_state_1->get_save_checksum();
+
+		game_state_1->fill_unsaved_data();
+
+
+		// make sure that the fill_unsaved_data does not change saved data at all
+		REQUIRE(before_key1.to_string() == game_state_1->get_save_checksum().to_string());
+
+	}
+}
+
+TEST_CASE("fill_unsaved_values_determinism_5", "[determinism][fill_unsaved_tests]") {
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("187611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+
+
+
+	game_state_1->game_seed = test_game_seed;
+
+
+	for(int i = 0; i <= 3653; i++) {
+
+
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+
+		auto before_key1 = game_state_1->get_save_checksum();
+
+		game_state_1->fill_unsaved_data();
+
+
+		// make sure that the fill_unsaved_data does not change saved data at all
+		REQUIRE(before_key1.to_string() == game_state_1->get_save_checksum().to_string());
+
+	}
+}
+
+TEST_CASE("fill_unsaved_values_determinism_6", "[determinism][fill_unsaved_tests]") {
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("188611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+
+
+
+	game_state_1->game_seed = test_game_seed;
+
+
+	for(int i = 0; i <= 3653; i++) {
+
+
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+
+		auto before_key1 = game_state_1->get_save_checksum();
+
+		game_state_1->fill_unsaved_data();
+
+
+		// make sure that the fill_unsaved_data does not change saved data at all
+		REQUIRE(before_key1.to_string() == game_state_1->get_save_checksum().to_string());
+
+	}
+}
+
+
+TEST_CASE("fill_unsaved_values_determinism_7", "[determinism][fill_unsaved_tests]") {
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("189611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+
+
+
+	game_state_1->game_seed = test_game_seed;
+
+
+	for(int i = 0; i <= 3653; i++) {
+
+
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+
+		auto before_key1 = game_state_1->get_save_checksum();
+
+		game_state_1->fill_unsaved_data();
+
+
+		// make sure that the fill_unsaved_data does not change saved data at all
+		REQUIRE(before_key1.to_string() == game_state_1->get_save_checksum().to_string());
+
+	}
+}
+
+TEST_CASE("fill_unsaved_values_determinism_8", "[determinism][fill_unsaved_tests]") {
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("190611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+
+
+
+	game_state_1->game_seed = test_game_seed;
+
+
+	for(int i = 0; i <= 3653; i++) {
+
+
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+
+		auto before_key1 = game_state_1->get_save_checksum();
+
+		game_state_1->fill_unsaved_data();
+
+
+		// make sure that the fill_unsaved_data does not change saved data at all
+		REQUIRE(before_key1.to_string() == game_state_1->get_save_checksum().to_string());
+
+	}
+}
+
+TEST_CASE("fill_unsaved_values_determinism_9", "[determinism][fill_unsaved_tests]") {
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("191611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+
+
+
+	game_state_1->game_seed = test_game_seed;
+
+
+	for(int i = 0; i <= 3653; i++) {
+
+
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+
+		auto before_key1 = game_state_1->get_save_checksum();
+
+		game_state_1->fill_unsaved_data();
+
+
+		// make sure that the fill_unsaved_data does not change saved data at all
+		REQUIRE(before_key1.to_string() == game_state_1->get_save_checksum().to_string());
+
+	}
+}
+
+TEST_CASE("fill_unsaved_values_determinism_10", "[determinism][fill_unsaved_tests]") {
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("192611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+
+
+
+	game_state_1->game_seed = test_game_seed;
+
+
+	for(int i = 0; i <= 3653; i++) {
+
+
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+
+		auto before_key1 = game_state_1->get_save_checksum();
+
+		game_state_1->fill_unsaved_data();
+
+
+		// make sure that the fill_unsaved_data does not change saved data at all
+		REQUIRE(before_key1.to_string() == game_state_1->get_save_checksum().to_string());
+
+	}
+}
+
+
+
+TEST_CASE("sim_game_with_saveload_1", "[determinism][sim_with_saveload_tests]") {
 
 
 	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
 	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
 
-	game_state_1->world.nation_set_is_player_controlled(dcon::nation_id{ 1 }, true);
-	game_state_1->world.nation_set_is_player_controlled(dcon::nation_id{ 2 }, true);
-	game_state_1->local_player_nation = dcon::nation_id{ 1 };
-
-	game_state_2->world.nation_set_is_player_controlled(dcon::nation_id{ 1 }, true);
-	game_state_2->world.nation_set_is_player_controlled(dcon::nation_id{ 2 }, true);
-	game_state_2->local_player_nation = dcon::nation_id{ 2 };
-
-	game_state_2->game_seed = game_state_1->game_seed = 808080;
+	game_state_2->game_seed = game_state_1->game_seed = test_game_seed;
 
 	compare_game_states(*game_state_1, *game_state_2);
 
-	// run the first gamestate for about a month
-	for(int i = 0; i <= 31; i++) {
+	// run the first gamestate for about five years
+	for(int i = 0; i <= 1826; i++) {
 		game_state_1->console_log(std::to_string(i));
 		game_state_1->single_game_tick();
 	}
@@ -2071,8 +1030,432 @@ TEST_CASE("sim_game_with_saveload", "[determinism]") {
 	test_load_save(*game_state_1, buffer.get(), uint32_t(length));
 	test_load_save(*game_state_2, buffer.get(), uint32_t(length));
 
-	// run both gamestates
-	for(int i = 0; i <= 3650; i++) {
+	// run both gamestates for another 5 years
+	for(int i = 0; i <= 1826; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+		game_state_2->single_game_tick();
+		compare_game_states(*game_state_1, *game_state_2);
+	}
+
+}
+
+
+TEST_CASE("sim_game_with_saveload_2", "[determinism][sim_with_saveload_tests]") {
+
+
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("184611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("184611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_2->fill_unsaved_data();
+	}
+
+	game_state_2->game_seed = game_state_1->game_seed = test_game_seed;
+
+	compare_game_states(*game_state_1, *game_state_2);
+
+	// run the first gamestate for about five years
+	for(int i = 0; i <= 1826; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+	}
+	// serialize the save and get both gamestates to reload it
+	auto length = sys::sizeof_save_section(*game_state_1);
+	auto buffer = std::unique_ptr<uint8_t[]>(new uint8_t[length]);
+	auto buffer_position = sys::write_save_section(buffer.get(), *game_state_1);
+
+	test_load_save(*game_state_1, buffer.get(), uint32_t(length));
+	test_load_save(*game_state_2, buffer.get(), uint32_t(length));
+
+	// run both gamestates for another 5 years
+	for(int i = 0; i <= 1826; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+		game_state_2->single_game_tick();
+		compare_game_states(*game_state_1, *game_state_2);
+	}
+
+}
+
+TEST_CASE("sim_game_with_saveload_3", "[determinism][sim_with_saveload_tests]") {
+
+
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("185611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("185611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_2->fill_unsaved_data();
+	}
+
+	game_state_2->game_seed = game_state_1->game_seed = test_game_seed;
+
+	compare_game_states(*game_state_1, *game_state_2);
+
+	// run the first gamestate for about five years
+	for(int i = 0; i <= 1826; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+	}
+	// serialize the save and get both gamestates to reload it
+	auto length = sys::sizeof_save_section(*game_state_1);
+	auto buffer = std::unique_ptr<uint8_t[]>(new uint8_t[length]);
+	auto buffer_position = sys::write_save_section(buffer.get(), *game_state_1);
+
+	test_load_save(*game_state_1, buffer.get(), uint32_t(length));
+	test_load_save(*game_state_2, buffer.get(), uint32_t(length));
+
+	// run both gamestates for another 5 years
+	for(int i = 0; i <= 1826; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+		game_state_2->single_game_tick();
+		compare_game_states(*game_state_1, *game_state_2);
+	}
+
+}
+
+TEST_CASE("sim_game_with_saveload_4", "[determinism][sim_with_saveload_tests]") {
+
+
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("186611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("186611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_2->fill_unsaved_data();
+	}
+
+	game_state_2->game_seed = game_state_1->game_seed = test_game_seed;
+
+	compare_game_states(*game_state_1, *game_state_2);
+
+	// run the first gamestate for about five years
+	for(int i = 0; i <= 1826; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+	}
+	// serialize the save and get both gamestates to reload it
+	auto length = sys::sizeof_save_section(*game_state_1);
+	auto buffer = std::unique_ptr<uint8_t[]>(new uint8_t[length]);
+	auto buffer_position = sys::write_save_section(buffer.get(), *game_state_1);
+
+	test_load_save(*game_state_1, buffer.get(), uint32_t(length));
+	test_load_save(*game_state_2, buffer.get(), uint32_t(length));
+
+	// run both gamestates for another 5 years
+	for(int i = 0; i <= 1826; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+		game_state_2->single_game_tick();
+		compare_game_states(*game_state_1, *game_state_2);
+	}
+
+}
+
+TEST_CASE("sim_game_with_saveload_5", "[determinism][sim_with_saveload_tests]") {
+
+
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("187611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("187611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_2->fill_unsaved_data();
+	}
+
+	game_state_2->game_seed = game_state_1->game_seed = test_game_seed;
+
+	compare_game_states(*game_state_1, *game_state_2);
+
+	// run the first gamestate for about five years
+	for(int i = 0; i <= 1826; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+	}
+	// serialize the save and get both gamestates to reload it
+	auto length = sys::sizeof_save_section(*game_state_1);
+	auto buffer = std::unique_ptr<uint8_t[]>(new uint8_t[length]);
+	auto buffer_position = sys::write_save_section(buffer.get(), *game_state_1);
+
+	test_load_save(*game_state_1, buffer.get(), uint32_t(length));
+	test_load_save(*game_state_2, buffer.get(), uint32_t(length));
+
+	// run both gamestates for another 5 years
+	for(int i = 0; i <= 1826; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+		game_state_2->single_game_tick();
+		compare_game_states(*game_state_1, *game_state_2);
+	}
+
+}
+
+TEST_CASE("sim_game_with_saveload_6", "[determinism][sim_with_saveload_tests]") {
+
+
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("188611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("188611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_2->fill_unsaved_data();
+	}
+
+	game_state_2->game_seed = game_state_1->game_seed = test_game_seed;
+
+	compare_game_states(*game_state_1, *game_state_2);
+
+	// run the first gamestate for about five years
+	for(int i = 0; i <= 1826; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+	}
+	// serialize the save and get both gamestates to reload it
+	auto length = sys::sizeof_save_section(*game_state_1);
+	auto buffer = std::unique_ptr<uint8_t[]>(new uint8_t[length]);
+	auto buffer_position = sys::write_save_section(buffer.get(), *game_state_1);
+
+	test_load_save(*game_state_1, buffer.get(), uint32_t(length));
+	test_load_save(*game_state_2, buffer.get(), uint32_t(length));
+
+	// run both gamestates for another 5 years
+	for(int i = 0; i <= 1826; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+		game_state_2->single_game_tick();
+		compare_game_states(*game_state_1, *game_state_2);
+	}
+
+}
+
+TEST_CASE("sim_game_with_saveload_7", "[determinism][sim_with_saveload_tests]") {
+
+
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("189611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("189611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_2->fill_unsaved_data();
+	}
+
+	game_state_2->game_seed = game_state_1->game_seed = test_game_seed;
+
+	compare_game_states(*game_state_1, *game_state_2);
+
+	// run the first gamestate for about five years
+	for(int i = 0; i <= 1826; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+	}
+	// serialize the save and get both gamestates to reload it
+	auto length = sys::sizeof_save_section(*game_state_1);
+	auto buffer = std::unique_ptr<uint8_t[]>(new uint8_t[length]);
+	auto buffer_position = sys::write_save_section(buffer.get(), *game_state_1);
+
+	test_load_save(*game_state_1, buffer.get(), uint32_t(length));
+	test_load_save(*game_state_2, buffer.get(), uint32_t(length));
+
+	// run both gamestates for another 5 years
+	for(int i = 0; i <= 1826; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+		game_state_2->single_game_tick();
+		compare_game_states(*game_state_1, *game_state_2);
+	}
+
+}
+
+TEST_CASE("sim_game_with_saveload_8", "[determinism][sim_with_saveload_tests]") {
+
+
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("190611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("190611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_2->fill_unsaved_data();
+	}
+
+	game_state_2->game_seed = game_state_1->game_seed = test_game_seed;
+
+	compare_game_states(*game_state_1, *game_state_2);
+
+	// run the first gamestate for about five years
+	for(int i = 0; i <= 1826; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+	}
+	// serialize the save and get both gamestates to reload it
+	auto length = sys::sizeof_save_section(*game_state_1);
+	auto buffer = std::unique_ptr<uint8_t[]>(new uint8_t[length]);
+	auto buffer_position = sys::write_save_section(buffer.get(), *game_state_1);
+
+	test_load_save(*game_state_1, buffer.get(), uint32_t(length));
+	test_load_save(*game_state_2, buffer.get(), uint32_t(length));
+
+	// run both gamestates for another 5 years
+	for(int i = 0; i <= 1826; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+		game_state_2->single_game_tick();
+		compare_game_states(*game_state_1, *game_state_2);
+	}
+
+}
+
+TEST_CASE("sim_game_with_saveload_9", "[determinism][sim_with_saveload_tests]") {
+
+
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("191611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("191611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_2->fill_unsaved_data();
+	}
+
+	game_state_2->game_seed = game_state_1->game_seed = test_game_seed;
+
+	compare_game_states(*game_state_1, *game_state_2);
+
+	// run the first gamestate for about five years
+	for(int i = 0; i <= 1826; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+	}
+	// serialize the save and get both gamestates to reload it
+	auto length = sys::sizeof_save_section(*game_state_1);
+	auto buffer = std::unique_ptr<uint8_t[]>(new uint8_t[length]);
+	auto buffer_position = sys::write_save_section(buffer.get(), *game_state_1);
+
+	test_load_save(*game_state_1, buffer.get(), uint32_t(length));
+	test_load_save(*game_state_2, buffer.get(), uint32_t(length));
+
+	// run both gamestates for another 5 years
+	for(int i = 0; i <= 1826; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+		game_state_2->single_game_tick();
+		compare_game_states(*game_state_1, *game_state_2);
+	}
+
+}
+
+TEST_CASE("sim_game_with_saveload_10", "[determinism][sim_with_saveload_tests]") {
+
+
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
+
+
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("192611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_1->fill_unsaved_data();
+	}
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("192611_TEST_SAVE.bin"))) {
+		assert(false);
+		std::abort();
+	} else {
+		game_state_2->fill_unsaved_data();
+	}
+
+	game_state_2->game_seed = game_state_1->game_seed = test_game_seed;
+
+	compare_game_states(*game_state_1, *game_state_2);
+
+	// run the first gamestate for about five years
+	for(int i = 0; i <= 1826; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+	}
+	// serialize the save and get both gamestates to reload it
+	auto length = sys::sizeof_save_section(*game_state_1);
+	auto buffer = std::unique_ptr<uint8_t[]>(new uint8_t[length]);
+	auto buffer_position = sys::write_save_section(buffer.get(), *game_state_1);
+
+	test_load_save(*game_state_1, buffer.get(), uint32_t(length));
+	test_load_save(*game_state_2, buffer.get(), uint32_t(length));
+
+	// run both gamestates for another 5 years
+	for(int i = 0; i <= 1826; i++) {
 		game_state_1->console_log(std::to_string(i));
 		game_state_1->single_game_tick();
 		game_state_2->single_game_tick();

--- a/tests/determinism_tests.cpp
+++ b/tests/determinism_tests.cpp
@@ -1560,6 +1560,11 @@ void checked_single_tick_advanced(sys::state& state1, sys::state& state2) {
 	}
 }
 
+void write_test_save(sys::state& state) {
+	auto current_date = state.current_date.to_string(state.start_date);
+	sys::write_save_file(state, sys::save_type::normal, current_date + "_TEST_SAVE", current_date + "_TEST_SAVE");
+}
+
 
 void test_load_save(sys::state& state, uint8_t* ptr_in, uint32_t length) {
 
@@ -1623,6 +1628,49 @@ TEST_CASE("sim_year", "[determinism]") {
 	}
 }
 
+TEST_CASE("populate_test_saves", "[determinism]") {
+	// Test that the game states are equal after playing
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+
+
+	game_state_1->game_seed = 808080;
+
+	for(int i = 0; i <= 36530; i++) {
+		game_state_1->console_log(std::to_string(i));
+		game_state_1->single_game_tick();
+		auto current_date = game_state_1->current_date.to_ymd(game_state_1->start_date);
+		if(current_date == sys::year_month_day{ 1846, 1, 1 }) {
+			write_test_save(*game_state_1);
+		}
+		else if(current_date == sys::year_month_day{ 1858, 1, 1 }) {
+			write_test_save(*game_state_1);
+		}
+		else if(current_date == sys::year_month_day{ 1868, 1, 1 }) {
+			write_test_save(*game_state_1);
+		}
+		else if(current_date == sys::year_month_day{ 1876, 1, 1 }) {
+			write_test_save(*game_state_1);
+		}
+		else if(current_date == sys::year_month_day{ 1886, 1, 1 }) {
+			write_test_save(*game_state_1);
+		}
+		else if(current_date == sys::year_month_day{ 1896, 1, 1 }) {
+			write_test_save(*game_state_1);
+		}
+		else if(current_date == sys::year_month_day{ 1906, 1, 1 }) {
+			write_test_save(*game_state_1);
+		}
+		else if(current_date == sys::year_month_day{ 1916, 1, 1 }) {
+			write_test_save(*game_state_1);
+		}
+		else if(current_date == sys::year_month_day{ 1926, 1, 1 }) {
+			write_test_save(*game_state_1);
+			break;
+		}
+
+	}
+}
+
 
 TEST_CASE("sim_game_solo", "[determinism]") {
 	// Test that the game states are equal after playing
@@ -1631,7 +1679,7 @@ TEST_CASE("sim_game_solo", "[determinism]") {
 
 	game_state_1->game_seed = 808080;
 
-	for(int i = 0; i <= 3650; i++) {
+	for(int i = 0; i <= 36530; i++) {
 		game_state_1->console_log(std::to_string(i));
 		game_state_1->single_game_tick();
 	}
@@ -1663,14 +1711,14 @@ TEST_CASE("sim_game_second", "[determinism]") {
 	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
 
 
-	if(!sys::try_read_save_file(*game_state_1, NATIVE("1846_TEST_SAVE.bin"))) {
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("184611_TEST_SAVE.bin"))) {
 		assert(false);
 		std::abort();
 	}
 	else {
 		game_state_1->fill_unsaved_data();
 	}
-	if(!sys::try_read_save_file(*game_state_2, NATIVE("1846_TEST_SAVE.bin"))) {
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("184611_TEST_SAVE.bin"))) {
 		assert(false);
 		std::abort();
 	}
@@ -1696,14 +1744,14 @@ TEST_CASE("sim_game_third", "[determinism]") {
 	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
 
 
-	if(!sys::try_read_save_file(*game_state_1, NATIVE("1856_TEST_SAVE.bin"))) {
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("185611_TEST_SAVE.bin"))) {
 		assert(false);
 		std::abort();
 	}
 	else {
 		game_state_1->fill_unsaved_data();
 	}
-	if(!sys::try_read_save_file(*game_state_2, NATIVE("1856_TEST_SAVE.bin"))) {
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("185611_TEST_SAVE.bin"))) {
 		assert(false);
 		std::abort();
 	}
@@ -1728,14 +1776,14 @@ TEST_CASE("sim_game_fourth", "[determinism]") {
 	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
 
 
-	if(!sys::try_read_save_file(*game_state_1, NATIVE("1866_TEST_SAVE.bin"))) {
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("186611_TEST_SAVE.bin"))) {
 		assert(false);
 		std::abort();
 	}
 	else {
 		game_state_1->fill_unsaved_data();
 	}
-	if(!sys::try_read_save_file(*game_state_2, NATIVE("1866_TEST_SAVE.bin"))) {
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("186611_TEST_SAVE.bin"))) {
 		assert(false);
 		std::abort();
 	}
@@ -1760,14 +1808,14 @@ TEST_CASE("sim_game_fifth", "[determinism]") {
 	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
 
 
-	if(!sys::try_read_save_file(*game_state_1, NATIVE("1876_TEST_SAVE.bin"))) {
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("187611_TEST_SAVE.bin"))) {
 		assert(false);
 		std::abort();
 	}
 	else {
 		game_state_1->fill_unsaved_data();
 	}
-	if(!sys::try_read_save_file(*game_state_2, NATIVE("1876_TEST_SAVE.bin"))) {
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("187611_TEST_SAVE.bin"))) {
 		assert(false);
 		std::abort();
 	}
@@ -1792,14 +1840,14 @@ TEST_CASE("sim_game_sixth", "[determinism]") {
 	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
 
 
-	if(!sys::try_read_save_file(*game_state_1, NATIVE("1886_TEST_SAVE.bin"))) {
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("188611_TEST_SAVE.bin"))) {
 		assert(false);
 		std::abort();
 	}
 	else {
 		game_state_1->fill_unsaved_data();
 	}
-	if(!sys::try_read_save_file(*game_state_2, NATIVE("1886_TEST_SAVE.bin"))) {
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("188611_TEST_SAVE.bin"))) {
 		assert(false);
 		std::abort();
 	}
@@ -1824,14 +1872,14 @@ TEST_CASE("sim_game_seventh", "[determinism]") {
 	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
 
 
-	if(!sys::try_read_save_file(*game_state_1, NATIVE("1896_TEST_SAVE.bin"))) {
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("189611_TEST_SAVE.bin"))) {
 		assert(false);
 		std::abort();
 	}
 	else {
 		game_state_1->fill_unsaved_data();
 	}
-	if(!sys::try_read_save_file(*game_state_2, NATIVE("1896_TEST_SAVE.bin"))) {
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("189611_TEST_SAVE.bin"))) {
 		assert(false);
 		std::abort();
 	}
@@ -1856,14 +1904,14 @@ TEST_CASE("sim_game_eigth", "[determinism]") {
 	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
 
 
-	if(!sys::try_read_save_file(*game_state_1, NATIVE("1906_TEST_SAVE.bin"))) {
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("190611_TEST_SAVE.bin"))) {
 		assert(false);
 		std::abort();
 	}
 	else {
 		game_state_1->fill_unsaved_data();
 	}
-	if(!sys::try_read_save_file(*game_state_2, NATIVE("1906_TEST_SAVE.bin"))) {
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("190611_TEST_SAVE.bin"))) {
 		assert(false);
 		std::abort();
 	}
@@ -1888,14 +1936,14 @@ TEST_CASE("sim_game_ninth", "[determinism]") {
 	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
 
 
-	if(!sys::try_read_save_file(*game_state_1, NATIVE("1916_TEST_SAVE.bin"))) {
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("191611_TEST_SAVE.bin"))) {
 		assert(false);
 		std::abort();
 	}
 	else {
 		game_state_1->fill_unsaved_data();
 	}
-	if(!sys::try_read_save_file(*game_state_2, NATIVE("1916_TEST_SAVE.bin"))) {
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("191611_TEST_SAVE.bin"))) {
 		assert(false);
 		std::abort();
 	}
@@ -1920,14 +1968,14 @@ TEST_CASE("sim_game_tenth", "[determinism]") {
 	std::unique_ptr<sys::state> game_state_2 = load_testing_scenario_file(sys::network_mode_type::client);
 
 
-	if(!sys::try_read_save_file(*game_state_1, NATIVE("1926_TEST_SAVE.bin"))) {
+	if(!sys::try_read_save_file(*game_state_1, NATIVE("192611_TEST_SAVE.bin"))) {
 		assert(false);
 		std::abort();
 	}
 	else {
 		game_state_1->fill_unsaved_data();
 	}
-	if(!sys::try_read_save_file(*game_state_2, NATIVE("1926_TEST_SAVE.bin"))) {
+	if(!sys::try_read_save_file(*game_state_2, NATIVE("192611_TEST_SAVE.bin"))) {
 		assert(false);
 		std::abort();
 	}

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -21,15 +21,37 @@
 #define NATIVE_SEP "/"
 #endif
 
-std::unique_ptr<sys::state> load_testing_scenario_file(sys::network_mode_type mode = sys::network_mode_type::single_player, dcon::nation_id selected_nation = dcon::nation_id{ }) {
+
+std::unique_ptr<sys::state> load_testing_scenario_file(sys::network_mode_type mode = sys::network_mode_type::single_player) {
 	std::unique_ptr<sys::state> game_state = std::make_unique<sys::state>(); // too big for the stack
 
 	game_state->network_mode = mode;
 	game_state->user_settings.autosaves = sys::autosave_frequency::yearly;
 
 	add_root(game_state->common_fs, NATIVE("."));        // for the moment this lets us find the shader files
+	if(!sys::try_read_scenario_file(*game_state, NATIVE("tests_scenario.bin"))) {
+		std::abort();
+	} else {
+		game_state->on_scenario_load();
+		INFO("Scenario loaded");
+	}
+	
+	
 
-	if (!sys::try_read_scenario_and_save_file(*game_state, NATIVE("tests_scenario.bin"))) {
+	return game_state;
+}
+
+
+
+
+std::unique_ptr<sys::state> load_testing_scenario_file_with_save(sys::network_mode_type mode = sys::network_mode_type::single_player, dcon::nation_id selected_nation = dcon::nation_id{ }) {
+	std::unique_ptr<sys::state> game_state = std::make_unique<sys::state>(); // too big for the stack
+
+	game_state->network_mode = mode;
+	game_state->user_settings.autosaves = sys::autosave_frequency::yearly;
+
+	add_root(game_state->common_fs, NATIVE("."));        // for the moment this lets us find the shader files
+	if(!sys::try_read_scenario_and_save_file(*game_state, NATIVE("tests_scenario.bin"))) {
 		// scenario making functions
 		parsers::error_handler err("");
 		game_state->load_scenario_data(err, sys::year_month_day{ 1836, 1, 1 });
@@ -46,6 +68,8 @@ std::unique_ptr<sys::state> load_testing_scenario_file(sys::network_mode_type mo
 		game_state->fill_unsaved_data();
 		INFO("Scenario loaded");
 	}
+
+
 
 	return game_state;
 }

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -21,10 +21,11 @@
 #define NATIVE_SEP "/"
 #endif
 
-std::unique_ptr<sys::state> load_testing_scenario_file(sys::network_mode_type mode = sys::network_mode_type::single_player) {
+std::unique_ptr<sys::state> load_testing_scenario_file(sys::network_mode_type mode = sys::network_mode_type::single_player, dcon::nation_id selected_nation = dcon::nation_id{ }) {
 	std::unique_ptr<sys::state> game_state = std::make_unique<sys::state>(); // too big for the stack
 
 	game_state->network_mode = mode;
+	game_state->user_settings.autosaves = sys::autosave_frequency::yearly;
 
 	add_root(game_state->common_fs, NATIVE("."));        // for the moment this lets us find the shader files
 
@@ -36,6 +37,12 @@ std::unique_ptr<sys::state> load_testing_scenario_file(sys::network_mode_type mo
 		INFO("Wrote new scenario");
 		std::abort();
 	} else {
+		if(!selected_nation) {
+			auto observer_nation = game_state->world.national_identity_get_nation_from_identity_holder(game_state->national_definitions.rebel_id);
+			game_state->local_player_nation = observer_nation;
+		} else {
+			game_state->local_player_nation = selected_nation;
+		}
 		game_state->fill_unsaved_data();
 		INFO("Scenario loaded");
 	}


### PR DESCRIPTION
Fixes an oos caused by a data race in a parallel block that is reading from a wide array of resources which it shouldn't do whilst running in parralel. I changed the specific block to run serially instead.

Refactored oos tests to span the entire game, with each individual test spanning about 10 years with specific start saves, which can be generated by first running the "populate_test_saves" test. Also removed alot of old, unused and outdated oos tests & code.

Lastly, added the option to pass a custom file name to the write_save_file function to be able to distinguish the auto-generated saves. (and may be useful later if the option to name saves is added)