### PR TITLE
Scriptable fort_level modifier, linear fort siege effect & make enemy canals not enterable

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -558,6 +558,9 @@ These relate to unit movement
 - `alice_navy_sailing_hours_per_day = 20.0f`: The amount of hours a navy sails per day on average. Effectively this is a multiplier to the navy's km/hour stat deciding how far a navy can sail in a single day
 As the above defines implies, the distances between provinces are measured in kilometers now when it comes to unit-movement, and maps directly onto the km/hour stat.
 
+These relate to occupations
+- `alice_fort_siege_slowdown = 0.75f`: Slowdown modifier to siege speed for each fort level in the province. 0.75 = takes 75% of base siege time longer per fort level. 0.75 is the default vanilla value
+
 ### Support for reforms based on party issues
 
 In issues.txt you can add a `vote_modifiers = { ... }` section to any particular issue option within the party issues section. For example, one could go here:

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -560,6 +560,7 @@ As the above defines implies, the distances between provinces are measured in ki
 
 These relate to occupations
 - `alice_fort_siege_slowdown = 0.75f`: Slowdown modifier to siege speed for each fort level in the province. 0.75 = takes 75% of base siege time longer per fort level. 0.75 is the default vanilla value
+- `alice_rebel_reduction_after_reoccupation = 7.0f`: When a rebel province is reoccupied by the owner, all pops which were part of the controlling rebel faction gets their militancy divided by this amount
 
 ### Support for reforms based on party issues
 

--- a/src/ai/ai.cpp
+++ b/src/ai/ai.cpp
@@ -671,7 +671,7 @@ void send_fleet_home(sys::state& state, dcon::navy_id n, fleet_activity moving_s
 		v.set_ai_activity(uint8_t(at_base));
 	} else if(!home_port) {
 		v.set_ai_activity(uint8_t(fleet_activity::unspecified));
-	} else if(auto naval_path = province::make_naval_path(state, v.get_location_from_navy_location(), home_port); naval_path.size() > 0) {
+	} else if(auto naval_path = province::make_naval_path(state, v.get_location_from_navy_location(), home_port, v.get_controller_from_navy_control()); naval_path.size() > 0) {
 		auto new_size = uint32_t(naval_path.size());
 		auto existing_path = v.get_path();
 		existing_path.resize(new_size);
@@ -715,7 +715,7 @@ bool set_fleet_target(sys::state& state, dcon::nation_id n, dcon::province_id st
 
 	if(result) {
 		auto existing_path = state.world.navy_get_path(for_navy);
-		auto path = province::make_naval_path(state, start, result);
+		auto path = province::make_naval_path(state, start, result, state.world.navy_get_controller_from_navy_control(for_navy));
 		if(path.size() > 0) {
 			auto new_size = std::min(uint32_t(path.size()), uint32_t(4));
 			existing_path.resize(new_size);
@@ -856,7 +856,7 @@ void pickup_idle_ships(sys::state& state) {
 						if(!province::has_naval_access_to_province(state, owner, target_prov)) {
 							target_prov = state.world.province_get_port_to(target_prov);
 						}
-						auto naval_path = province::make_naval_path(state, location, target_prov);
+						auto naval_path = province::make_naval_path(state, location, target_prov, n.get_controller_from_navy_control());
 
 						auto existing_path = n.get_path();
 						auto new_size = uint32_t(naval_path.size());
@@ -883,7 +883,7 @@ void pickup_idle_ships(sys::state& state) {
 						if(!province::has_naval_access_to_province(state, owner, target_prov)) {
 							target_prov = state.world.province_get_port_to(target_prov);
 						}
-						auto naval_path = province::make_naval_path(state, location, target_prov);
+						auto naval_path = province::make_naval_path(state, location, target_prov, n.get_controller_from_navy_control());
 
 						auto existing_path = n.get_path();
 						auto new_size = uint32_t(naval_path.size());
@@ -916,7 +916,7 @@ void pickup_idle_ships(sys::state& state) {
 					state.world.navy_set_ai_activity(n, uint8_t(fleet_activity::idle));
 			} else if(home_port) {
 				auto existing_path = state.world.navy_get_path(n);
-				auto path = province::make_naval_path(state, location, home_port);
+				auto path = province::make_naval_path(state, location, home_port, n.get_controller_from_navy_control());
 				if(path.size() > 0) {
 					auto new_size = uint32_t(path.size());
 					existing_path.resize(new_size);
@@ -1304,7 +1304,7 @@ void move_idle_guards(sys::state& state) {
 				state.world.navy_set_arrival_time(transport_fleet, sys::date{});
 				state.world.navy_set_unused_travel_days(transport_fleet, 0.0f);
 				state.world.navy_set_ai_activity(transport_fleet, uint8_t(fleet_activity::boarding));
-			} else if(auto fleet_path = province::make_naval_path(state, state.world.navy_get_location_from_navy_location(transport_fleet), fleet_destination); fleet_path.empty()) { // this essentially should be impossible ...
+			} else if(auto fleet_path = province::make_naval_path(state, state.world.navy_get_location_from_navy_location(transport_fleet), fleet_destination, state.world.navy_get_controller_from_navy_control(transport_fleet)); fleet_path.empty()) { // this essentially should be impossible ...
 				continue;
 			} else {
 				auto existing_path = state.world.navy_get_path(transport_fleet);
@@ -2060,7 +2060,7 @@ void move_gathered_attackers(sys::state& state) {
 				state.world.navy_set_arrival_time(transport_fleet, sys::date{});
 				state.world.navy_set_unused_travel_days(transport_fleet, 0.0f);
 				state.world.navy_set_ai_activity(transport_fleet, uint8_t(fleet_activity::boarding));
-			} else if(auto fleet_path = province::make_naval_path(state, state.world.navy_get_location_from_navy_location(transport_fleet), fleet_destination); fleet_path.empty()) {
+			} else if(auto fleet_path = province::make_naval_path(state, state.world.navy_get_location_from_navy_location(transport_fleet), fleet_destination, state.world.navy_get_controller_from_navy_control(transport_fleet)); fleet_path.empty()) {
 				continue;
 			} else {
 				auto existing_path = state.world.navy_get_path(transport_fleet);

--- a/src/culture/rebels.cpp
+++ b/src/culture/rebels.cpp
@@ -1374,7 +1374,7 @@ void update_armies(sys::state& state) {
 			if(prov.id.index() >= state.province_definitions.first_sea_province.index())
 				continue;
 			/* impassable */
-			if((adj.get_type() & province::border::impassible_bit) != 0)
+			if(province::is_adjacency_impassable(state, dcon::nation_id{ }, adj.id))
 				continue;
 			if(allow_in_area(state, prov, arc.get_controller())) {
 				//float weight = trigger::evaluate_multiplicative_modifier(state, type.get_movement_evaluation(), trigger::to_generic(prov), trigger::to_generic(prov), trigger::to_generic(arc.get_controller()));

--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -3994,7 +3994,7 @@ std::vector<dcon::province_id> calculate_navy_path(sys::state & state, dcon::nat
 		return std::vector<dcon::province_id>{};
 
 	if(dest.index() >= state.province_definitions.first_sea_province.index()) {
-		return province::make_naval_path(state, last_province, dest);
+		return province::make_naval_path(state, last_province, dest, source);
 	} else {
 		if(!state.world.province_get_is_coast(dest))
 			return std::vector<dcon::province_id>{};
@@ -4002,7 +4002,7 @@ std::vector<dcon::province_id> calculate_navy_path(sys::state & state, dcon::nat
 		if(!province::has_naval_access_to_province(state, source, dest))
 			return std::vector<dcon::province_id>{};
 
-		return province::make_naval_path(state, last_province, dest);
+		return province::make_naval_path(state, last_province, dest, source);
 	}
 }
 void execute_move_navy(sys::state& state, dcon::nation_id source, dcon::navy_id n, dcon::province_id dest, bool reset) {

--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -3851,7 +3851,8 @@ void execute_move_army(sys::state& state, dcon::nation_id source, dcon::army_id 
 	auto battle = state.world.army_get_battle_from_army_battle_participation(a);
 	if(dest.index() < state.province_definitions.first_sea_province.index()) {
 		/* Case for land destinations */
-		if(battle && !province::has_naval_access_to_province(state, source, dest)) {
+		// the previous call was to "province::has_naval_access_to_province" instead, was there a reason for that?
+		if(battle && !province::has_access_to_province(state, source, dest)) {
 			return;
 		}
 	} else {

--- a/src/gamestate/dcon_generated.txt
+++ b/src/gamestate/dcon_generated.txt
@@ -1882,7 +1882,7 @@ relationship{
 	}
 
 	property{
-		name{ sea_adj_prov }
+		name{ canal_or_blockade_province }
 		type{ dcon::province_id }
 		tag{ save }
 	}

--- a/src/gamestate/modifiers.hpp
+++ b/src/gamestate/modifiers.hpp
@@ -58,8 +58,9 @@ namespace sys {
 	MOD_LIST_ELEMENT(47, min_build_fort, false, modifier_display_type::integer, "fort_level") \
 	MOD_LIST_ELEMENT(48, min_build_bank, false, modifier_display_type::integer, "bank_level") \
 	MOD_LIST_ELEMENT(49, min_build_university, false, modifier_display_type::integer, "university_level") \
-	MOD_LIST_ELEMENT(50, conversion_rate, true, modifier_display_type::percent, "modifier_conversion_rate")
-#define MOD_PROV_LIST_COUNT 51
+	MOD_LIST_ELEMENT(50, conversion_rate, true, modifier_display_type::percent, "modifier_conversion_rate") \
+	MOD_LIST_ELEMENT(51, fort_level, true, modifier_display_type::integer, "fort_level")
+#define MOD_PROV_LIST_COUNT 52
 
 #define MOD_NAT_LIST                                                                                                             \
 	MOD_LIST_ELEMENT(0, war_exhaustion, false, modifier_display_type::fp_two_places, "war_exhaustion")                             \

--- a/src/gui/gui_common_elements.hpp
+++ b/src/gui/gui_common_elements.hpp
@@ -2512,14 +2512,6 @@ inline void province_building_effect_tooltip(sys::state& state, text::columnar_l
 		text::add_to_layout_box(state, contents, box, text::fp_percentage{ def.infrastructure }, text::text_color::green);
 		text::close_layout_box(contents, box);
 	}
-	else if(bt == economy::province_building_type::fort) {
-		auto box = text::open_layout_box(contents, 0);
-		text::add_to_layout_box(state, contents, box, text::produce_simple_string(state, "FORT_LEVEL"), text::text_color::white);
-		text::add_to_layout_box(state, contents, box, std::string_view{ ":" }, text::text_color::white);
-		text::add_space_to_layout_box(state, contents, box);
-		text::add_to_layout_box(state, contents, box, 1, text::text_color::green);
-		text::close_layout_box(contents, box);
-	}
 }
 
 inline void province_building_tooltip(sys::state& state, text::columnar_layout& contents, dcon::province_id p, economy::province_building_type bt) {

--- a/src/gui/gui_map_icons.hpp
+++ b/src/gui/gui_map_icons.hpp
@@ -956,7 +956,7 @@ public:
 			for(auto navy : state.world.province_get_navy_location(prov)) {
 				if(navy.get_navy().get_controller_from_navy_control() == state.local_player_nation && military::will_recieve_attrition(state, navy.get_navy())) {
 					visible = true;
-					break;
+					return;
 				}
 			}
 		}
@@ -964,10 +964,11 @@ public:
 			for(auto army : state.world.province_get_army_location(prov)) {
 				if(army.get_army().get_controller_from_army_control() == state.local_player_nation && military::will_recieve_attrition(state, army.get_army())) {
 					visible = true;
-					break;
+					return;
 				}
 			}
 		}
+		visible = false;
 	}
 	void render(sys::state& state, int32_t x, int32_t y) noexcept override {
 		if(visible)

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -2083,7 +2083,7 @@ void make_sea_path(
 	float shift_x,
 	float shift_y
 ) {
-	auto path = province::make_naval_path(state, origin, target);
+	auto path = province::make_unowned_naval_path(state, origin, target);
 	float distance = 0.0f;
 
 	auto shift = glm::vec2(shift_x, shift_y) / glm::vec2(size_x, size_y);

--- a/src/map/map_state.cpp
+++ b/src/map/map_state.cpp
@@ -178,7 +178,7 @@ void update_trade_flow_arrows(sys::state& state, display_data& map_data) {
 			auto coast_origin = province::state_get_coastal_capital(state, s_origin);
 			auto coast_target = province::state_get_coastal_capital(state, s_target);
 
-			auto path = province::make_naval_path(state, coast_origin, coast_target);
+			auto path = province::make_unowned_naval_path(state, coast_origin, coast_target);
 			auto start = coast_origin;
 			for(int i = int(path.size()) - 1; i >= 0; i--) {
 				auto end = path[i];

--- a/src/military/military.cpp
+++ b/src/military/military.cpp
@@ -7917,7 +7917,11 @@ void update_movement(sys::state& state) {
 					a.set_navy_from_army_transport(to_navy);
 					a.set_black_flag(false);
 				} else {
+					// if there are not enough transports by the time the movement happens, eject them back to land and check for enemy armies to collide with
 					path.clear();
+					a.set_arrival_time(sys::date{ });
+					a.set_is_retreating(false);
+					army_arrives_in_province(state, a, from, military::crossing_type::sea, dcon::land_battle_id{});
 				}
 				a.set_unused_travel_days(0.0f);
 			} else { // land province

--- a/src/military/military.cpp
+++ b/src/military/military.cpp
@@ -8439,17 +8439,16 @@ void update_siege_progress(sys::state& state) {
 				province to its owner's control without the owner participating, you get +2.5 relations with the owner.
 				*/
 
-				// if siege won from rebels : treat as rebel defeat
-				// commented out militancy reduction as this already happens when the rebel units are destroyed, and shouldn't fire on re-occupation
+				// if siege won from rebels : divide by reduction_after_reoccupation define
 				auto old_rf = state.world.province_get_rebel_faction_from_province_rebel_control(prov);
-				//if(old_rf) {
-				//	for(auto pop : state.world.province_get_pop_location(prov)) {
-				//		//if(pop.get_pop().get_rebel_faction_from_pop_rebellion_membership() == old_rf) {
-				//		auto mil = pop_demographics::get_militancy(state, pop.get_pop()) / state.defines.reduction_after_defeat;
-				//		pop_demographics::set_militancy(state, pop.get_pop().id, mil);
-				//		//}
-				//	}
-				//}
+				if(old_rf) {
+					for(auto pop : state.world.province_get_pop_location(prov)) {
+						if(pop.get_pop().get_rebel_faction_from_pop_rebellion_membership() == old_rf) {
+							auto mil = pop_demographics::get_militancy(state, pop.get_pop()) / state.defines.alice_rebel_reduction_after_reoccupation;
+							pop_demographics::set_militancy(state, pop.get_pop().id, mil);
+						}
+					}
+				}
 
 				state.world.province_set_former_controller(prov, controller);
 				state.world.province_set_former_rebel_controller(prov, old_rf);

--- a/src/military/military.hpp
+++ b/src/military/military.hpp
@@ -305,6 +305,7 @@ dcon::unit_type_id get_best_transport(sys::state& state, dcon::nation_id n, bool
 dcon::unit_type_id get_best_light_ship(sys::state& state, dcon::nation_id n, bool primary_culture = false, bool evaluate_shortages = true);
 dcon::unit_type_id get_best_big_ship(sys::state& state, dcon::nation_id n, bool primary_culture = false, bool evaluate_shortages = true);
 
+bool are_enemies(sys::state const& state, dcon::nation_id a, dcon::nation_id b);
 bool are_at_war(sys::state const& state, dcon::nation_id a, dcon::nation_id b);
 bool are_allied_in_war(sys::state const& state, dcon::nation_id a, dcon::nation_id b);
 bool are_in_common_war(sys::state const& state, dcon::nation_id a, dcon::nation_id b);

--- a/src/nations/nations.cpp
+++ b/src/nations/nations.cpp
@@ -213,7 +213,7 @@ void recalculate_markets_distance(sys::state& state) {
 
 				auto speed = std::max(1.f, std::max(stats_0.maximum_speed, stats_1.maximum_speed));
 
-				path = province::make_naval_path(state, coast_0, coast_1);
+				path = province::make_unowned_naval_path(state, coast_0, coast_1);
 				p_prev = coast_0;
 
 				auto ps = path.size();
@@ -470,7 +470,7 @@ void generate_sea_trade_routes(sys::state& state) {
 				std::vector<dcon::province_id> path{ };
 				auto speed = base_speed;
 				dcon::province_id p_prev{ };
-				path = province::make_naval_path(state, coast_0, coast_1);
+				path = province::make_unowned_naval_path(state, coast_0, coast_1);
 				p_prev = coast_0;
 
 				auto ps = path.size();

--- a/src/parsing/defines.hpp
+++ b/src/parsing/defines.hpp
@@ -756,6 +756,7 @@
 	LUA_DEFINES_LIST_ELEMENT(alice_army_marching_hours_per_day, 5.0) \
 	LUA_DEFINES_LIST_ELEMENT(alice_navy_sailing_hours_per_day, 20.0) \
 	LUA_DEFINES_LIST_ELEMENT(alice_fort_siege_slowdown, 0.75) \
+	LUA_DEFINES_LIST_ELEMENT(alice_rebel_reduction_after_reoccupation, 7.0) \
 
 // scales the needs values so that they are needs per this many pops
 // this value was arrived at by looking at farmers: 40'000 farmers produces enough grain to satisfy about 2/3

--- a/src/parsing/defines.hpp
+++ b/src/parsing/defines.hpp
@@ -755,6 +755,7 @@
 	LUA_DEFINES_LIST_ELEMENT(alice_attrition_war_exhaustion, 1.5) \
 	LUA_DEFINES_LIST_ELEMENT(alice_army_marching_hours_per_day, 5.0) \
 	LUA_DEFINES_LIST_ELEMENT(alice_navy_sailing_hours_per_day, 20.0) \
+	LUA_DEFINES_LIST_ELEMENT(alice_fort_siege_slowdown, 0.75) \
 
 // scales the needs values so that they are needs per this many pops
 // this value was arrived at by looking at farmers: 40'000 farmers produces enough grain to satisfy about 2/3

--- a/src/parsing/parser_defs.txt
+++ b/src/parsing/parser_defs.txt
@@ -246,6 +246,7 @@ modifier_base
 	farmers_savings              value      float            member_fn
 	disallow_naval_trade              value      float            member_fn
 	disallow_land_trade              value      float            member_fn
+	fort_level 						value       float 			 member_fn
 
 religion_def
 	nation_modifier group     modifier_base    member_fn
@@ -271,7 +272,6 @@ building_definition
 	visibility           value    none              discard
 	onmap                value    none              discard
 	province             value    none              discard
-	fort_level           value    none              discard
 	pop_build_factory    value    none              discard
 	spawn_railway_track  value    none              discard
 	strategic_factory    value    none              discard

--- a/src/parsing/parsers_declarations.hpp
+++ b/src/parsing/parsers_declarations.hpp
@@ -627,6 +627,7 @@ public:
 	MOD_NAT_FUNCTION(max_tariff)
 	MOD_NAT_FUNCTION(ruling_party_support)
 	MOD_PROV_FUNCTION(local_ruling_party_support)
+	MOD_PROV_FUNCTION(fort_level)
 	MOD_NAT_FUNCTION(rich_vote)
 	MOD_NAT_FUNCTION(middle_vote)
 	MOD_NAT_FUNCTION(poor_vote)

--- a/src/provinces/province.cpp
+++ b/src/provinces/province.cpp
@@ -1465,7 +1465,6 @@ bool is_strait_blocked(sys::state& state, dcon::nation_id thisnation, dcon::prov
 
 bool is_strait_blocked(sys::state& state, dcon::nation_id thisnation, dcon::province_adjacency_id adjacency) {
 	auto path_bits = state.world.province_adjacency_get_type(adjacency);
-	assert((state.world.province_adjacency_get_type(adjacency) & province::border::non_adjacent_bit) != 0);
  	auto strait_prov = state.world.province_adjacency_get_canal_or_blockade_province(adjacency);
 	if(strait_prov) { // strait crossing
 		if(military::province_has_enemy_fleet(state, strait_prov, thisnation)) {

--- a/src/provinces/province.cpp
+++ b/src/provinces/province.cpp
@@ -1464,6 +1464,9 @@ bool is_strait_blocked(sys::state& state, dcon::nation_id thisnation, dcon::prov
 }
 
 bool is_strait_blocked(sys::state& state, dcon::nation_id thisnation, dcon::province_adjacency_id adjacency) {
+	// assert both provinces are land
+	assert(state.world.province_adjacency_get_connected_provinces(adjacency, 0).index() < state.province_definitions.first_sea_province.index());
+	assert(state.world.province_adjacency_get_connected_provinces(adjacency, 1).index() < state.province_definitions.first_sea_province.index());
 	auto path_bits = state.world.province_adjacency_get_type(adjacency);
  	auto strait_prov = state.world.province_adjacency_get_canal_or_blockade_province(adjacency);
 	if(strait_prov) { // strait crossing
@@ -1475,6 +1478,9 @@ bool is_strait_blocked(sys::state& state, dcon::nation_id thisnation, dcon::prov
 }
 
 bool is_canal_adjacency_passable(sys::state& state, dcon::nation_id thisnation, dcon::province_adjacency_id adj) {
+	// assert both provinces are sea
+	assert(state.world.province_adjacency_get_connected_provinces(adj ,0).index() >= state.province_definitions.first_sea_province.index());
+	assert(state.world.province_adjacency_get_connected_provinces(adj, 1).index() >= state.province_definitions.first_sea_province.index());
 	auto canal_prov = state.world.province_adjacency_get_canal_or_blockade_province(adj);
 	if(bool(canal_prov)) {
 		auto canal_controller = state.world.province_get_nation_from_province_control(canal_prov);
@@ -1491,8 +1497,6 @@ bool is_adjacency_impassable(sys::state& state, dcon::nation_id thisnation, dcon
 	if((state.world.province_adjacency_get_type(adj) & province::border::impassible_bit) != 0) {
 		return true;
 	}
-	auto prov_a = state.world.province_adjacency_get_connected_provinces(adj, 0);
-	auto prov_b = state.world.province_adjacency_get_connected_provinces(adj, 1);
 	// if non_adjacent bit is set, check for potential strait or canal blocking
 	if((state.world.province_adjacency_get_type(adj) & province::border::non_adjacent_bit) != 0) {
 		auto blocking_prov = state.world.province_adjacency_get_canal_or_blockade_province(adj);

--- a/src/provinces/province.hpp
+++ b/src/provinces/province.hpp
@@ -82,6 +82,8 @@ float revolt_risk(sys::state& state, dcon::province_id id);
 void change_province_owner(sys::state& state, dcon::province_id id, dcon::nation_id new_owner);
 bool is_strait_blocked(sys::state& state, dcon::nation_id thisnation, dcon::province_id from, dcon::province_id to);
 bool is_strait_blocked(sys::state& state, dcon::nation_id thisnation, dcon::province_adjacency_id adjacency);
+bool is_adjacency_impassable(sys::state& state, dcon::nation_id thisnation, dcon::province_adjacency_id adj);
+bool is_canal_adjacency_passable(sys::state& state, dcon::nation_id thisnation, dcon::province_adjacency_id adj);
 void conquer_province(sys::state& state, dcon::province_id id, dcon::nation_id new_owner);
 
 void update_crimes(sys::state& state);
@@ -114,7 +116,7 @@ float direct_distance(sys::state& state, dcon::province_id a, dcon::province_id 
 float direct_distance_km(sys::state& state, dcon::province_id a, dcon::province_id b);
 
 // naval range distance between a port and a sea province. Must take the distance of a naval path instead of direct distance
-naval_range_data naval_range_distance(sys::state& state, dcon::province_id port_prov, dcon::province_id sea_prov);
+naval_range_data naval_range_distance(sys::state& state, dcon::province_id port_prov, dcon::province_id sea_prov, dcon::nation_id nation_as);
 // sorting distance returns values such that a smaller sorting distance between two provinces
 // means that they are closer, but does not translate 1 to 1 to actual distances (i.e. is the negative dot product)
 float sorting_distance(sys::state& state, dcon::province_id a, dcon::province_id b);
@@ -139,7 +141,9 @@ std::vector<dcon::province_id> make_unowned_path(sys::state& state, dcon::provin
 // used for rebel unit and black-flagged unit pathfinding
 std::vector<dcon::province_id> make_unowned_land_path(sys::state& state, dcon::province_id start, dcon::province_id end);
 // naval unit pathfinding; start and end provinces may be land provinces; function assumes you have naval access to both
-std::vector<dcon::province_id> make_naval_path(sys::state& state, dcon::province_id start, dcon::province_id end);
+std::vector<dcon::province_id> make_naval_path(sys::state& state, dcon::province_id start, dcon::province_id end, dcon::nation_id nation_as);
+//for sea trade routes
+std::vector<dcon::province_id> make_unowned_naval_path(sys::state& state, dcon::province_id start, dcon::province_id end);
 
 std::vector<dcon::province_id> make_naval_retreat_path(sys::state& state, dcon::nation_id nation_as, dcon::province_id start);
 std::vector<dcon::province_id> make_land_retreat_path(sys::state& state, dcon::nation_id nation_as, dcon::province_id start);

--- a/src/provinces/province.hpp
+++ b/src/provinces/province.hpp
@@ -71,6 +71,8 @@ bool state_is_coastal(sys::state& state, dcon::state_instance_id s);
 bool state_is_coastal_non_core_nb(sys::state& state, dcon::state_instance_id s);
 bool state_borders_nation(sys::state& state, dcon::nation_id n, dcon::state_instance_id si);
 
+float get_province_modifier_without_hostile_buildings(sys::state& state, dcon::nation_id as_nation, dcon::province_id prov, dcon::provincial_modifier_value prov_mod_val);
+
 dcon::province_id pick_capital(sys::state& state, dcon::nation_id n);
 
 float state_admin_efficiency(sys::state& state, dcon::state_instance_id id);

--- a/src/provinces/province_templates.hpp
+++ b/src/provinces/province_templates.hpp
@@ -45,4 +45,13 @@ void for_each_province_in_state_instance(sys::state& state, dcon::state_instance
 		}
 	}
 }
+
+template<typename F>
+void for_each_province_building(sys::state& state, F const& function) {
+	for(auto t = economy::province_building_type::railroad; t != economy::province_building_type::last; t = economy::province_building_type(uint8_t(t) + 1)) {
+		function(t);
+	}
+}
+
+
 } // namespace province


### PR DESCRIPTION
- Makes canals controlled by an enemy nation (at war with) not enterable by one's ships. This does not affect trade route pathing currently, so trade route paths make an "unowned" naval path instead. This is mainly due to my inexeperience with the trade code, and not being sure if it would be balanced.

- Changed the effects of fort (province siege speed, defence bonus) to be depentent on the "fort_level" modifier instead of the raw building level. This allows for other modifiers to add "fort_level" to provinces aswell instead of only the fort building.

- Changed movement_cost modifiers in unit speed calculations to only include modifier effects from province buildings if not controlled by a hostile nation. If it is controlled by hostile, province building modifiers are subtracted (mainly for not being able to benefit from railroad speed bonus in enemy territory)

- Changed the fort effect on siege speed to be a linear equation, instead of using a fixed siege table. This leads to a more natural progression in fort bonuses, as before the first fort would provide a massive boost, while the later levels provided considerably less.

Fixed minor bug with the small unit counter attrition icon.
- 