### PR TITLE
Multi-player player cache

### DIFF
--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -5804,6 +5804,11 @@ void execute_notify_start_game(sys::state& state, dcon::nation_id source) {
 	game_scene::switch_scene(state, game_scene::scene_id::in_game_basic);
 	state.map_state.set_selected_province(dcon::province_id{});
 	state.map_state.unhandled_province_selection = true;
+
+	auto cache = sys::player_data{};
+	cache.nation = state.local_player_nation;
+	state.player_data_cache.push_back(cache);
+
 	state.ui_lock.unlock();
 }
 

--- a/src/gamestate/serialization.cpp
+++ b/src/gamestate/serialization.cpp
@@ -702,7 +702,7 @@ uint8_t const* read_save_section(uint8_t const* ptr_in, uint8_t const* section_e
 	ptr_in = deserialize(ptr_in, state.pending_p_event);
 	ptr_in = deserialize(ptr_in, state.pending_f_p_event);
 	ptr_in = memcpy_deserialize(ptr_in, state.pending_messages);
-	ptr_in = memcpy_deserialize(ptr_in, state.player_data_cache);
+	ptr_in = deserialize(ptr_in, state.player_data_cache);
 	ptr_in = deserialize(ptr_in, state.future_n_event);
 	ptr_in = deserialize(ptr_in, state.future_p_event);
 
@@ -755,7 +755,7 @@ uint8_t* write_save_section(uint8_t* ptr_in, sys::state& state) {
 	ptr_in = serialize(ptr_in, state.pending_p_event);
 	ptr_in = serialize(ptr_in, state.pending_f_p_event);
 	ptr_in = memcpy_serialize(ptr_in, state.pending_messages);
-	ptr_in = memcpy_serialize(ptr_in, state.player_data_cache);
+	ptr_in = serialize(ptr_in, state.player_data_cache);
 	ptr_in = serialize(ptr_in, state.future_n_event);
 	ptr_in = serialize(ptr_in, state.future_p_event);
 
@@ -802,7 +802,7 @@ size_t sizeof_save_section(sys::state& state) {
 	sz += serialize_size(state.pending_p_event);
 	sz += serialize_size(state.pending_f_p_event);
 	sz += sizeof(state.pending_messages);
-	sz += sizeof(state.player_data_cache);
+	sz += serialize_size(state.player_data_cache);
 	sz += serialize_size(state.future_n_event);
 	sz += serialize_size(state.future_p_event);
 

--- a/src/gamestate/system_state.cpp
+++ b/src/gamestate/system_state.cpp
@@ -4544,11 +4544,24 @@ void state::single_game_tick() {
 	}
 
 	/*
-	 * END OF DAY: update cached data
-	 */
+	* END OF DAY: update cached data
+	*/
 
-	player_data_cache.treasury_record[current_date.value % 32] = nations::get_treasury(*this, local_player_nation);
-	player_data_cache.population_record[current_date.value % 32] = world.nation_get_demographics(local_player_nation, demographics::total);
+	for(auto n : world.in_nation) {
+		if(!n.get_is_player_controlled())
+			continue;
+
+		if(!find_player_data_cache(n)) {
+			auto cache = sys::player_data{};
+			cache.nation = n;
+			player_data_cache.push_back(cache);
+		}
+		if(auto* cache = find_player_data_cache(n)) {
+			(*cache).treasury_record[current_date.value % 32] = nations::get_treasury(*this, n);
+			(*cache).population_record[current_date.value % 32] = world.nation_get_demographics(n, demographics::total);
+		}
+	}
+	
 	if((current_date.value % 16) == 0) {
 		auto index = economy::most_recent_price_record_index(*this);
 		for(auto c : world.in_commodity) {

--- a/src/gamestate/system_state.hpp
+++ b/src/gamestate/system_state.hpp
@@ -471,6 +471,7 @@ struct state_selection_data {
 };
 
 struct player_data { // currently this data is serialized via memcpy, to make sure no pointers end up in here
+	dcon::nation_id nation;
 	std::array<float, 32> treasury_record = {0.0f}; // current day's value = date.value & 31
 	std::array<float, 32> population_record = { 0.0f }; // current day's value = date.value & 31
 };
@@ -601,7 +602,15 @@ struct alignas(64) state {
 	sys::date ui_date = sys::date{0};
 	uint32_t game_seed = 0; // do *not* alter this value, ever
 	float inflation = 0.999f; // to compensate for some of money generation which will happen anyway
-	player_data player_data_cache;
+	std::vector<player_data> player_data_cache;
+	player_data* find_player_data_cache(dcon::nation_id n) {
+		for(auto& c : player_data_cache) {
+			if(c.nation == n)
+				return &c;
+		}
+
+		return nullptr;
+	}
 	std::vector<dcon::army_id> selected_armies;
 	std::vector<dcon::regiment_id> selected_regiments; // selected regiments inside the army
 

--- a/src/gui/gui_topbar.hpp
+++ b/src/gui/gui_topbar.hpp
@@ -166,11 +166,14 @@ public:
 
 	void on_update(sys::state& state) noexcept override {
 		std::vector<float> datapoints(size_t(32));
-		for(size_t i = 0; i < state.player_data_cache.treasury_record.size(); ++i)
-			datapoints[i] = state.player_data_cache.treasury_record[(state.ui_date.value + 1 + i) % 32] - state.player_data_cache.treasury_record[(state.ui_date.value + 0 + i) % 32];
-		datapoints[datapoints.size() - 1] = state.player_data_cache.treasury_record[(state.ui_date.value + 1 + 31) % 32] - state.player_data_cache.treasury_record[(state.ui_date.value + 0 + 31) % 32];
-		datapoints[0] = datapoints[1]; // otherwise you will store the difference between two non-consecutive days here
-		set_data_points(state, datapoints);
+
+		if(auto* cache = state.find_player_data_cache(state.local_player_nation)) {
+			for(size_t i = 0; i < (*cache).treasury_record.size(); ++i)
+				datapoints[i] = (*cache).treasury_record[(state.ui_date.value + 1 + i) % 32] - (*cache).treasury_record[(state.ui_date.value + 0 + i) % 32];
+			datapoints[datapoints.size() - 1] = (*cache).treasury_record[(state.ui_date.value + 1 + 31) % 32] - (*cache).treasury_record[(state.ui_date.value + 0 + 31) % 32];
+			datapoints[0] = datapoints[1]; // otherwise you will store the difference between two non-consecutive days here
+			set_data_points(state, datapoints);
+		}
 	}
 };
 
@@ -252,26 +255,28 @@ public:
 		auto n = retrieve<dcon::nation_id>(state, parent);
 		auto total_pop = state.world.nation_get_demographics(n, demographics::total);
 
-		auto pop_amount = state.player_data_cache.population_record[state.ui_date.value % 32];
-		auto pop_change = state.ui_date.value <= 32
-			? (state.ui_date.value <= 2 ? 0.0f : pop_amount - state.player_data_cache.population_record[2])
-			: (pop_amount - state.player_data_cache.population_record[(state.ui_date.value - 30) % 32]);
+		if(auto* cache = state.find_player_data_cache(state.local_player_nation)) {
+			auto pop_amount = (*cache).population_record[state.ui_date.value % 32];
+			auto pop_change = state.ui_date.value <= 32
+				? (state.ui_date.value <= 2 ? 0.0f : pop_amount - (*cache).population_record[2])
+				: (pop_amount - (*cache).population_record[(state.ui_date.value - 30) % 32]);
 
-		text::text_color color = pop_change < 0 ?  text::text_color::red : text::text_color::green;
-		if(pop_change == 0)
-			color = text::text_color::white;
+			text::text_color color = pop_change < 0 ? text::text_color::red : text::text_color::green;
+			if(pop_change == 0)
+				color = text::text_color::white;
 
-		auto layout = text::create_endless_layout(state, internal_layout,
-		text::layout_parameters{0, 0, int16_t(base_data.size.x), int16_t(base_data.size.y), base_data.data.text.font_handle, 0, text::alignment::left, text::text_color::black, false});
-		auto box = text::open_layout_box(layout, 0);
-		text::add_to_layout_box(state, layout, box, text::prettify(int32_t(total_pop)));
-		text::add_to_layout_box(state, layout, box, std::string(" ("));
-		if(pop_change > 0) {
-			text::add_to_layout_box(state, layout, box, std::string("+"), text::text_color::green);
+			auto layout = text::create_endless_layout(state, internal_layout,
+			text::layout_parameters{ 0, 0, int16_t(base_data.size.x), int16_t(base_data.size.y), base_data.data.text.font_handle, 0, text::alignment::left, text::text_color::black, false });
+			auto box = text::open_layout_box(layout, 0);
+			text::add_to_layout_box(state, layout, box, text::prettify(int32_t(total_pop)));
+			text::add_to_layout_box(state, layout, box, std::string(" ("));
+			if(pop_change > 0) {
+				text::add_to_layout_box(state, layout, box, std::string("+"), text::text_color::green);
+			}
+			text::add_to_layout_box(state, layout, box, text::pretty_integer{ int64_t(pop_change) }, color);
+			text::add_to_layout_box(state, layout, box, std::string(")"));
+			text::close_layout_box(layout, box);
 		}
-		text::add_to_layout_box(state, layout, box, text::pretty_integer{int64_t(pop_change)}, color);
-		text::add_to_layout_box(state, layout, box, std::string(")"));
-		text::close_layout_box(layout, box);
 	}
 	tooltip_behavior has_tooltip(sys::state& state) noexcept override {
 		return tooltip_behavior::variable_tooltip;
@@ -280,15 +285,17 @@ public:
 
 		auto nation_id = retrieve<dcon::nation_id>(state, parent);
 
-		auto pop_amount = state.player_data_cache.population_record[state.ui_date.value % 32];
-		auto pop_change = state.ui_date.value <= 30 ? 0.0f : (pop_amount - state.player_data_cache.population_record[(state.ui_date.value - 30) % 32]);
+		if(auto* cache = state.find_player_data_cache(state.local_player_nation)) {
+			auto pop_amount = (*cache).population_record[state.ui_date.value % 32];
+			auto pop_change = state.ui_date.value <= 30 ? 0.0f : (pop_amount - (*cache).population_record[(state.ui_date.value - 30) % 32]);
 
-		text::add_line(state, contents, "pop_growth_topbar_3", text::variable_type::curr, text::pretty_integer{ int64_t(state.world.nation_get_demographics(nation_id, demographics::total)) });
-		text::add_line(state, contents, "pop_growth_topbar_2", text::variable_type::x, text::pretty_integer{ int64_t(pop_change) });
-		text::add_line(state, contents, "pop_growth_topbar", text::variable_type::x, text::pretty_integer{ int64_t(nations::get_monthly_pop_increase_of_nation(state, nation_id)) });
-		text::add_line(state, contents, "pop_growth_topbar_4", text::variable_type::val, text::pretty_integer{ int64_t(state.world.nation_get_demographics(nation_id, demographics::total) * 4) });
+			text::add_line(state, contents, "pop_growth_topbar_3", text::variable_type::curr, text::pretty_integer{ int64_t(state.world.nation_get_demographics(nation_id, demographics::total)) });
+			text::add_line(state, contents, "pop_growth_topbar_2", text::variable_type::x, text::pretty_integer{ int64_t(pop_change) });
+			text::add_line(state, contents, "pop_growth_topbar", text::variable_type::x, text::pretty_integer{ int64_t(nations::get_monthly_pop_increase_of_nation(state, nation_id)) });
+			text::add_line(state, contents, "pop_growth_topbar_4", text::variable_type::val, text::pretty_integer{ int64_t(state.world.nation_get_demographics(nation_id, demographics::total) * 4) });
 
-		text::add_line_break_to_layout(state, contents);
+			text::add_line_break_to_layout(state, contents);
+		}
 
 		active_modifiers_description(state, contents, nation_id, 0, sys::national_mod_offsets::pop_growth, true);
 	}
@@ -304,23 +311,25 @@ public:
 		text::layout_parameters{ 0, 0, int16_t(base_data.size.x), int16_t(base_data.size.y), base_data.data.text.font_handle, 0, text::alignment::center, text::text_color::black, false });
 		auto box = text::open_layout_box(layout, 0);
 
-		auto current_day_record = state.player_data_cache.treasury_record[state.ui_date.value % 32];
-		auto previous_day_record = state.player_data_cache.treasury_record[(state.ui_date.value + 31) % 32];
-		auto change = current_day_record - previous_day_record;
+		if(auto* cache = state.find_player_data_cache(state.local_player_nation)) {
+			auto current_day_record = (*cache).treasury_record[state.ui_date.value % 32];
+			auto previous_day_record = (*cache).treasury_record[(state.ui_date.value + 31) % 32];
+			auto change = current_day_record - previous_day_record;
 
-		text::add_to_layout_box(state, layout, box, text::prettify_currency(nations::get_treasury(state, n)));
-		text::add_to_layout_box(state, layout, box, std::string(" ("));
-		if(change > 0) {
-			text::add_to_layout_box(state, layout, box, std::string("+"), text::text_color::green);
-			text::add_to_layout_box(state, layout, box, text::prettify_currency( change ), text::text_color::green);
-		} else if(change == 0) {
-			text::add_to_layout_box(state, layout, box, text::prettify_currency( change ), text::text_color::white);
-		} else {
-			text::add_to_layout_box(state, layout, box, text::prettify_currency(change), text::text_color::red);
+			text::add_to_layout_box(state, layout, box, text::prettify_currency(nations::get_treasury(state, n)));
+			text::add_to_layout_box(state, layout, box, std::string(" ("));
+			if(change > 0) {
+				text::add_to_layout_box(state, layout, box, std::string("+"), text::text_color::green);
+				text::add_to_layout_box(state, layout, box, text::prettify_currency(change), text::text_color::green);
+			} else if(change == 0) {
+				text::add_to_layout_box(state, layout, box, text::prettify_currency(change), text::text_color::white);
+			} else {
+				text::add_to_layout_box(state, layout, box, text::prettify_currency(change), text::text_color::red);
+			}
+			text::add_to_layout_box(state, layout, box, std::string(")"));
 		}
-		text::add_to_layout_box(state, layout, box, std::string(")"));
-
 		text::close_layout_box(layout, box);
+
 	}
 
 	tooltip_behavior has_tooltip(sys::state& state) noexcept override {


### PR DESCRIPTION
Store player cache variables for all played nations so on resync (when the host sends the savegame to clients) they keep the history of treasury and population.