### PR TITLE
Adding naval range into PA, mapping unit travel directly to KMs & other minor oddities fix.

### DIFF
--- a/assets/alice.gui
+++ b/assets/alice.gui
@@ -1637,6 +1637,12 @@ guiTypes = {
 				spriteType = "GFX_alice_small_unit_frames"
 				position = { 0 0 }
 			}
+			iconType = {
+				name ="small_attrition_icon"
+				spriteType = "GFX_unit_attr"
+				position = { 65 14 }
+				Orientation = "UPPER_LEFT"
+			}
 			instantTextBoxType={
 				position = { 34 4 }
 				name = "strength"

--- a/assets/localisation/en-US/alice.csv
+++ b/assets/localisation/en-US/alice.csv
@@ -1678,3 +1678,4 @@ alice_ship_not_in_supply_range;?RShip outside supply range?W, closest port: ?O$x
 alice_supply_range_distance;Using ?O$x$?W/?O$y$?W distance to the nearest port
 alice_supply_range_friendly_port;?GAdjacent to friendly port?W
 alice_supply_range_deep_waters;?RIn deep waters?W
+alice_ship_supply_range_unreachable;?RNavy unreachable by any port?W

--- a/assets/localisation/en-US/alice.csv
+++ b/assets/localisation/en-US/alice.csv
@@ -1673,3 +1673,8 @@ alice_sort_pops;Sort Pops
 alice_sort_states;Sort States
 alice_topbar_avg_literacy_in_states;The average ?Yliteracy?W of our non-colonial population is ?Y$x$?W
 open_economy_scene;Open economy viewer
+alice_ship_in_supply_range;Ship in supply range, closest port: $x$
+alice_ship_not_in_supply_range;Ship outside supply range, closest port: $x$
+alice_supply_range_distance;Using $x$/$y$ distance to the nearest port
+alice_supply_range_friendly_port;Adjacent to friendly port
+alice_supply_range_deep_waters;In deep waters

--- a/assets/localisation/en-US/alice.csv
+++ b/assets/localisation/en-US/alice.csv
@@ -1673,8 +1673,8 @@ alice_sort_pops;Sort Pops
 alice_sort_states;Sort States
 alice_topbar_avg_literacy_in_states;The average ?Yliteracy?W of our non-colonial population is ?Y$x$?W
 open_economy_scene;Open economy viewer
-alice_ship_in_supply_range;Ship in supply range, closest port: $x$
-alice_ship_not_in_supply_range;Ship outside supply range, closest port: $x$
-alice_supply_range_distance;Using $x$/$y$ distance to the nearest port
-alice_supply_range_friendly_port;Adjacent to friendly port
-alice_supply_range_deep_waters;In deep waters
+alice_ship_in_supply_range;?GShip in supply range?W, closest port: ?O$x$?W
+alice_ship_not_in_supply_range;?RShip outside supply range?W, closest port: ?O$x$?W
+alice_supply_range_distance;Using ?O$x$?W/?O$y$?W distance to the nearest port
+alice_supply_range_friendly_port;?GAdjacent to friendly port?W
+alice_supply_range_deep_waters;?RIn deep waters?W

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -553,6 +553,10 @@ These relate to army attrition
 - `alice_attrition_war_exhaustion = 1.5`: Multiplier to the war exhaustion gained from taking attrition losses. Works similar to the "COMBATLOSS_WAR_EXHAUSTION" define, but for attrition losses instead. Set to 0 to disable all attrition war exhaustion.
 
 
+These relate to unit movement
+- `alice_army_marching_hours_per_day = 5.0f`: The amount of hours an army marches per day on average. Effectively this is a multiplier to the army's km/hour stat deciding how far an army can move in a single day
+- `alice_navy_sailing_hours_per_day = 20.0f`: The amount of hours a navy sails per day on average. Effectively this is a multiplier to the navy's km/hour stat deciding how far a navy can sail in a single day
+
 ### Support for reforms based on party issues
 
 In issues.txt you can add a `vote_modifiers = { ... }` section to any particular issue option within the party issues section. For example, one could go here:

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -556,6 +556,7 @@ These relate to army attrition
 These relate to unit movement
 - `alice_army_marching_hours_per_day = 5.0f`: The amount of hours an army marches per day on average. Effectively this is a multiplier to the army's km/hour stat deciding how far an army can move in a single day
 - `alice_navy_sailing_hours_per_day = 20.0f`: The amount of hours a navy sails per day on average. Effectively this is a multiplier to the navy's km/hour stat deciding how far a navy can sail in a single day
+As the above defines implies, the distances between provinces are measured in kilometers now when it comes to unit-movement, and maps directly onto the km/hour stat.
 
 ### Support for reforms based on party issues
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -876,7 +876,7 @@ When player navies die from attrition, the admirals are lost too.
 
 ### Movement
 
-Adjacent provinces have a base distance between them (this base also takes terrain into account in some way). When moving to a province, this cost is multiplied by (origin-province-movement-cost-modifier + 1.0)^0.05. The unit "pays" for this cost each day based on its speed, and when it is all paid for, the unit arrives in its destination province. An army's or navy's speed is based on the speed of its slowest ship or regiment x (1 + infrastructure-provided-by-railroads x railroad-level-of-origin) x (possibly-some-modifier-for-crossing-water) x (define:LAND_SPEED_MODIFIER or define:NAVAL_SPEED_MODIFIER) x (leader-speed-trait + 1)
+Adjacent provinces have a base distance between them (this base also takes terrain into account in some way). When moving to a province, this cost is multiplied by (origin-province-movement-cost-modifier + 1.0)^0.05. The unit "pays" for this cost each day based on its speed, and when it is all paid for, the unit arrives in its destination province. An army's or navy's speed is based on the speed of its slowest ship or regiment x (possibly-some-modifier-for-crossing-water) x (define:LAND_SPEED_MODIFIER or define:NAVAL_SPEED_MODIFIER) x (leader-speed-trait + 1)
 
 When a unit arrives in a new province, it takes attrition (as if it had spent the monthly tick in the province).
 

--- a/src/common_types/container_types.hpp
+++ b/src/common_types/container_types.hpp
@@ -133,6 +133,18 @@ struct modifier_hash {
 	}
 };
 
+struct province_hash {
+	using is_avalanching = void;
+
+	province_hash() {
+	}
+
+	auto operator()(dcon::province_id p) const noexcept -> uint64_t {
+		int32_t index = p.index();
+		return ankerl::unordered_dense::hash<int32_t>()(index);
+	}
+};
+
 } // namespace sys
 
 template<typename value_type, typename tag_type, typename allocator = std::allocator<value_type>>

--- a/src/culture/rebels.cpp
+++ b/src/culture/rebels.cpp
@@ -860,6 +860,7 @@ void rebel_hunting_check(sys::state& state) {
 					if(state.world.army_get_location_from_army_location(a) == closest_prov) {
 						state.world.army_get_path(a).clear();
 						state.world.army_set_arrival_time(a, sys::date{});
+						state.world.army_set_unused_travel_days(a, 0.0f);
 
 						rebel_hunters[i] = rebel_hunters.back();
 						rebel_hunters.pop_back();
@@ -871,7 +872,9 @@ void rebel_hunting_check(sys::state& state) {
 						for(uint32_t j = 0; j < new_size; j++) {
 							existing_path.at(j) = path[j];
 						}
-						state.world.army_set_arrival_time(a, military::arrival_time_to(state, a, path.back()));
+						auto arrival_info = military::arrival_time_to(state, a, path.back());
+						state.world.army_set_arrival_time(a, arrival_info.arrival_time);
+						state.world.army_set_unused_travel_days(a, arrival_info.unused_travel_days);
 						state.world.army_set_dig_in(a, 0);
 
 						rebel_hunters[i] = rebel_hunters.back();
@@ -900,7 +903,9 @@ void rebel_hunting_check(sys::state& state) {
 				for(uint32_t j = 0; j < new_size; j++) {
 					existing_path.at(j) = path[j];
 				}
-				state.world.army_set_arrival_time(a, military::arrival_time_to(state, a, path.back()));
+				auto arrival_info = military::arrival_time_to(state, a, path.back());
+				state.world.army_set_arrival_time(a, arrival_info.arrival_time);
+				state.world.army_set_unused_travel_days(a, arrival_info.unused_travel_days);
 				state.world.army_set_dig_in(a, 0);
 			} else {
 				state.world.army_set_ai_province(a, state.world.army_get_location_from_army_location(a));
@@ -1389,7 +1394,9 @@ void update_armies(sys::state& state) {
 		if(best_prov != location) {
 			ar.get_path().resize(1);
 			ar.get_path()[0] = best_prov;
-			ar.set_arrival_time(military::arrival_time_to(state, ar.id, best_prov));
+			auto arrival_info = military::arrival_time_to(state, ar.id, best_prov);
+			ar.set_arrival_time(arrival_info.arrival_time);
+			ar.set_unused_travel_days(arrival_info.unused_travel_days);
 			ar.set_dig_in(0);
 			ar.set_is_rebel_hunter(false);
 		}

--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -4218,6 +4218,10 @@ void execute_merge_navies(sys::state& state, dcon::nation_id source, dcon::navy_
 	state.world.navy_get_path(a).clear();
 	state.world.navy_set_arrival_time(a, sys::date{});
 
+	uint8_t highest_months_out_of_range = std::max(state.world.navy_get_months_outside_naval_range(b), state.world.navy_get_months_outside_naval_range(a));
+
+	state.world.navy_set_months_outside_naval_range(a, highest_months_out_of_range);
+
 	auto regs = state.world.navy_get_navy_membership(b);
 	while(regs.begin() != regs.end()) {
 		auto reg = (*regs.begin()).get_ship();
@@ -4655,6 +4659,7 @@ void execute_evenly_split_navy(sys::state& state, dcon::nation_id source, dcon::
 		auto new_u = fatten(state.world, state.world.create_navy());
 		new_u.set_controller_from_navy_control(source);
 		new_u.set_location_from_navy_location(state.world.navy_get_location_from_navy_location(a));
+		new_u.set_months_outside_naval_range(state.world.navy_get_months_outside_naval_range(a));
 
 		for(auto t : to_transfer) {
 			state.world.ship_set_navy_from_navy_membership(t, new_u);
@@ -4744,6 +4749,7 @@ void execute_split_navy(sys::state& state, dcon::nation_id source, dcon::navy_id
 		auto new_u = fatten(state.world, state.world.create_navy());
 		new_u.set_controller_from_navy_control(source);
 		new_u.set_location_from_navy_location(state.world.navy_get_location_from_navy_location(a));
+		new_u.set_months_outside_naval_range(state.world.navy_get_months_outside_naval_range(a));
 
 		for(auto t : to_transfer) {
 			state.world.ship_set_navy_from_navy_membership(t, new_u);

--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -3866,6 +3866,7 @@ void execute_move_army(sys::state& state, dcon::nation_id source, dcon::army_id 
 	if(!dest) {
 		existing_path.clear();
 		state.world.army_set_arrival_time(a, sys::date{});
+		state.world.army_set_unused_travel_days(a, 0.0f);
 		return;
 	}
 
@@ -3876,6 +3877,7 @@ void execute_move_army(sys::state& state, dcon::nation_id source, dcon::army_id 
 		//we assume that the intention is to cancel the current move command. Cancel the existing path and return w/o assigning a new one
 		if(state.world.army_get_location_from_army_location(a) == dest) {
 			state.world.army_set_arrival_time(a, sys::date{});
+			state.world.army_set_unused_travel_days(a, 0.0f);
 			return;
 		}
 	}
@@ -3896,12 +3898,15 @@ void execute_move_army(sys::state& state, dcon::nation_id source, dcon::army_id 
 		}
 
 		if(existing_path.at(new_size - 1) != old_first_prov) {
-			state.world.army_set_arrival_time(a, military::arrival_time_to(state, a, path.back()));
+			auto arrival_info = military::arrival_time_to(state, a, path.back());
+			state.world.army_set_arrival_time(a, arrival_info.arrival_time);
+			state.world.army_set_unused_travel_days(a, arrival_info.unused_travel_days);
 		}
 		state.world.army_set_dig_in(a, 0);
 		state.world.army_set_is_rebel_hunter(a, false);
 	} else if(reset) {
 		state.world.army_set_arrival_time(a, sys::date{});
+		state.world.army_set_unused_travel_days(a, 0.0f);
 	}
 	state.world.army_set_moving_to_merge(a, false);
 
@@ -4016,6 +4021,7 @@ void execute_move_navy(sys::state& state, dcon::nation_id source, dcon::navy_id 
 	if(!dest) {
 		existing_path.clear();
 		state.world.navy_set_arrival_time(n, sys::date{});
+		state.world.navy_set_unused_travel_days(n, 0.0f);
 		return;
 	}
 
@@ -4039,10 +4045,13 @@ void execute_move_navy(sys::state& state, dcon::nation_id source, dcon::navy_id 
 		}
 
 		if(existing_path.at(new_size - 1) != old_first_prov) {
-			state.world.navy_set_arrival_time(n, military::arrival_time_to(state, n, path.back()));
+			auto arrival_info = military::arrival_time_to(state, n, path.back());
+			state.world.navy_set_arrival_time(n, arrival_info.arrival_time);
+			state.world.navy_set_unused_travel_days(n, arrival_info.unused_travel_days);
 		}
 	} else if(reset) {
 		state.world.navy_set_arrival_time(n, sys::date{});
+		state.world.navy_set_unused_travel_days(n, 0.0f);
 	}
 	state.world.navy_set_moving_to_merge(n, false);
 
@@ -4161,6 +4170,7 @@ void execute_merge_armies(sys::state& state, dcon::nation_id source, dcon::army_
 	// stop movement
 	state.world.army_get_path(a).clear();
 	state.world.army_set_arrival_time(a, sys::date{});
+	state.world.army_set_unused_travel_days(a, 0.0f);
 
 	// set dig in to the lowest value of the two armies
 	state.world.army_set_dig_in(a,std::min(
@@ -4217,6 +4227,7 @@ void execute_merge_navies(sys::state& state, dcon::nation_id source, dcon::navy_
 	// stop movement
 	state.world.navy_get_path(a).clear();
 	state.world.navy_set_arrival_time(a, sys::date{});
+	state.world.navy_set_unused_travel_days(a, 0.0f);
 
 	uint8_t highest_months_out_of_range = std::max(state.world.navy_get_months_outside_naval_range(b), state.world.navy_get_months_outside_naval_range(a));
 

--- a/src/gamestate/dcon_generated.txt
+++ b/src/gamestate/dcon_generated.txt
@@ -2229,6 +2229,11 @@ object {
 		tag{ save }
 	}
 	property{
+		name{ months_outside_naval_range }
+		type{ uint8_t }
+		tag{ save }
+	}
+	property{
 		name{ is_retreating }
 		type{ bitfield }
 		tag{ save }

--- a/src/gamestate/dcon_generated.txt
+++ b/src/gamestate/dcon_generated.txt
@@ -2190,6 +2190,11 @@ object {
 		tag{ save }
 	}
 	property{
+		name{ unused_travel_days }
+		type{ float }
+		tag{ save }
+	}
+	property{
 		name{ ai_activity }
 		type{ uint8_t }
 		tag{ save }
@@ -2226,6 +2231,11 @@ object {
 	property{
 		name{ arrival_time }
 		type{ sys::date }
+		tag{ save }
+	}
+	property{
+		name{ unused_travel_days }
+		type{ float }
 		tag{ save }
 	}
 	property{

--- a/src/gamestate/dcon_generated.txt
+++ b/src/gamestate/dcon_generated.txt
@@ -1875,6 +1875,11 @@ relationship{
 		type{ float }
 		
 	}
+	property{
+		name{ distance_km }
+		type{ float }
+		
+	}
 
 	property{
 		name{ sea_adj_prov }

--- a/src/gamestate/serialization.cpp
+++ b/src/gamestate/serialization.cpp
@@ -139,6 +139,7 @@ uint8_t const* read_scenario_section(uint8_t const* ptr_in, uint8_t const* secti
 	{ // map
 		ptr_in = memcpy_deserialize(ptr_in, state.map_state.map_data.size_x);
 		ptr_in = memcpy_deserialize(ptr_in, state.map_state.map_data.size_y);
+		ptr_in = memcpy_deserialize(ptr_in, state.map_state.map_data.world_circumference);
 		ptr_in = deserialize(ptr_in, state.map_state.map_data.river_vertices);
 		ptr_in = deserialize(ptr_in, state.map_state.map_data.river_starts);
 		ptr_in = deserialize(ptr_in, state.map_state.map_data.river_counts);
@@ -321,6 +322,7 @@ uint8_t* write_scenario_section(uint8_t* ptr_in, sys::state& state) {
 	{ // map
 		ptr_in = memcpy_serialize(ptr_in, state.map_state.map_data.size_x);
 		ptr_in = memcpy_serialize(ptr_in, state.map_state.map_data.size_y);
+		ptr_in = memcpy_serialize(ptr_in, state.map_state.map_data.world_circumference);
 		ptr_in = serialize(ptr_in, state.map_state.map_data.river_vertices);
 		ptr_in = serialize(ptr_in, state.map_state.map_data.river_starts);
 		ptr_in = serialize(ptr_in, state.map_state.map_data.river_counts);
@@ -503,6 +505,7 @@ scenario_size sizeof_scenario_section(sys::state& state) {
 	{ // map
 		sz += sizeof(state.map_state.map_data.size_x);
 		sz += sizeof(state.map_state.map_data.size_y);
+		sz += sizeof(state.map_state.map_data.world_circumference);
 		sz += serialize_size(state.map_state.map_data.river_vertices);
 		sz += serialize_size(state.map_state.map_data.river_starts);
 		sz += serialize_size(state.map_state.map_data.river_counts);

--- a/src/gui/gui_map_icons.hpp
+++ b/src/gui/gui_map_icons.hpp
@@ -947,6 +947,35 @@ class top_unit_icon : public window_element_base {
 	}
 };
 
+class small_counter_attrition_icon : public image_element_base {
+public:
+	bool visible = false;
+	void on_update(sys::state& state) noexcept override {
+		auto prov = retrieve<dcon::province_id>(state, parent);
+		if(prov.index() >= state.province_definitions.first_sea_province.index()) {
+			for(auto navy : state.world.province_get_navy_location(prov)) {
+				if(navy.get_navy().get_controller_from_navy_control() == state.local_player_nation && military::will_recieve_attrition(state, navy.get_navy())) {
+					visible = true;
+					break;
+				}
+			}
+		}
+		else {
+			for(auto army : state.world.province_get_army_location(prov)) {
+				if(army.get_army().get_controller_from_army_control() == state.local_player_nation && military::will_recieve_attrition(state, army.get_army())) {
+					visible = true;
+					break;
+				}
+			}
+		}
+	}
+	void render(sys::state& state, int32_t x, int32_t y) noexcept override {
+		if(visible)
+			image_element_base::render(state, x, y);
+	}
+
+};
+
 class small_top_unit_icon : public window_element_base {
 	std::unique_ptr<element_base> make_child(sys::state& state, std::string_view name, dcon::gui_def_id id) noexcept override {
 		if(name == "controller_flag") {
@@ -955,7 +984,10 @@ class small_top_unit_icon : public window_element_base {
 			return make_element_by_type<tl_strength>(state, id);
 		} else if(name == "frame_bg") {
 			return make_element_by_type<tl_frame_bg>(state, id);
-		} else {
+		} else if(name == "small_attrition_icon") {
+			return make_element_by_type< small_counter_attrition_icon>(state, id);
+		}
+		else {
 			return nullptr;
 		}
 	}

--- a/src/gui/gui_province_window.hpp
+++ b/src/gui/gui_province_window.hpp
@@ -2133,7 +2133,8 @@ public:
 			if(!adjacent && coastal_target && state.world.nation_get_central_ports(state.local_player_nation) != 0) {
 				for(auto p : state.world.nation_get_province_ownership(state.local_player_nation)) {
 					if(auto nb_level = p.get_province().get_building_level(uint8_t(economy::province_building_type::naval_base)); nb_level > 0 && p.get_province().get_nation_from_province_control() == state.local_player_nation) {
-						if(province::direct_distance(state, p.get_province(), coastal_target) <= province::world_circumference * 0.075f * nb_level) {
+						auto arbitrary_circumference = state.map_state.map_data.world_circumference / 10.0f;
+						if(province::direct_distance(state, p.get_province(), coastal_target) <= arbitrary_circumference * 0.075f * nb_level) {
 							reachable_by_sea = true;
 							break;
 						}

--- a/src/gui/map_tooltip.cpp
+++ b/src/gui/map_tooltip.cpp
@@ -233,6 +233,25 @@ void country_name_box(sys::state& state, text::columnar_layout& contents, dcon::
 				text::close_layout_box(contents, box);
 			}
 		}
+		if(prov.index() >= state.province_definitions.first_sea_province.index()) {
+			if(province::province_is_deep_waters(state, prov)) {
+				text::add_line(state, contents, "alice_supply_range_deep_waters");
+			}
+			else if(province::sea_province_is_adjacent_to_friendly_coast(state, prov, state.local_player_nation)) {
+				text::add_line(state, contents, "alice_supply_range_friendly_port");
+			}
+			else {
+				auto values = military::closest_naval_range_port_with_distance(state, prov, state.local_player_nation);
+				if(bool(values.first) && values.second <= state.defines.supply_range * ( 1.0f + state.world.nation_get_modifier_values(state.local_player_nation, sys::national_mod_offsets::supply_range))) {
+					text::add_line(state, contents, "alice_ship_in_supply_range", text::variable_type::x, text::produce_simple_string(state, state.world.province_get_name(values.first)));
+				}
+				else {
+					text::add_line(state, contents, "alice_ship_not_in_supply_range", text::variable_type::x, text::produce_simple_string(state, state.world.province_get_name(values.first)));
+				}
+				//auto used_distance = province::direct_distance(state, values.first, prov) * province::world_circumference;
+				text::add_line(state, contents, "alice_supply_range_distance", text::variable_type::x, text::fp_two_places{values.second }, text::variable_type::y, text::fp_two_places{ state.defines.supply_range * (1.0f + state.world.nation_get_modifier_values(state.local_player_nation, sys::national_mod_offsets::supply_range)) });
+			}
+		}
 	}
 }
 

--- a/src/gui/map_tooltip.cpp
+++ b/src/gui/map_tooltip.cpp
@@ -122,17 +122,20 @@ void country_name_box(sys::state& state, text::columnar_layout& contents, dcon::
 				// if the first province on the actual unit path is the same as the calculated route, use the arrival time for a more accurate estimate
 				if(army.get_path().size() > 0 && *(army.get_path().end() - 1) == path.back()) {
 					dt += (army.get_arrival_time().to_raw_value() - state.current_date.to_raw_value());
-
-					curprov = path.front();
-					for(auto provonpath = path.begin() + 1; provonpath != path.end(); ++provonpath) {
-						dt += military::movement_time_from_to(state, a, curprov, *provonpath);
-						curprov = *provonpath;;
+					float extra_days = army.get_unused_travel_days();
+					curprov = path.back();
+					for(auto iterator = path.rbegin() + 1; iterator != path.rend(); iterator++) {
+						auto provonpath = *iterator;
+						military::update_movement_arrival_days(state, provonpath, curprov, army.id, extra_days, dt);
+						curprov = provonpath;
 					}
 
 				}
 				else {
-					for(const auto provonpath : path) {
-						dt += military::movement_time_from_to(state, a, curprov, provonpath);
+					float extra_days = 0.0f;
+					for(auto iterator = path.rbegin(); iterator != path.rend(); iterator++) {
+						auto provonpath = *iterator;
+						military::update_movement_arrival_days(state, provonpath, curprov, army.id, extra_days, dt);
 						curprov = provonpath;
 					}
 				}
@@ -199,17 +202,21 @@ void country_name_box(sys::state& state, text::columnar_layout& contents, dcon::
 					// if the first province on the actual unit path is the same as the calculated route, use the arrival time for a more accurate estimate
 					if(navy.get_path().size() > 0 && *(navy.get_path().end() - 1) == path.back()) {
 						dt += (navy.get_arrival_time().to_raw_value() - state.current_date.to_raw_value());
+						float extra_days = navy.get_unused_travel_days();
+						curprov = path.back();
+						for(auto iterator = path.rbegin() + 1; iterator != path.rend(); iterator++) {
+							auto provonpath = *iterator;
+							military::update_movement_arrival_days(state, provonpath, curprov, navy.id, extra_days, dt);
 
-						curprov = path.front();
-						for(auto provonpath = path.begin() + 1; provonpath != path.end(); ++provonpath) {
-							dt += military::movement_time_from_to(state, n, curprov, *provonpath);
-							curprov = *provonpath;;
+							curprov = provonpath;
 						}
 
 					}
 					else {
-						for(const auto provonpath : path) {
-							dt += military::movement_time_from_to(state, n, curprov, provonpath);
+						float extra_days = 0.0f;
+						for(auto iterator = path.rbegin(); iterator != path.rend(); iterator++) {
+							auto provonpath = *iterator;
+							military::update_movement_arrival_days(state, provonpath, curprov, navy.id, extra_days, dt);
 							curprov = provonpath;
 						}
 					}

--- a/src/gui/map_tooltip.cpp
+++ b/src/gui/map_tooltip.cpp
@@ -237,7 +237,7 @@ void country_name_box(sys::state& state, text::columnar_layout& contents, dcon::
 			if(province::province_is_deep_waters(state, prov)) {
 				text::add_line(state, contents, "alice_supply_range_deep_waters");
 			}
-			else if(province::sea_province_is_adjacent_to_friendly_coast(state, prov, state.local_player_nation)) {
+			else if(province::sea_province_is_adjacent_to_accessible_coast(state, prov, state.local_player_nation)) {
 				text::add_line(state, contents, "alice_supply_range_friendly_port");
 			}
 			else {

--- a/src/gui/map_tooltip.cpp
+++ b/src/gui/map_tooltip.cpp
@@ -240,7 +240,8 @@ void country_name_box(sys::state& state, text::columnar_layout& contents, dcon::
 				text::close_layout_box(contents, box);
 			}
 		}
-		if(prov.index() >= state.province_definitions.first_sea_province.index()) {
+		// only show ship supply range information if the province is sea, and the selected navies are controlled by the player
+		if(prov.index() >= state.province_definitions.first_sea_province.index() && state.world.navy_get_controller_from_navy_control( state.selected_navies.front()) == state.local_player_nation) {
 			if(province::province_is_deep_waters(state, prov)) {
 				text::add_line(state, contents, "alice_supply_range_deep_waters");
 			}

--- a/src/gui/map_tooltip.cpp
+++ b/src/gui/map_tooltip.cpp
@@ -253,10 +253,12 @@ void country_name_box(sys::state& state, text::columnar_layout& contents, dcon::
 				if(bool(values.first) && values.second <= state.defines.supply_range * ( 1.0f + state.world.nation_get_modifier_values(state.local_player_nation, sys::national_mod_offsets::supply_range))) {
 					text::add_line(state, contents, "alice_ship_in_supply_range", text::variable_type::x, text::produce_simple_string(state, state.world.province_get_name(values.first)));
 				}
+				else if(!bool(values.first)) {
+					text::add_line(state, contents, "alice_ship_supply_range_unreachable");
+				}
 				else {
 					text::add_line(state, contents, "alice_ship_not_in_supply_range", text::variable_type::x, text::produce_simple_string(state, state.world.province_get_name(values.first)));
 				}
-				//auto used_distance = province::direct_distance(state, values.first, prov) * province::world_circumference;
 				text::add_line(state, contents, "alice_supply_range_distance", text::variable_type::x, text::fp_two_places{values.second }, text::variable_type::y, text::fp_two_places{ state.defines.supply_range * (1.0f + state.world.nation_get_modifier_values(state.local_player_nation, sys::national_mod_offsets::supply_range)) });
 			}
 		}

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -208,6 +208,7 @@ public:
 	uint32_t size_x;
 	uint32_t size_y;
 	uint32_t land_vertex_count = 0;
+	float world_circumference;
 
 	// Meshes
 	static constexpr uint32_t vo_land = 0;

--- a/src/military/military.cpp
+++ b/src/military/military.cpp
@@ -4761,27 +4761,25 @@ float effective_navy_speed(sys::state& state, dcon::navy_id n) {
 
 float movement_time_from_to(sys::state& state, dcon::army_id a, dcon::province_id from, dcon::province_id to) {
 	auto adj = state.world.get_province_adjacency_by_province_pair(from, to);
-	/*float distance = province::distance(state, adj);*/
-	float distance = province::direct_distance_km(state, from, to);
+	float distance = province::distance_km(state, adj);
 	float sum_mods = (state.world.province_get_modifier_values(to, sys::provincial_mod_offsets::movement_cost) - 1.0f) +
 					 (state.world.province_get_modifier_values(from, sys::provincial_mod_offsets::movement_cost) - 1.0f);
 	float effective_distance = std::max(0.1f, distance * (sum_mods + 1.0f));
 
 	float effective_speed = effective_army_speed(state, a);
 
-	float days = effective_speed > 0.0f ? effective_distance / (effective_speed * 5.0f) : 50;
+	float days = effective_speed > 0.0f ? effective_distance / (effective_speed * state.defines.alice_army_marching_hours_per_day) : 50;
 	assert(days > 0.0f);
 	return days;
 }
 float movement_time_from_to(sys::state& state, dcon::navy_id n, dcon::province_id from, dcon::province_id to) {
 	auto adj = state.world.get_province_adjacency_by_province_pair(from, to);
-	/*float distance = province::distance(state, adj);*/
-	float distance = province::direct_distance_km(state, from, to);
+	float distance = province::distance_km(state, adj);
 	float effective_distance = distance;
 
 	float effective_speed = effective_navy_speed(state, n);
 
-	float days = effective_speed > 0.0f ? effective_distance / (effective_speed * 20) : 50;
+	float days = effective_speed > 0.0f ? effective_distance / (effective_speed * state.defines.alice_navy_sailing_hours_per_day) : 50;
 	assert(days > 0.0f);
 	return days;
 }

--- a/src/military/military.cpp
+++ b/src/military/military.cpp
@@ -4758,9 +4758,9 @@ float effective_navy_speed(sys::state& state, dcon::navy_id n) {
 float movement_time_from_to(sys::state& state, dcon::army_id a, dcon::province_id from, dcon::province_id to) {
 	auto adj = state.world.get_province_adjacency_by_province_pair(from, to);
 	float distance = province::distance_km(state, adj);
-	float sum_mods = (state.world.province_get_modifier_values(to, sys::provincial_mod_offsets::movement_cost) - 1.0f) +
-					 (state.world.province_get_modifier_values(from, sys::provincial_mod_offsets::movement_cost) - 1.0f);
-	float effective_distance = std::max(0.1f, distance * (sum_mods + 1.0f));
+	// take the average of the modifiers in the two provinces
+	float avg_mods = (state.world.province_get_modifier_values(to, sys::provincial_mod_offsets::movement_cost) + state.world.province_get_modifier_values(from, sys::provincial_mod_offsets::movement_cost)) / 2.0f;
+	float effective_distance = std::max(0.1f, distance * avg_mods);
 
 	float effective_speed = effective_army_speed(state, a);
 

--- a/src/military/military.cpp
+++ b/src/military/military.cpp
@@ -4758,8 +4758,10 @@ float effective_navy_speed(sys::state& state, dcon::navy_id n) {
 float movement_time_from_to(sys::state& state, dcon::army_id a, dcon::province_id from, dcon::province_id to) {
 	auto adj = state.world.get_province_adjacency_by_province_pair(from, to);
 	float distance = province::distance_km(state, adj);
-	// take the average of the modifiers in the two provinces
-	float avg_mods = (state.world.province_get_modifier_values(to, sys::provincial_mod_offsets::movement_cost) + state.world.province_get_modifier_values(from, sys::provincial_mod_offsets::movement_cost)) / 2.0f;
+	// take the average of the modifiers in the two provinces. If the army is "over" a sea prov (naval invading or moving into transports), use 1.0f as the movement_cost.
+	float prov_from_mod = from.index() < state.province_definitions.first_sea_province.index() ? state.world.province_get_modifier_values(from, sys::provincial_mod_offsets::movement_cost) : 1.0f;
+	float prov_to_mod = to.index() < state.province_definitions.first_sea_province.index() ? state.world.province_get_modifier_values(to, sys::provincial_mod_offsets::movement_cost) : 1.0f;
+	float avg_mods = (prov_from_mod + prov_to_mod) / 2.0f;
 	float effective_distance = std::max(0.1f, distance * avg_mods);
 
 	float effective_speed = effective_army_speed(state, a);

--- a/src/military/military.cpp
+++ b/src/military/military.cpp
@@ -4756,30 +4756,32 @@ float effective_navy_speed(sys::state& state, dcon::navy_id n) {
 	auto bg = get_leader_background_wrapper(state, leader);
 	auto per = get_leader_personality_wrapper(state, leader);
 	auto leader_move = state.world.leader_trait_get_speed(bg) + state.world.leader_trait_get_speed(per);
-	return min_speed * (state.world.navy_get_is_retreating(n) ? 2.0f : 1.0f) * (leader_move + 1.0f) * state.defines.naval_speed_modifier;
+	return min_speed * (state.world.navy_get_is_retreating(n) ? 2.0f : 1.0f) * (leader_move + 1.0f);
 }
 
 float movement_time_from_to(sys::state& state, dcon::army_id a, dcon::province_id from, dcon::province_id to) {
 	auto adj = state.world.get_province_adjacency_by_province_pair(from, to);
-	float distance = province::distance(state, adj);
+	/*float distance = province::distance(state, adj);*/
+	float distance = province::direct_distance_km(state, from, to);
 	float sum_mods = (state.world.province_get_modifier_values(to, sys::provincial_mod_offsets::movement_cost) - 1.0f) +
 					 (state.world.province_get_modifier_values(from, sys::provincial_mod_offsets::movement_cost) - 1.0f);
 	float effective_distance = std::max(0.1f, distance * (sum_mods + 1.0f));
 
-	float effective_speed = effective_army_speed(state, a) / 2.0f;
+	float effective_speed = effective_army_speed(state, a);
 
-	float days = effective_speed > 0.0f ? effective_distance / effective_speed : 50;
+	float days = effective_speed > 0.0f ? effective_distance / (effective_speed * 5.0f) : 50;
 	assert(days > 0.0f);
 	return days;
 }
 float movement_time_from_to(sys::state& state, dcon::navy_id n, dcon::province_id from, dcon::province_id to) {
 	auto adj = state.world.get_province_adjacency_by_province_pair(from, to);
-	float distance = province::distance(state, adj);
+	/*float distance = province::distance(state, adj);*/
+	float distance = province::direct_distance_km(state, from, to);
 	float effective_distance = distance;
 
-	float effective_speed = effective_navy_speed(state, n) / 2.0f;
+	float effective_speed = effective_navy_speed(state, n);
 
-	float days = effective_speed > 0.0f ? effective_distance / effective_speed : 50;
+	float days = effective_speed > 0.0f ? effective_distance / (effective_speed * 20) : 50;
 	assert(days > 0.0f);
 	return days;
 }

--- a/src/military/military.hpp
+++ b/src/military/military.hpp
@@ -271,6 +271,13 @@ struct arrival_time_info_raw {
 	float unused_travel_days;
 };
 
+
+struct naval_range_display_data {
+	dcon::province_id closest_port;
+	float distance;
+	sys::date timestamp;
+};
+
 constexpr inline int32_t days_before_retreat = 11;
 
 enum class battle_result {
@@ -391,7 +398,7 @@ ve::fp_vector ve_mobilization_impact(sys::state const& state, ve::tagged_vector<
 
 float get_ship_combat_score(sys::state& state, dcon::ship_id ship);
 
-std::pair<dcon::province_id, float> closest_naval_range_port_with_distance(sys::state& state, dcon::province_id prov, dcon::nation_id nation);
+naval_range_display_data closest_naval_range_port_with_distance(sys::state& state, dcon::province_id prov, dcon::nation_id nation);
 
 uint32_t naval_supply_from_naval_base(sys::state& state, dcon::province_id prov, dcon::nation_id nation);
 void update_naval_supply_points(sys::state& state); // must run after determining connectivity

--- a/src/military/military.hpp
+++ b/src/military/military.hpp
@@ -382,6 +382,8 @@ ve::fp_vector ve_mobilization_impact(sys::state const& state, ve::tagged_vector<
 
 float get_ship_combat_score(sys::state& state, dcon::ship_id ship);
 
+std::pair<dcon::province_id, float> closest_naval_range_port_with_distance(sys::state& state, dcon::province_id prov, dcon::nation_id nation);
+
 uint32_t naval_supply_from_naval_base(sys::state& state, dcon::province_id prov, dcon::nation_id nation);
 void update_naval_supply_points(sys::state& state); // must run after determining connectivity
 void update_cbs(sys::state& state);

--- a/src/military/military.hpp
+++ b/src/military/military.hpp
@@ -262,6 +262,15 @@ struct land_battle_report {
 	bool player_on_winning_side;
 };
 
+struct arrival_time_info {
+	sys::date arrival_time;
+	float unused_travel_days;
+};
+struct arrival_time_info_raw {
+	int32_t travel_days;
+	float unused_travel_days;
+};
+
 constexpr inline int32_t days_before_retreat = 11;
 
 enum class battle_result {
@@ -491,12 +500,20 @@ void reduce_ship_strength_safe(sys::state& state, dcon::ship_id reg, float value
 template<regiment_dmg_source damage_source>
 void regiment_take_damage(sys::state& state, dcon::regiment_id reg, float value);
 
-int32_t movement_time_from_to(sys::state& state, dcon::army_id a, dcon::province_id from, dcon::province_id to);
-int32_t movement_time_from_to(sys::state& state, dcon::navy_id n, dcon::province_id from, dcon::province_id to);
-sys::date arrival_time_to(sys::state& state, dcon::army_id a, dcon::province_id p);
-sys::date arrival_time_to(sys::state& state, dcon::navy_id n, dcon::province_id p);
+float movement_time_from_to(sys::state& state, dcon::army_id a, dcon::province_id from, dcon::province_id to);
+float movement_time_from_to(sys::state& state, dcon::navy_id n, dcon::province_id from, dcon::province_id to);
+arrival_time_info arrival_time_to(sys::state& state, dcon::army_id a, dcon::province_id p);
+arrival_time_info arrival_time_to(sys::state& state, dcon::navy_id n, dcon::province_id p);
+arrival_time_info_raw arrival_time_to_in_days(sys::state& state, dcon::army_id a, dcon::province_id to, dcon::province_id from);
+arrival_time_info_raw arrival_time_to_in_days(sys::state& state, dcon::navy_id n, dcon::province_id to, dcon::province_id from);
 float fractional_distance_covered(sys::state& state, dcon::army_id a);
 float fractional_distance_covered(sys::state& state, dcon::navy_id a);
+
+template<typename T>
+void update_movement_arrival_days(sys::state& state, dcon::province_id to, dcon::province_id from, T army, float& unused_travel_days, sys::date& arrival_time);
+
+template<typename T>
+void update_movement_arrival_days_on_unit(sys::state& state, dcon::province_id to, dcon::province_id from, T army);
 
 enum class crossing_type {
 	none, river, sea

--- a/src/parsing/defines.cpp
+++ b/src/parsing/defines.cpp
@@ -5,6 +5,7 @@
 #include "defines.hpp"
 #include "parsers.hpp"
 #include "system_state.hpp"
+#include "math_fns.hpp"
 
 void parsing::defines::assign_define(sys::state& state, int32_t line, std::string_view text, float v,
 		parsers::error_handler& err) {
@@ -145,4 +146,5 @@ void parsing::defines::parse_file(sys::state& state, std::string_view data, pars
 	/* Fixups and nudges */
 	state.defines.investment_score_factor *= 0.05f;
 	state.defines.base_truce_months = std::max(0.f, state.defines.base_truce_months); //some mods try to be funny
+	state.map_state.map_data.world_circumference = 2 * math::pi * state.defines.alice_globe_mean_radius_km; // calculate and store world circumference based on define
 }

--- a/src/parsing/defines.hpp
+++ b/src/parsing/defines.hpp
@@ -753,6 +753,8 @@
 	LUA_DEFINES_LIST_ELEMENT(alice_army_sea_transport_attrition, 2.5) \
 	LUA_DEFINES_LIST_ELEMENT(alice_fort_siege_attrition_per_level, 0.35) \
 	LUA_DEFINES_LIST_ELEMENT(alice_attrition_war_exhaustion, 1.5) \
+	LUA_DEFINES_LIST_ELEMENT(alice_army_marching_hours_per_day, 5.0) \
+	LUA_DEFINES_LIST_ELEMENT(alice_navy_sailing_hours_per_day, 20.0) \
 
 // scales the needs values so that they are needs per this many pops
 // this value was arrived at by looking at farmers: 40'000 farmers produces enough grain to satisfy about 2/3

--- a/src/provinces/province.cpp
+++ b/src/provinces/province.cpp
@@ -28,6 +28,39 @@ bool nations_are_adjacent(sys::state& state, dcon::nation_id a, dcon::nation_id 
 	auto it = state.world.get_nation_adjacency_by_nation_adjacency_pair(a, b);
 	return bool(it);
 }
+
+bool province_is_deep_waters(sys::state& state, dcon::province_id prov) {
+	assert(prov.index() >= state.province_definitions.first_sea_province.index());
+	
+	for(auto adj : state.world.province_get_province_adjacency(prov)) {
+		auto indx = adj.get_connected_provinces(0).id != prov ? 0 : 1;
+		auto adj_prov = adj.get_connected_provinces(indx);
+		if(adj_prov.id.index() < state.province_definitions.first_sea_province.index()) {
+			return false;
+		}
+	}
+	return true;
+
+}
+
+bool sea_province_is_adjacent_to_friendly_coast(sys::state& state, dcon::province_id prov, dcon::nation_id nation) {
+	assert(prov.index() >= state.province_definitions.first_sea_province.index());
+
+	for(auto adj : state.world.province_get_province_adjacency(prov)) {
+		auto indx = adj.get_connected_provinces(0).id != prov ? 0 : 1;
+		auto adj_prov = adj.get_connected_provinces(indx);
+		if(adj_prov.id.index() < state.province_definitions.first_sea_province.index()) {
+			auto controller = state.world.province_get_nation_from_province_control(adj_prov);
+			if(nation == controller || nations::are_allied(state, nation, controller) || military::are_in_common_war(state, nation, controller)) {
+				return true;
+			}
+		}
+	}
+	return false;
+
+}
+
+
 void update_connected_regions(sys::state& state) {
 	if(!state.adjacency_data_out_of_date)
 		return;
@@ -2152,12 +2185,18 @@ float distance(sys::state& state, dcon::province_adjacency_id pair) {
 	return state.world.province_adjacency_get_distance(pair);
 }
 
+
 // direct distance between two provinces; does not pathfind
 float direct_distance(sys::state& state, dcon::province_id a, dcon::province_id b) {
 	auto apos = state.world.province_get_mid_point_b(a);
 	auto bpos = state.world.province_get_mid_point_b(b);
 	auto dot = (apos.x * bpos.x + apos.y * bpos.y) + apos.z * bpos.z;
 	return math::acos(dot) * (world_circumference / (2.0f * math::pi));
+}
+
+// naval range distance between two provinces
+float naval_range_distance(sys::state& state, dcon::province_id a, dcon::province_id b) {
+	return direct_distance(state, a, b) * naval_range_distance_mult;
 }
 
 float sorting_distance(sys::state& state, dcon::province_id a, dcon::province_id b) {

--- a/src/provinces/province.cpp
+++ b/src/provinces/province.cpp
@@ -43,16 +43,16 @@ bool province_is_deep_waters(sys::state& state, dcon::province_id prov) {
 
 }
 
-bool sea_province_is_adjacent_to_friendly_coast(sys::state& state, dcon::province_id prov, dcon::nation_id nation) {
+bool sea_province_is_adjacent_to_accessible_coast(sys::state& state, dcon::province_id prov, dcon::nation_id nation) {
 	assert(prov.index() >= state.province_definitions.first_sea_province.index());
 
 	for(auto adj : state.world.province_get_province_adjacency(prov)) {
 		auto indx = adj.get_connected_provinces(0).id != prov ? 0 : 1;
 		auto adj_prov = adj.get_connected_provinces(indx);
 		if(adj_prov.id.index() < state.province_definitions.first_sea_province.index()) {
-			auto controller = state.world.province_get_nation_from_province_control(adj_prov);
-			if(nation == controller || nations::are_allied(state, nation, controller) || military::are_in_common_war(state, nation, controller)) {
+			if(has_naval_access_to_province(state, nation, adj_prov)) {
 				return true;
+
 			}
 		}
 	}

--- a/src/provinces/province.cpp
+++ b/src/provinces/province.cpp
@@ -2194,6 +2194,15 @@ float direct_distance(sys::state& state, dcon::province_id a, dcon::province_id 
 	return math::acos(dot) * (world_circumference / (2.0f * math::pi));
 }
 
+
+float direct_distance_km(sys::state& state, dcon::province_id a, dcon::province_id b) {
+	auto apos = state.world.province_get_mid_point_b(a);
+	auto bpos = state.world.province_get_mid_point_b(b);
+	auto dot = (apos.x * bpos.x + apos.y * bpos.y) + apos.z * bpos.z;
+	return math::acos(dot) * state.defines.alice_globe_mean_radius_km;
+	/*return (math::acos(dot) / math::pi) * ((state.defines.alice_globe_mean_radius_km * 2) * math::pi) / 2.0f;*/
+}
+
 // naval range distance between two provinces
 float naval_range_distance(sys::state& state, dcon::province_id a, dcon::province_id b) {
 	return direct_distance(state, a, b) * naval_range_distance_mult;

--- a/src/provinces/province.cpp
+++ b/src/provinces/province.cpp
@@ -1772,7 +1772,8 @@ bool can_start_colony(sys::state& state, dcon::nation_id n, dcon::state_definiti
 		for(auto p : state.world.nation_get_province_ownership(n)) {
 			if(auto nb_level = p.get_province().get_building_level(uint8_t(economy::province_building_type::naval_base)); nb_level > 0 && p.get_province().get_nation_from_province_control() == n) {
 				auto dist = province::direct_distance(state, p.get_province(), coastal_target);
-				if(dist <= province::world_circumference * state.defines.alice_naval_base_to_colonial_distance_factor * nb_level) {
+				auto arbitrary_circumference = state.map_state.map_data.world_circumference / 10.0f;
+				if(dist <= arbitrary_circumference * state.defines.alice_naval_base_to_colonial_distance_factor * nb_level) {
 					reachable_by_sea = true;
 					break;
 				}
@@ -1877,7 +1878,8 @@ bool fast_can_start_colony(sys::state& state, dcon::nation_id n, dcon::state_def
 		for(auto p : state.world.nation_get_province_ownership(n)) {
 			if(auto nb_level = p.get_province().get_building_level(uint8_t(economy::province_building_type::naval_base)); nb_level > 0 && p.get_province().get_nation_from_province_control() == n) {
 				auto dist = province::direct_distance(state, p.get_province(), coastal_target);
-				if(dist <= province::world_circumference * 0.04f * nb_level) {
+				auto arbitrary_circumference = state.map_state.map_data.world_circumference / 10.0f;
+				if(dist <= arbitrary_circumference * 0.04f * nb_level) {
 					reachable_by_sea = true;
 					break;
 				}
@@ -2185,13 +2187,19 @@ float distance(sys::state& state, dcon::province_adjacency_id pair) {
 	return state.world.province_adjacency_get_distance(pair);
 }
 
+// distance in kilometers between to adjacent provinces
+float distance_km(sys::state& state, dcon::province_adjacency_id pair) {
+	return state.world.province_adjacency_get_distance_km(pair);
+}
+
 
 // direct distance between two provinces; does not pathfind
 float direct_distance(sys::state& state, dcon::province_id a, dcon::province_id b) {
 	auto apos = state.world.province_get_mid_point_b(a);
 	auto bpos = state.world.province_get_mid_point_b(b);
 	auto dot = (apos.x * bpos.x + apos.y * bpos.y) + apos.z * bpos.z;
-	return math::acos(dot) * (world_circumference / (2.0f * math::pi));
+	auto arbitrary_circumference = state.map_state.map_data.world_circumference / 10.0f;
+	return math::acos(dot) * (arbitrary_circumference / (2.0f * math::pi));
 }
 
 
@@ -2858,7 +2866,9 @@ void restore_distances(sys::state& state) {
 	}
 	for(auto adj : state.world.in_province_adjacency) {
 		auto dist = direct_distance(state, adj.get_connected_provinces(0), adj.get_connected_provinces(1));
+		auto dist_km = direct_distance_km(state, adj.get_connected_provinces(0), adj.get_connected_provinces(1));
 		adj.set_distance(dist);
+		adj.set_distance_km(dist_km);
 	}
 }
 

--- a/src/provinces/province.hpp
+++ b/src/provinces/province.hpp
@@ -5,6 +5,8 @@
 
 namespace province {
 
+inline constexpr float naval_range_distance_mult = 0.391f; // multiplier applied to regular direct distances to compute the naval range distance. This is so default naval range values match up with the expected values from vic2.
+
 inline constexpr float world_circumference = 40075.0f / 10.0f; // in arbitrary units
 
 inline constexpr uint16_t to_map_id(dcon::province_id id) {
@@ -30,6 +32,9 @@ struct global_provincial_state {
 	dcon::modifier_id south_america;
 	dcon::modifier_id oceania;
 };
+
+bool province_is_deep_waters(sys::state& state, dcon::province_id prov);
+bool sea_province_is_adjacent_to_friendly_coast(sys::state& state, dcon::province_id prov, dcon::nation_id nation);
 
 bool nations_are_adjacent(sys::state& state, dcon::nation_id a, dcon::nation_id b);
 void update_connected_regions(sys::state& state);
@@ -96,6 +101,9 @@ float state_distance(sys::state& state, dcon::state_instance_id state_id, dcon::
 float distance(sys::state& state, dcon::province_adjacency_id pair);
 // direct distance between two provinces; does not pathfind
 float direct_distance(sys::state& state, dcon::province_id a, dcon::province_id b);
+
+// naval range distance between two provinces
+float naval_range_distance(sys::state& state, dcon::province_id a, dcon::province_id b);
 // sorting distance returns values such that a smaller sorting distance between two provinces
 // means that they are closer, but does not translate 1 to 1 to actual distances (i.e. is the negative dot product)
 float sorting_distance(sys::state& state, dcon::province_id a, dcon::province_id b);

--- a/src/provinces/province.hpp
+++ b/src/provinces/province.hpp
@@ -34,7 +34,7 @@ struct global_provincial_state {
 };
 
 bool province_is_deep_waters(sys::state& state, dcon::province_id prov);
-bool sea_province_is_adjacent_to_friendly_coast(sys::state& state, dcon::province_id prov, dcon::nation_id nation);
+bool sea_province_is_adjacent_to_accessible_coast(sys::state& state, dcon::province_id prov, dcon::nation_id nation);
 
 bool nations_are_adjacent(sys::state& state, dcon::nation_id a, dcon::nation_id b);
 void update_connected_regions(sys::state& state);

--- a/src/provinces/province.hpp
+++ b/src/provinces/province.hpp
@@ -31,6 +31,11 @@ struct global_provincial_state {
 	dcon::modifier_id oceania;
 };
 
+struct naval_range_data {
+	float distance;
+	bool is_reachable;
+};
+
 bool province_is_deep_waters(sys::state& state, dcon::province_id prov);
 bool sea_province_is_adjacent_to_accessible_coast(sys::state& state, dcon::province_id prov, dcon::nation_id nation);
 
@@ -106,8 +111,8 @@ float direct_distance(sys::state& state, dcon::province_id a, dcon::province_id 
 
 float direct_distance_km(sys::state& state, dcon::province_id a, dcon::province_id b);
 
-// naval range distance between two provinces
-float naval_range_distance(sys::state& state, dcon::province_id a, dcon::province_id b);
+// naval range distance between a port and a sea province. Must take the distance of a naval path instead of direct distance
+naval_range_data naval_range_distance(sys::state& state, dcon::province_id port_prov, dcon::province_id sea_prov);
 // sorting distance returns values such that a smaller sorting distance between two provinces
 // means that they are closer, but does not translate 1 to 1 to actual distances (i.e. is the negative dot product)
 float sorting_distance(sys::state& state, dcon::province_id a, dcon::province_id b);

--- a/src/provinces/province.hpp
+++ b/src/provinces/province.hpp
@@ -102,6 +102,8 @@ float distance(sys::state& state, dcon::province_adjacency_id pair);
 // direct distance between two provinces; does not pathfind
 float direct_distance(sys::state& state, dcon::province_id a, dcon::province_id b);
 
+float direct_distance_km(sys::state& state, dcon::province_id a, dcon::province_id b);
+
 // naval range distance between two provinces
 float naval_range_distance(sys::state& state, dcon::province_id a, dcon::province_id b);
 // sorting distance returns values such that a smaller sorting distance between two provinces

--- a/src/provinces/province.hpp
+++ b/src/provinces/province.hpp
@@ -7,8 +7,6 @@ namespace province {
 
 inline constexpr float naval_range_distance_mult = 0.391f; // multiplier applied to regular direct distances to compute the naval range distance. This is so default naval range values match up with the expected values from vic2.
 
-inline constexpr float world_circumference = 40075.0f / 10.0f; // in arbitrary units
-
 inline constexpr uint16_t to_map_id(dcon::province_id id) {
 	return uint16_t(id.index() + 1);
 }
@@ -99,6 +97,10 @@ void upgrade_colonial_state(sys::state& state, dcon::nation_id owner, dcon::stat
 float state_distance(sys::state& state, dcon::state_instance_id state_id, dcon::province_id prov_id);
 // distance between to adjacent provinces
 float distance(sys::state& state, dcon::province_adjacency_id pair);
+
+// distance in kilometers between to adjacent provinces
+float distance_km(sys::state& state, dcon::province_adjacency_id pair);
+
 // direct distance between two provinces; does not pathfind
 float direct_distance(sys::state& state, dcon::province_id a, dcon::province_id b);
 

--- a/tests/determinism_tests.cpp
+++ b/tests/determinism_tests.cpp
@@ -308,7 +308,7 @@ TEST_CASE("sim_none", "[determinism]") {
 // this test repopulates all the test saves which is used for the tests below. Each test uses a save and runs in a 10-year incremement from the start of that save-
 TEST_CASE("populate_test_saves", "[determinism]") {
 
-	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file(sys::network_mode_type::host);
+	std::unique_ptr<sys::state> game_state_1 = load_testing_scenario_file_with_save(sys::network_mode_type::host);
 
 
 	game_state_1->game_seed = test_game_seed;


### PR DESCRIPTION
This PR adds naval range and naval attrition into PA from Vic2 which was absent. If any navy is too far away from a controlled port (define:NAVAL_RANGE * naval range modifiers) it will take monthly attrition, which starts at 1%, and adds an additional 2% each month for each attrition tick it recieves. The attrition "counter" is reset when the navy reaches a sea province which is adjacent to a accesible coast.  There are some exceptions, such as never taking attrition in sea provinces adjacent to accessible coast, or always triggering the attrition if the ship is in "deep waters", aka a sea province completly suorrounded by other sea provinces.

This vanilla mechanic does serve an important purpose, which is to incentivize having naval bases in many parts of the world for effective power projection.

Implemented "unused travel days", to allow armies/navies to average out travel days over a multiple-province path. Basically it will "save up" any unused days (eg if the days it takes is 1.5, it will take 2 days to travel and 0.5 will be saved as unused). It will then use these unused days when applicable to lower travel times on a later province in the same path. 
This is meant to prevent a path of many small provinces taking longer than it should compared to a few big provinces.

Lastly changed unit movement time calculation to use kilometers, which themselves are caclulated based on the earth_radius define. This maps directly unto the unit's km/hour stat.

Fixed some minor oddities in distance & unit speed calculation, and added small attrition icon when zoomed-out.
