### PR TITLE
Various crisis fixes

### DIFF
--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -5227,6 +5227,8 @@ void execute_crisis_add_wargoal(sys::state& state, dcon::nation_id source, new_w
 		data.cb_state, // state;
 		data.cb_type // cb
 	});
+	auto infamy = military::crisis_cb_addition_infamy_cost(state, data.cb_type, source, data.target, data.cb_state);
+	state.world.nation_set_infamy(source, state.world.nation_get_infamy(source) + infamy);
 
 	auto& current_diplo = state.world.nation_get_diplomatic_points(source);
 	state.world.nation_set_diplomatic_points(source, current_diplo - 1.0f);

--- a/src/gui/topbar_subwindows/diplomacy_subwindows/gui_crisis_window.hpp
+++ b/src/gui/topbar_subwindows/diplomacy_subwindows/gui_crisis_window.hpp
@@ -313,7 +313,7 @@ public:
 
 class crisis_add_wargoal_window : public window_element_base {
 private:
-	wargoal_offer_setup_window* wargoal_setup_win = nullptr;
+	wargoal_offer_setup_window<true>* wargoal_setup_win = nullptr;
 	wargoal_offer_country_select_window* wargoal_country_win = nullptr;
 	wargoal_target_country_select_window* wargoal_target_win = nullptr;
 
@@ -467,7 +467,7 @@ public:
 			return make_element_by_type<invisible_element>(state, id);
 		} else if(name == "wargoal_country_select") {
 			{
-				auto ptr = make_element_by_type<wargoal_offer_setup_window>(state, id);
+				auto ptr = make_element_by_type<wargoal_offer_setup_window<true>>(state, id);
 				wargoal_setup_win = ptr.get();
 				ptr->set_visible(state, false);
 				add_child_to_front(std::move(ptr));
@@ -812,7 +812,7 @@ class diplomacy_crisis_subtitle_text : public simple_text_element_base {
 public:
 	void on_update(sys::state& state) noexcept override {
 		auto first_wg = state.crisis_attacker_wargoals.at(0);
-		if (first_wg.cb == state.military_definitions.liberate) {
+		if (first_wg.cb == state.military_definitions.crisis_liberate) {
 			text::substitution_map m;
 			text::add_to_substitution_map(m, text::variable_type::country, first_wg.wg_tag);
 			if(state.world.nation_get_owned_province_count(state.world.national_identity_get_nation_from_identity_holder(first_wg.wg_tag)) > 0) {

--- a/src/gui/topbar_subwindows/diplomacy_subwindows/gui_pick_wargoal_window.hpp
+++ b/src/gui/topbar_subwindows/diplomacy_subwindows/gui_pick_wargoal_window.hpp
@@ -32,6 +32,18 @@ public:
 	}
 };
 
+
+struct get_target {
+	dcon::nation_id n;
+};
+struct get_offer_to {
+	dcon::nation_id n;
+};
+struct set_target {
+	dcon::nation_id n;
+};
+
+template<bool Crisis>
 class wargoal_type_item_button : public tinted_button_element_base {
 public:
 	void button_action(sys::state& state) noexcept override {
@@ -52,18 +64,32 @@ public:
 		set_button_text(state, text::produce_simple_string(state, fat_id.get_name()));
 
 		auto other_cbs = state.world.nation_get_available_cbs(state.local_player_nation);
-		auto can_declare_with_wg = [&]() {
-			if((state.world.cb_type_get_type_bits(content) & military::cb_flag::always) != 0) {
-				return true;
-			}
-			for(auto& fabbed : other_cbs) {
-				if(fabbed.cb_type == content && fabbed.target == target)
+		bool can_use = false;
+		if constexpr(Crisis) {
+			auto crisis_target = retrieve<get_target>(state, parent).n;
+			auto is_crisis = [&]() {
+				auto crisis_target_role = nations::committed_in_crisis_state(state, crisis_target);
+				auto player_role = nations::committed_in_crisis_state(state, state.local_player_nation);
+				return (crisis_target_role != nations::crisis_role::not_involved && player_role != nations::crisis_role::not_involved && crisis_target_role != player_role);
+			};
+			can_use = military::cb_conditions_satisfied(state, state.local_player_nation, crisis_target, content) && is_crisis();
+		}
+		else {
+			auto can_declare_with_wg = [&]() {
+				if((state.world.cb_type_get_type_bits(content) & military::cb_flag::always) != 0) {
 					return true;
-			}
-			return false;
-			}();
-		auto w = military::find_war_between(state, state.local_player_nation, target);
-		bool can_use = military::cb_conditions_satisfied(state, state.local_player_nation, target, content) && (can_declare_with_wg || w);
+				}
+				for(auto& fabbed : other_cbs) {
+					if(fabbed.cb_type == content && fabbed.target == target)
+						return true;
+				}
+				return false;
+				}();
+			auto w = military::find_war_between(state, state.local_player_nation, target);
+			can_use = military::cb_conditions_satisfied(state, state.local_player_nation, target, content) && (can_declare_with_wg || w);
+		}
+
+		
 
 		disabled = !can_use;
 		if(disabled) {
@@ -135,7 +161,7 @@ public:
 		}
 	}
 };
-
+template<bool Crisis>
 class wargoal_type_item : public listbox_row_element_base<dcon::cb_type_id> {
 public:
 	std::unique_ptr<element_base> make_child(sys::state& state, std::string_view name, dcon::gui_def_id id) noexcept override {
@@ -146,7 +172,7 @@ public:
 		} else if(name == "select_goal_invalid") {
 			return make_element_by_type<invisible_element>(state, id);
 		} else if(name == "select_goal") {
-			auto ptr = make_element_by_type<wargoal_type_item_button>(state, id);
+			auto ptr = make_element_by_type<wargoal_type_item_button<Crisis>>(state, id);
 			//ptr->base_data.position.x += 16; // Nudge
 			return ptr;
 		} else {
@@ -155,7 +181,7 @@ public:
 	}
 };
 
-class wargoal_type_listbox : public listbox_element_base<wargoal_type_item, dcon::cb_type_id> {
+class wargoal_type_listbox : public listbox_element_base<wargoal_type_item<false>, dcon::cb_type_id> {
 protected:
 	std::string_view get_row_element_name() override {
 		return "wargoal_item";
@@ -1308,15 +1334,6 @@ public:
 	}
 };
 
-struct get_target {
-	dcon::nation_id n;
-};
-struct get_offer_to {
-	dcon::nation_id n;
-};
-struct set_target {
-	dcon::nation_id n;
-};
 
 class wargoal_offer_description1 : public simple_multiline_body_text {
 public:
@@ -1463,8 +1480,8 @@ public:
 		}
 	}
 };
-
-class wargoal_offer_type_listbox : public listbox_element_base<wargoal_type_item, dcon::cb_type_id> {
+template<bool Crisis>
+class wargoal_offer_type_listbox : public listbox_element_base<wargoal_type_item<Crisis>, dcon::cb_type_id> {
 protected:
 	std::string_view get_row_element_name() override {
 		return "wargoal_item";
@@ -1472,37 +1489,37 @@ protected:
 
 public:
 	void on_update(sys::state& state) noexcept override {
-		row_contents.clear();
+		this->row_contents.clear();
 
-		auto selected_cb = retrieve<dcon::cb_type_id>(state, parent);
+		auto selected_cb = retrieve<dcon::cb_type_id>(state, this->parent);
 		if(selected_cb) {
-			row_contents.push_back(selected_cb);
-			update(state);
+			this->row_contents.push_back(selected_cb);
+			this->update(state);
 			return;
 		}
 
-		dcon::nation_id actor = retrieve<get_offer_to>(state, parent).n;
-		dcon::nation_id content = retrieve<get_target>(state, parent).n;
+		dcon::nation_id actor = retrieve<get_offer_to>(state, this->parent).n;
+		dcon::nation_id content = retrieve<get_target>(state, this->parent).n;
 
 		for(auto cb_type : state.world.in_cb_type) {
 			
 			if(military::cb_conditions_satisfied(state, actor, content, cb_type)) {
 				if((cb_type.get_type_bits() & military::cb_flag::always) != 0)
-					row_contents.push_back(cb_type);
+					this->row_contents.push_back(cb_type);
 				else if((cb_type.get_type_bits() & military::cb_flag::is_not_constructing_cb) == 0)
-					row_contents.push_back(cb_type);
+					this->row_contents.push_back(cb_type);
 			}
 		}
 
-		update(state);
+		this->update(state);
 	}
 };
-
+template<bool Crisis>
 class wargoal_offer_setup_window : public window_element_base {
 public:
 	std::unique_ptr<element_base> make_child(sys::state& state, std::string_view name, dcon::gui_def_id id) noexcept override {
 		if(name == "country_list") {
-			return make_element_by_type<wargoal_offer_type_listbox>(state, id);
+			return make_element_by_type<wargoal_offer_type_listbox<Crisis>>(state, id);
 		} else if(name == "cancel_select") {
 			return make_element_by_type<wargoal_cancel_button>(state, id);
 		} else {
@@ -1627,7 +1644,7 @@ public:
 
 class offer_war_goal_dialog : public window_element_base {
 private:
-	wargoal_offer_setup_window* wargoal_setup_win = nullptr;
+	wargoal_offer_setup_window<true>* wargoal_setup_win = nullptr;
 	wargoal_offer_country_select_window* wargoal_country_win = nullptr;
 	wargoal_target_country_select_window* wargoal_target_win = nullptr;
 
@@ -1760,7 +1777,7 @@ public:
 			return make_element_by_type<invisible_element>(state, id);
 		} else if(name == "wargoal_country_select") {
 			{
-				auto ptr = make_element_by_type<wargoal_offer_setup_window>(state, id);
+				auto ptr = make_element_by_type<wargoal_offer_setup_window<true>>(state, id);
 				wargoal_setup_win = ptr.get();
 				ptr->set_visible(state, false);
 				add_child_to_front(std::move(ptr));

--- a/src/nations/nations.cpp
+++ b/src/nations/nations.cpp
@@ -1880,33 +1880,41 @@ float tax_efficiency(sys::state& state, dcon::nation_id n) {
 	return std::clamp(state.defines.base_country_tax_efficiency + eff_mod, 0.01f, 1.f);
 }
 
-bool is_involved_in_crisis(sys::state const& state, dcon::nation_id n) {
+crisis_role involved_in_crisis_state(sys::state const& state, dcon::nation_id n) {
 	if(n == state.primary_crisis_attacker)
-		return true;
+		return crisis_role::attacker;
 	if(n == state.primary_crisis_defender)
-		return true;
+		return crisis_role::defender;
 	for(auto& par : state.crisis_participants) {
 		if(!par.id)
-			return false;
+			return crisis_role::not_involved;
 		if(par.id == n)
-			return true;
+			return (par.supports_attacker) ? crisis_role::attacker : crisis_role::defender;
 	}
+	return crisis_role::not_involved;
+}
+crisis_role committed_in_crisis_state(sys::state const& state, dcon::nation_id n) {
+	if(n == state.primary_crisis_attacker)
+		return crisis_role::attacker;
+	if(n == state.primary_crisis_defender)
+		return crisis_role::defender;
+	for(auto& par : state.crisis_participants) {
+		if(!par.id)
+			return crisis_role::not_involved;
+		if(par.id == n && !par.merely_interested)
+			return (par.supports_attacker) ? crisis_role::attacker : crisis_role::defender;
+	}
+	return crisis_role::not_involved;
+}
 
-	return false;
-}
 bool is_committed_in_crisis(sys::state const& state, dcon::nation_id n) {
-	if(n == state.primary_crisis_attacker)
-		return true;
-	if(n == state.primary_crisis_defender)
-		return true;
-	for(auto& par : state.crisis_participants) {
-		if(!par.id)
-			return false;
-		if(par.id == n)
-			return !par.merely_interested;
-	}
-	return false;
+	return committed_in_crisis_state(state, n) != crisis_role::not_involved;
 }
+
+bool is_involved_in_crisis(sys::state const& state, dcon::nation_id n) {
+	return involved_in_crisis_state(state, n) != crisis_role::not_involved;
+}
+
 void switch_all_players(sys::state& state, dcon::nation_id new_n, dcon::nation_id old_n) {
 	if(state.network_mode == sys::network_mode_type::single_player) {
 		state.world.nation_set_is_player_controlled(new_n, true);
@@ -3047,6 +3055,10 @@ void add_as_primary_crisis_defender(sys::state& state, dcon::nation_id n) {
 
 void add_as_primary_crisis_attacker(sys::state& state, dcon::nation_id n) {
 	state.primary_crisis_attacker = n;
+	// if it is liberation crisis and the attacker dosen't exist, add the new primary attacker as the owner of the currently added liberation wargoal. Else, if the nation is liberated by agreement, it will not be properly created from a template as no one will own the wargoal
+	if(state.current_crisis == sys::crisis_type::liberation && !state.crisis_attacker) {
+		state.crisis_attacker_wargoals.at(0).added_by = n;
+	}
 
 	notification::post(state, notification::message{
 		[n](sys::state& state, text::layout_base& contents) {
@@ -3514,16 +3526,29 @@ void update_crisis(sys::state& state) {
 			assert(state.crisis_attacker_wargoals.size() > 0);
 
 			auto first_wg = state.crisis_attacker_wargoals.at(0);
-			war = military::create_war(state, state.crisis_attacker,
-						state.crisis_defender,
+
+			// check that the crisis attacker or defender actually exists before creating a war with them. In a liberation crisis, it is possible that the crisis_attacker or crisis_defender will not exist.
+			// If they don't exist, use the primary defender/attacker instead (which is the GP backing their side)
+			auto find_actual_crisis_actor = [&](dcon::nation_id crisis_actor, dcon::nation_id primary_crisis_actor) {
+				if(crisis_actor && state.world.nation_get_owned_province_count(crisis_actor) != 0) {
+					return crisis_actor;
+				} else {
+					return primary_crisis_actor;
+				}
+			};
+			auto actual_defender = find_actual_crisis_actor(state.crisis_defender, state.primary_crisis_defender);
+			auto actual_attacker = find_actual_crisis_actor(state.crisis_attacker, state.primary_crisis_attacker);
+
+			war = military::create_war(state, actual_attacker,
+						actual_defender,
 						first_wg.cb, first_wg.state,
 						first_wg.wg_tag, first_wg.secondary_nation);
 
-			if(state.crisis_attacker != state.primary_crisis_attacker) {
+			if(actual_attacker != state.primary_crisis_attacker) {
 				military::add_to_war(state, war, state.primary_crisis_attacker, true);
 				state.world.war_set_primary_attacker(war, state.primary_crisis_attacker);
 			}
-			if(state.crisis_defender != state.primary_crisis_defender) {
+			if(actual_defender != state.primary_crisis_defender) {
 				military::add_to_war(state, war, state.primary_crisis_defender, false);
 				state.world.war_set_primary_defender(war, state.primary_crisis_defender);
 			}

--- a/src/nations/nations.hpp
+++ b/src/nations/nations.hpp
@@ -74,6 +74,11 @@ enum class war_initiation : bool {
 	join_war,
 	declare_war
 };
+enum class crisis_role : uint8_t {
+	not_involved,
+	attacker,
+	defender
+};
 
 struct global_national_state {
 	std::vector<triggered_modifier> triggered_modifiers;
@@ -337,8 +342,11 @@ int32_t national_focuses_in_use(sys::state& state, dcon::nation_id n);
 bool can_expand_colony(sys::state& state, dcon::nation_id n);
 bool is_losing_colonial_race(sys::state& state, dcon::nation_id n);
 bool sphereing_progress_is_possible(sys::state& state, dcon::nation_id n); // can increase opinion or add to sphere
+crisis_role  involved_in_crisis_state(sys::state const& state, dcon::nation_id n);
+crisis_role committed_in_crisis_state(sys::state const& state, dcon::nation_id n);
 bool is_involved_in_crisis(sys::state const& state, dcon::nation_id n);
 bool is_committed_in_crisis(sys::state const& state, dcon::nation_id n);
+
 void switch_all_players(sys::state& state, dcon::nation_id new_n, dcon::nation_id old_n); // switches all players who are on one country to another. Can be called in either SP or MP
 
 bool has_units_inside_other_nation(sys::state& state, dcon::nation_id nation_a, dcon::nation_id nation_b);


### PR DESCRIPTION
- Fix liberation crisies creating invalid wars if the crisis attacker dosen't exist.
- Properly give the primary attacker ownership of the liberation wargoal in liberation crisies. Otherwise the released nation may end up with a empty template.
- Fix not being able to add wargoals in a crisis
- Fix crisis wargoals not giving infamy when added
- Fix not being able to offer wargoals in crisis to nations on-the-fence