### PR TITLE
Gamerule improvements&hotfix

### DIFF
--- a/assets/alice.gui
+++ b/assets/alice.gui
@@ -278,22 +278,6 @@ guiTypes = {
 				position = { 167 99 }
 				quadTextureSprite = "GFX_checkbox_default"
 			}
-			# Fog of War (Y/N)
-			instantTextBoxType = {
-				name = "fow_label"
-				position = { 78 124 }
-				text = "fow_label"
-				font = "Arial16"
-				borderSize = { 0 0}
-				maxsize = { 236 18 }
-				orientation = "UPPER_LEFT"
-				format = left
-			}
-			checkboxType = {
-				name = "fow_checkbox"
-				position = { 51 123 }
-				quadTextureSprite = "GFX_checkbox_default"
-			}
 			# Dynamic railroads (Y/N)
 			instantTextBoxType = {
 				name = "railroad_label"

--- a/assets/localisation/en-US/alice.csv
+++ b/assets/localisation/en-US/alice.csv
@@ -1780,3 +1780,15 @@ consumption;Consumption
 import;Import
 export;Export
 gva;GVA
+alice_gamerule_allow_partial_retreat;Partial retreating of military units
+alice_gamerule_allow_partial_retreat_desc;Specifes whether to enable armies and navies to retreat out of a battle one at a time. Also known as "cycling"
+alice_gamerule_allow_partial_retreat_opt_disabled;Cannot partial retreat
+alice_gamerule_allow_partial_retreat_opt_enabled;Can partial retreat
+alice_gamerule_fog_of_war;Fog of war
+alice_gamerule_fog_of_war_desc;Specifies whether to enable fog of war (FoW) to obscure vision of neutral/enemy provinces&units
+alice_gamerule_fog_of_war_opt_disabled;Fog of war is OFF
+alice_gamerule_fog_of_war_opt_enabled;Fog of war is ON
+alice_gamerule_auto_concession_peace;Auto-peace when conceding wargoals
+alice_gamerule_auto_concession_peace_desc;Specifies whether a conceding peacedeal (ie one side surrenders to ALL added wargoals, or 100 warscore) will always be accepted no matter what
+alice_gamerule_auto_concession_peace_opt_cannot_reject;Conceding peace offers cannot be rejected
+alice_gamerule_auto_concession_peace_opt_can_reject;Conceding peace offers can be rejected

--- a/src/entry_point_nix.cpp
+++ b/src/entry_point_nix.cpp
@@ -369,10 +369,6 @@ int main (int argc, char *argv[]) {
 	network::init(game_state);
 
 	game_state.load_user_settings();
-	// only load gamerule settings if host or singleplayer. A client would have to load the host' settings anyway
-	if(game_state.network_mode == sys::network_mode_type::host || game_state.network_mode == sys::network_mode_type::single_player) {
-		game_state.load_gamerule_settings();
-	}
 	ui::populate_definitions_map(game_state);
 
 	if(headless) {

--- a/src/entry_point_nix.cpp
+++ b/src/entry_point_nix.cpp
@@ -369,6 +369,10 @@ int main (int argc, char *argv[]) {
 	network::init(game_state);
 
 	game_state.load_user_settings();
+	// only load gamerule settings if host or singleplayer. A client would have to load the host' settings anyway
+	if(game_state.network_mode == sys::network_mode_type::host || game_state.network_mode == sys::network_mode_type::single_player) {
+		game_state.load_gamerule_settings();
+	}
 	ui::populate_definitions_map(game_state);
 
 	if(headless) {

--- a/src/entry_point_win.cpp
+++ b/src/entry_point_win.cpp
@@ -300,10 +300,6 @@ int WINAPI wWinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPWSTR
 
 		// scenario loading functions (would have to run these even when scenario is pre-built)
 		game_state.load_user_settings();
-		// only load gamerule settings if host or singleplayer. A client would have to load the host' settings anyway
-		if(game_state.network_mode == sys::network_mode_type::host || game_state.network_mode == sys::network_mode_type::single_player) {
-			game_state.load_gamerule_settings();
-		}
 		ui::populate_definitions_map(game_state);
 
 		if(game_state.network_mode == sys::network_mode_type::host) {

--- a/src/entry_point_win.cpp
+++ b/src/entry_point_win.cpp
@@ -300,6 +300,10 @@ int WINAPI wWinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPWSTR
 
 		// scenario loading functions (would have to run these even when scenario is pre-built)
 		game_state.load_user_settings();
+		// only load gamerule settings if host or singleplayer. A client would have to load the host' settings anyway
+		if(game_state.network_mode == sys::network_mode_type::host || game_state.network_mode == sys::network_mode_type::single_player) {
+			game_state.load_gamerule_settings();
+		}
 		ui::populate_definitions_map(game_state);
 
 		if(game_state.network_mode == sys::network_mode_type::host) {

--- a/src/filesystem/simple_fs.hpp
+++ b/src/filesystem/simple_fs.hpp
@@ -78,6 +78,7 @@ native_string get_full_name(file const& f);
 // functions that operate outside of a filesystem object
 directory get_or_create_save_game_directory();
 directory get_or_create_templates_directory();
+directory get_or_create_gamerules_directory();
 directory get_or_create_oos_directory();
 directory get_or_create_scenario_directory();
 directory get_or_create_settings_directory();

--- a/src/filesystem/simple_fs_nix.cpp
+++ b/src/filesystem/simple_fs_nix.cpp
@@ -541,6 +541,12 @@ directory get_or_create_templates_directory() {
 
 	return directory(nullptr, path);
 }
+directory get_or_create_templates_directory() {
+	native_string path = native_string(getenv("HOME")) + "/.local/share/Alice/gamerules/";
+	make_directories(path);
+
+	return directory(nullptr, path);
+}
 
 directory get_or_create_oos_directory() {
 	native_string path = native_string(getenv("HOME")) + "/.local/share/Alice/oos/";

--- a/src/filesystem/simple_fs_nix.cpp
+++ b/src/filesystem/simple_fs_nix.cpp
@@ -541,7 +541,7 @@ directory get_or_create_templates_directory() {
 
 	return directory(nullptr, path);
 }
-directory get_or_create_templates_directory() {
+directory get_or_create_gamerules_directory() {
 	native_string path = native_string(getenv("HOME")) + "/.local/share/Alice/gamerules/";
 	make_directories(path);
 

--- a/src/filesystem/simple_fs_win.cpp
+++ b/src/filesystem/simple_fs_win.cpp
@@ -475,6 +475,22 @@ directory get_or_create_templates_directory() {
 	return directory(nullptr, base_path);
 }
 
+directory get_or_create_gamerules_directory() {
+	native_char* local_path_out = nullptr;
+	native_string base_path;
+	if(SHGetKnownFolderPath(FOLDERID_Documents, 0, nullptr, &local_path_out) == S_OK) {
+		base_path = native_string(local_path_out) + NATIVE("\\Project Alice");
+	}
+	CoTaskMemFree(local_path_out);
+	if(base_path.length() > 0) {
+		CreateDirectoryW(base_path.c_str(), nullptr);
+		base_path += NATIVE("\\gamerules");
+		CreateDirectoryW(base_path.c_str(), nullptr);
+	}
+	return directory(nullptr, base_path);
+}
+
+
 directory get_or_create_oos_directory() {
 	native_char* local_path_out = nullptr;
 	native_string base_path;

--- a/src/gamerule/gamerule.cpp
+++ b/src/gamerule/gamerule.cpp
@@ -36,6 +36,9 @@ void restore_gamerule_ui_settings(sys::state& state) {
 	}
 }
 void set_gamerule(sys::state& state, dcon::gamerule_id gamerule, uint8_t new_setting) {
+	if(check_gamerule(state, gamerule, new_setting)) {
+		return;
+	}
 	auto old_setting = state.world.gamerule_get_current_setting(gamerule);
 	auto& options = state.world.gamerule_get_options(gamerule);
 	auto on_deselect_effect = options[old_setting].on_deselect;
@@ -48,6 +51,8 @@ void set_gamerule(sys::state& state, dcon::gamerule_id gamerule, uint8_t new_set
 	}
 	state.world.gamerule_set_current_setting(gamerule, new_setting);
 	state.ui_state.gamerule_ui_settings.insert_or_assign(gamerule, new_setting);
+	// if its being called from somewhere not in a command, set new_game to false
+	state.network_state.is_new_game = false;
 }
 
 

--- a/src/gamerule/gamerule.cpp
+++ b/src/gamerule/gamerule.cpp
@@ -27,6 +27,18 @@ void load_hardcoded_gamerules(parsers::scenario_building_context& context) {
 		std::vector<std::string> options = { "alice_gamerule_allow_sphereling_declare_war_on_spherelord_opt_no", "alice_gamerule_allow_sphereling_declare_war_on_spherelord_opt_yes" };
 		context.state.hardcoded_gamerules.sphereling_can_declare_spherelord = create_hardcoded_gamerule(context, "alice_gamerule_allow_sphereling_declare_war_on_spherelord", options, uint8_t(context.state.defines.alice_can_goto_war_against_spherelord_default_setting));
 	}
+	{
+		std::vector<std::string> options = { "alice_gamerule_allow_partial_retreat_opt_disabled", "alice_gamerule_allow_partial_retreat_opt_enabled" };
+		context.state.hardcoded_gamerules.allow_partial_retreat = create_hardcoded_gamerule(context, "alice_gamerule_allow_partial_retreat", options, uint8_t(context.state.defines.alice_allow_partial_retreat_default_setting));
+	}
+	{
+		std::vector<std::string> options = { "alice_gamerule_fog_of_war_opt_disabled", "alice_gamerule_fog_of_war_opt_enabled" };
+		context.state.hardcoded_gamerules.fog_of_war = create_hardcoded_gamerule(context, "alice_gamerule_fog_of_war", options, uint8_t(context.state.defines.alice_fog_of_war_default_setting));
+	}
+	{
+		std::vector<std::string> options = { "alice_gamerule_auto_concession_peace_opt_cannot_reject", "alice_gamerule_auto_concession_peace_opt_can_reject" };
+		context.state.hardcoded_gamerules.auto_concession_peace = create_hardcoded_gamerule(context, "alice_gamerule_auto_concession_peace", options, uint8_t(context.state.defines.alice_auto_concession_peace_default_setting));
+	}
 }
 
 void restore_gamerule_ui_settings(sys::state& state) {

--- a/src/gamerule/gamerule.hpp
+++ b/src/gamerule/gamerule.hpp
@@ -21,8 +21,26 @@ enum class sphereling_declare_war_settings : uint8_t {
 	yes = 1
 };
 
+enum class partial_retreat_settings : uint8_t {
+	disable = 0,
+	enable = 1
+};
+enum class fog_of_war_settings : uint8_t {
+	disable = 0,
+	enable = 1
+};
+enum class auto_concession_peace_settings : uint8_t {
+	cannot_reject = 0,
+	can_reject = 1
+};
+
+
+
 struct hardcoded_gamerules {
 	dcon::gamerule_id sphereling_can_declare_spherelord;
+	dcon::gamerule_id allow_partial_retreat;
+	dcon::gamerule_id fog_of_war;
+	dcon::gamerule_id auto_concession_peace;
 
 };
 

--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -5507,6 +5507,11 @@ void execute_change_gamerule_setting(sys::state& state, dcon::nation_id source, 
 		auto host_name = sys::player_name{ state.world.mp_player_get_nickname(host) };
 		execute_chat_message(state, host_nation, str, dcon::nation_id{ }, host_name);
 	}
+	// if you are in control of the gamerules (either host, or single player), then save the current gamerules as your default preferances in file
+	if(state.network_mode == sys::network_mode_type::single_player || state.network_mode == sys::network_mode_type::host) {
+
+		state.save_gamerule_settings();
+	}
 	
 }
 

--- a/src/gamestate/serialization.cpp
+++ b/src/gamestate/serialization.cpp
@@ -951,6 +951,11 @@ bool try_read_scenario_and_save_file(sys::state& state, native_string_view name)
 
 		state.on_scenario_load();
 
+		// only load gamerule settings if host or singleplayer. A client would have to load the host' settings anyway
+		if(state.network_mode == sys::network_mode_type::host || state.network_mode == sys::network_mode_type::single_player) {
+			state.load_gamerule_settings();
+		}
+
 		return true;
 	} else {
 		return false;
@@ -993,6 +998,13 @@ bool try_read_scenario_as_save_file(sys::state& state, native_string_view name) 
 			});
 
 		state.game_seed = uint32_t(std::random_device()());
+
+
+		// only load gamerule settings if host or singleplayer. A client would have to load the host' settings anyway
+		if(state.network_mode == sys::network_mode_type::host || state.network_mode == sys::network_mode_type::single_player) {
+			state.load_gamerule_settings();
+		}
+
 
 		return true;
 	} else {

--- a/src/gamestate/system_state.cpp
+++ b/src/gamestate/system_state.cpp
@@ -2026,7 +2026,6 @@ void state::save_user_settings() const {
 	ptr += 98;
 	std::memcpy(ptr, user_settings.other_message_settings, lower_half_count);
 	ptr += 98;
-	US_SAVE(fow_enabled);
 	constexpr size_t upper_half_count = 128 - 98;
 	std::memcpy(ptr, &user_settings.self_message_settings[98], upper_half_count);
 	ptr += upper_half_count;
@@ -2096,7 +2095,6 @@ void state::load_user_settings() {
 			std::memcpy(&user_settings.other_message_settings, ptr, std::min(lower_half_count, size_t(std::max(ptrdiff_t(0), (content.data + content.file_size) - ptr))));
 			ptr += 98;
 
-			US_LOAD(fow_enabled);
 			constexpr size_t upper_half_count = 128 - 98;
 			std::memcpy(&user_settings.self_message_settings[98], ptr, std::min(upper_half_count, size_t(std::max(ptrdiff_t(0), (content.data + content.file_size) - ptr))));
 			ptr += upper_half_count;
@@ -2230,9 +2228,9 @@ void state::load_gamerule_settings() {
 			num_gamerule_settings = 8192 * 4;
 
 		for(uint32_t i = 0; i < num_gamerule_settings; i++) {
+			uint8_t setting = data_ptr[i];
 			dcon::gamerule_id gamerule{ dcon::gamerule_id::value_base_t{ uint8_t(i) } };
-			if(world.gamerule_is_valid(gamerule)) {
-				uint8_t setting = data_ptr[i];
+			if(world.gamerule_is_valid(gamerule) && world.gamerule_get_settings_count(gamerule) > setting) {
 				gamerule::set_gamerule(*this, gamerule, setting);
 			}
 		}

--- a/src/gamestate/system_state.hpp
+++ b/src/gamestate/system_state.hpp
@@ -1029,6 +1029,8 @@ struct alignas(64) state {
 
 	void save_user_settings() const;
 	void load_user_settings();
+	void load_gamerule_settings();
+	void save_gamerule_settings() const;
 	void update_ui_scale(float new_scale);
 
 	void load_scenario_data(parsers::error_handler& err, sys::year_month_day bookmark_date);   // loads all scenario files other than map data

--- a/src/gamestate/system_state.hpp
+++ b/src/gamestate/system_state.hpp
@@ -378,7 +378,6 @@ struct user_settings_s {
 		message_response::ignore,//entered_automatic_alliance = 101,
 		message_response::standard_log,//chat_message = 102,
 	};
-	bool fow_enabled = false;
 	map_label_mode map_label = map_label_mode::quadratic;
 	uint8_t antialias_level = 4;
 	float gaussianblur_level = 1.f;

--- a/src/gui/gui_main_menu.cpp
+++ b/src/gui/gui_main_menu.cpp
@@ -315,19 +315,6 @@ void zoom_speed_scrollbar::on_update(sys::state& state) noexcept {
 	update_raw_value(state, int32_t(state.user_settings.zoom_speed));
 }
 
-void fow_checkbox::on_create(sys::state& state) noexcept {
-	checkbox_button::on_create(state);
-	disabled = (state.network_mode != sys::network_mode_type::single_player);
-}
-bool fow_checkbox::is_active(sys::state& state) noexcept {
-	return state.user_settings.fow_enabled;
-}
-void fow_checkbox::button_action(sys::state& state) noexcept {
-	state.user_settings.fow_enabled = !state.user_settings.fow_enabled;
-	state.map_state.map_data.update_fog_of_war(state);
-	send(state, parent, notify_setting_update{});
-}
-
 bool render_models_checkbox::is_active(sys::state& state) noexcept {
 	return state.user_settings.render_models;
 }

--- a/src/gui/gui_main_menu.hpp
+++ b/src/gui/gui_main_menu.hpp
@@ -168,12 +168,6 @@ class zoom_speed_scrollbar : public scrollbar {
 	void on_update(sys::state& state) noexcept final;
 };
 
-class fow_checkbox : public checkbox_button {
-public:
-	void on_create(sys::state& state) noexcept override;
-	bool is_active(sys::state& state) noexcept override;
-	void button_action(sys::state& state) noexcept override;
-};
 class render_models_checkbox : public checkbox_button {
 public:
 	bool is_active(sys::state& state) noexcept override;
@@ -367,8 +361,6 @@ class options_menu_window : public window_element_base {
 			return make_element_by_type<fonts_mode_checkbox>(state, id);
 		} else if(name == "mouse_left_click_mode_checkbox") {
 			return make_element_by_type<left_mouse_click_mode_checkbox>(state, id);
-		} else if(name == "fow_checkbox") {
-			return make_element_by_type<fow_checkbox>(state, id);
 		} else if(name == "render_models_checkbox") {
 			return make_element_by_type<render_models_checkbox>(state, id);
 		} else if(name == "black_map_font_checkbox") {

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -86,7 +86,7 @@ void display_data::update_fog_of_war(sys::state& state) {
 
 	// update fog of war too
 	std::vector<uint32_t> province_fows(state.world.province_size() + 1, 0xFFFFFFFF);
-	if(state.user_settings.fow_enabled || state.network_mode != sys::network_mode_type::single_player) {
+	if(gamerule::check_gamerule(state, state.hardcoded_gamerules.fog_of_war, uint8_t(gamerule::fog_of_war_settings::enable))) {
 		state.map_state.visible_provinces.clear();
 		state.map_state.visible_provinces.resize(state.world.province_size() + 1, false);
 		for(auto p : direct_provinces) {

--- a/src/map/map_state.cpp
+++ b/src/map/map_state.cpp
@@ -637,7 +637,7 @@ void update_unit_arrows(sys::state& state, display_data& map_data) {
 			return;
 		}
 		// Exclude if out of FOW
-		if(state.user_settings.fow_enabled || state.network_mode != sys::network_mode_type::single_player) {
+		if(gamerule::check_gamerule(state, state.hardcoded_gamerules.fog_of_war, uint8_t(gamerule::fog_of_war_settings::enable))) {
 			auto pc = map_army.get_army_location().get_location().id;
 			if(!state.map_state.visible_provinces[province::to_map_id(pc)]) {
 				continue;
@@ -680,7 +680,7 @@ void update_unit_arrows(sys::state& state, display_data& map_data) {
 			return;
 		}
 		// Exclude if out of FOW
-		if(state.user_settings.fow_enabled || state.network_mode != sys::network_mode_type::single_player) {
+		if(gamerule::check_gamerule(state, state.hardcoded_gamerules.fog_of_war, uint8_t(gamerule::fog_of_war_settings::enable))) {
 			auto pc = map_navy.get_navy_location().get_location().id;
 			if(!state.map_state.visible_provinces[province::to_map_id(pc)]) {
 				continue;

--- a/src/military/military.hpp
+++ b/src/military/military.hpp
@@ -380,6 +380,9 @@ float primary_warscore_from_blockades(sys::state& state, dcon::war_id w);
 // defender
 float directed_warscore(sys::state& state, dcon::war_id w, dcon::nation_id primary, dcon::nation_id secondary);
 
+// Goes though checks to see if the war shall be force peaced when a peaceoffer is sent, and force peaces the war if applicable. Returns true if the war was force-peaced, false if not.
+bool try_force_peace(sys::state& state, dcon::nation_id source, dcon::nation_id target, dcon::war_id in_war, dcon::peace_offer_id pending_offer);
+
 bool is_defender_wargoal(sys::state const& state, dcon::war_id w, dcon::wargoal_id wg);
 
 enum class war_role {

--- a/src/network/network.hpp
+++ b/src/network/network.hpp
@@ -66,6 +66,7 @@ struct client_data {
 	size_t save_stream_offset = 0;
 	size_t save_stream_size = 0;
 	bool handshake = true;
+	bool receiving_payload = false; // flag indicating whether this client is currently awaiting a payload for a command, or if its awaiting a header for a command
 
 	sys::date last_seen;
 
@@ -94,6 +95,7 @@ struct network_state {
 
 	std::unique_ptr<uint8_t[]> current_save_buffer;
 	size_t recv_count = 0;
+	bool receiving_payload = false; // flag indicating whether we are currently awaiting a payload for a command, or if its awaiting a header for a command from the server
 	uint32_t current_save_length = 0;
 	socket_t socket_fd = 0;
 	uint8_t lobby_password[16] = { 0 };

--- a/src/parsing/defines.hpp
+++ b/src/parsing/defines.hpp
@@ -765,6 +765,9 @@
 	LUA_DEFINES_LIST_ELEMENT(alice_military_spending_trigger_div, 1.35) \
 	LUA_DEFINES_LIST_ELEMENT(alice_social_spending_trigger_div, 1.0) \
 	LUA_DEFINES_LIST_ELEMENT(alice_can_goto_war_against_spherelord_default_setting, 1.0) \
+	LUA_DEFINES_LIST_ELEMENT(alice_allow_partial_retreat_default_setting, 1.0) \
+	LUA_DEFINES_LIST_ELEMENT(alice_fog_of_war_default_setting, 1.0) \
+	LUA_DEFINES_LIST_ELEMENT(alice_auto_concession_peace_default_setting, 1.0) \
 	LUA_DEFINES_LIST_ELEMENT(alice_render_on_map_generals, 0.0) \
 
 // scales the needs values so that they are needs per this many pops

--- a/src/provinces/province.cpp
+++ b/src/provinces/province.cpp
@@ -507,6 +507,11 @@ dcon::province_id pick_capital(sys::state& state, dcon::nation_id n) {
 
 void set_province_controller(sys::state& state, dcon::province_id p, dcon::nation_id n) {
 	auto old_con = state.world.province_get_nation_from_province_control(p);
+	auto curr_owner = state.world.province_get_nation_from_province_ownership(p);
+	// don't switch controllership on an uncolonized province
+	if(!curr_owner) {
+		return;
+	}
 	if(old_con != n) {
 		state.world.province_set_last_control_change(p, state.current_date);
 		state.trade_route_cached_values_out_of_date = true;
@@ -537,6 +542,11 @@ void set_province_controller(sys::state& state, dcon::province_id p, dcon::natio
 
 void set_province_controller(sys::state& state, dcon::province_id p, dcon::rebel_faction_id rf) {
 	auto old_con = state.world.province_get_rebel_faction_from_province_rebel_control(p);
+	auto curr_owner = state.world.province_get_nation_from_province_ownership(p);
+	// don't switch controllership on an uncolonized province
+	if(!curr_owner) {
+		return;
+	}
 	if(old_con != rf) {
 		state.world.province_set_last_control_change(p, state.current_date);
 		state.trade_route_cached_values_out_of_date = true;


### PR DESCRIPTION
Adds persistent saving of gamerule settings. Whenever the player as either the host or in singleplayer changes a gamerule, the current gamerules will be saved as the default ones. When the player launches the game, or loads the startdate those gamerules will be loaded again. Proper saves will keep their own gamerule settings when loaded.

Added gamerules for Fog of war, the auto-peace when conceding mechanic and for partial retreats. 

Furthermore fix an oversight in socket_recv_command, and make sure it is keeping track of which part of a command (healer or payload) is being expected inbetween calls. Also minor fix to change_controller, as it was possible for uncolonized land to change controller from some effects (eg GFM)