### PR TITLE
Fix migration mapmode & naval fixes and changes

### DIFF
--- a/assets/localisation/en-US/alice.csv
+++ b/assets/localisation/en-US/alice.csv
@@ -1014,6 +1014,7 @@ col_invest_4;Without competition, you will be able to turn this state into a col
 col_invest_5;It has been $x$ days since your last investment (next investment possible on $y$)
 col_invest_6;You have at least $x$ free colonial points
 activated_by_with_a_chance_of;Activated by ?Y$x$?!, with a chance of:
+activated_by_tech:Activated by technology ?Y$x$?!
 unit_max_speed;Max Speed ?G$x$?! KPH
 unit_attack;Attack ?G$x$
 unit_hull;Hull ?G$x$

--- a/src/common_types/container_types.hpp
+++ b/src/common_types/container_types.hpp
@@ -194,6 +194,18 @@ struct gamerule_hash {
 	}
 };
 
+struct nation_hash {
+	using is_avalanching = void;
+
+	nation_hash() {
+	}
+
+	auto operator()(dcon::nation_id p) const noexcept -> uint64_t {
+		int32_t index = p.index();
+		return ankerl::unordered_dense::hash<int32_t>()(index);
+	}
+};
+
 } // namespace sys
 
 template<typename value_type, typename tag_type, typename allocator = std::allocator<value_type>>

--- a/src/economy/demographics.cpp
+++ b/src/economy/demographics.cpp
@@ -3719,11 +3719,12 @@ void estimate_directed_immigration(sys::state& state, dcon::nation_id n, std::ve
 	auto next_month_start = ymd_date.month != 12 ? sys::year_month_day{ ymd_date.year, uint16_t(ymd_date.month + 1), uint16_t(1) } : sys::year_month_day{ ymd_date.year + 1, uint16_t(1), uint16_t(1) };
 	auto const days_in_month = uint32_t(sys::days_difference(month_start, next_month_start));
 
-	for(auto ids : state.world.in_pop) {
+	concurrency::parallel_for(uint32_t(0), pop_size, [&](uint32_t i) {
+		auto ids = dcon::pop_id{ dcon::pop_id::value_base_t(i) };
 		auto loc = state.world.pop_get_province_from_pop_location(ids);
 		auto owners = state.world.province_get_nation_from_province_ownership(loc);
 
-		auto section = uint64_t(ids.id.index()) / 16;
+		auto section = uint64_t(ids.index()) / 16;
 		auto tranche = int32_t(section / days_in_month);
 		auto day_of_month = tranche - 10;
 		if(day_of_month <= 0)
@@ -3734,15 +3735,17 @@ void estimate_directed_immigration(sys::state& state, dcon::nation_id n, std::ve
 			auto target = impl::get_immigration_target(state, owners, ids, state.current_date + day_adjustment);
 			if(owners == n) {
 				if(target && uint32_t(target.index()) < sz) {
-					national_amounts[uint32_t(target.index())] -= est_amount;
+					std::atomic_ref<float> ref{ national_amounts[uint32_t(target.index())] };
+					ref -= est_amount;
 				}
 			} else if(target == n) {
 				if(uint32_t(owners.index()) < sz) {
-					national_amounts[uint32_t(owners.index())] += est_amount;
+					std::atomic_ref<float> ref{ national_amounts[uint32_t(owners.index())] };
+					ref += est_amount;
 				}
 			}
 		}
-	}
+	});
 }
 
 float get_estimated_emigration(sys::state& state, dcon::pop_id ids) {

--- a/src/economy/demographics.cpp
+++ b/src/economy/demographics.cpp
@@ -3719,6 +3719,8 @@ void estimate_directed_immigration(sys::state& state, dcon::nation_id n, std::ve
 	auto next_month_start = ymd_date.month != 12 ? sys::year_month_day{ ymd_date.year, uint16_t(ymd_date.month + 1), uint16_t(1) } : sys::year_month_day{ ymd_date.year + 1, uint16_t(1), uint16_t(1) };
 	auto const days_in_month = uint32_t(sys::days_difference(month_start, next_month_start));
 
+	auto pop_size = state.world.pop_size();
+
 	concurrency::parallel_for(uint32_t(0), pop_size, [&](uint32_t i) {
 		auto ids = dcon::pop_id{ dcon::pop_id::value_base_t(i) };
 		auto loc = state.world.pop_get_province_from_pop_location(ids);

--- a/src/gamestate/commands.hpp
+++ b/src/gamestate/commands.hpp
@@ -444,7 +444,6 @@ struct new_admiral_data {
 struct retreat_from_naval_battle_data {
 	dcon::navy_id navy;
 	dcon::province_id dest;
-	bool auto_retreat;
 };
 
 struct land_battle_data {
@@ -1162,8 +1161,8 @@ void mark_regiments_to_split(sys::state& state, dcon::nation_id source,
 		std::array<dcon::regiment_id, num_packed_units> const& list);
 void mark_ships_to_split(sys::state& state, dcon::nation_id source, std::array<dcon::ship_id, num_packed_units> const& list);
 
-void retreat_from_naval_battle(sys::state& state, dcon::nation_id source, dcon::navy_id navy, bool auto_retreat, dcon::province_id dest = dcon::province_id{ });
-std::vector<dcon::province_id> can_retreat_from_naval_battle(sys::state& state, dcon::nation_id source, dcon::navy_id navy, bool auto_retreat, dcon::province_id dest = dcon::province_id{ });
+void retreat_from_naval_battle(sys::state& state, dcon::nation_id source, dcon::navy_id navy, dcon::province_id dest = dcon::province_id{ });
+std::vector<dcon::province_id> can_retreat_from_naval_battle(sys::state& state, dcon::nation_id source, dcon::navy_id navy, military::retreat_type retreat_type, dcon::province_id dest = dcon::province_id{ });
 
 void retreat_from_land_battle(sys::state& state, dcon::nation_id source, dcon::land_battle_id b);
 bool can_retreat_from_land_battle(sys::state& state, dcon::nation_id source, dcon::land_battle_id b);

--- a/src/gui/gui_land_combat.hpp
+++ b/src/gui/gui_land_combat.hpp
@@ -1078,21 +1078,7 @@ public:
 			text::localised_format_box(state, contents, box, "alice_regiment_battle_info", sub);
 			text::close_layout_box(contents, box);
 
-			if(state.world.nation_get_unit_stats(n, utid).reconnaissance_or_fire_range > 0) {
-				text::add_line(state, contents, "unit_recon", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(n, utid).reconnaissance_or_fire_range, 2));
-			}
-			if(state.world.nation_get_unit_stats(n, utid).siege_or_torpedo_attack > 0) {
-				text::add_line(state, contents, "unit_siege", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(n, utid).siege_or_torpedo_attack, 2));
-			}
-			text::add_line(state, contents, "unit_attack", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(n, utid).attack_or_gun_power, 2));
-			text::add_line(state, contents, "unit_defence", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(n, utid).defence_or_hull, 2));
-			text::add_line(state, contents, "unit_discipline", text::variable_type::x, text::format_percentage(state.military_definitions.unit_base_definitions[utid].discipline_or_evasion, 0));
-			if(state.military_definitions.unit_base_definitions[utid].support > 0) {
-				text::add_line(state, contents, "unit_support", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(n, utid).support, 0));
-			}
-			text::add_line(state, contents, "unit_maneuver", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(n, utid).maneuver, 0));
-			text::add_line(state, contents, "unit_max_speed", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(n, utid).maximum_speed, 2));
-			text::add_line(state, contents, "unit_supply_consumption", text::variable_type::x, text::format_percentage(state.world.nation_get_unit_stats(n, utid).supply_consumption, 0));
+			ui::display_unit_stats(state, contents, n, utid);
 			text::add_line(state, contents, "alice_unit_target", text::variable_type::x, target_display);
 			
 		}

--- a/src/gui/gui_map_icons.hpp
+++ b/src/gui/gui_map_icons.hpp
@@ -1557,7 +1557,7 @@ public:
 						++total_opp_count;
 
 						str += m.get_ship().get_strength();
-						display.top_right_value += m.get_ship().get_strength();
+						display.top_right_value += 1.0f;
 						display.top_right_org_value += m.get_ship().get_org();
 					}
 
@@ -1578,7 +1578,7 @@ public:
 						++total_count;
 
 						str += m.get_ship().get_strength();
-						display.top_left_value += m.get_ship().get_strength();
+						display.top_left_value += 1.0f;
 						display.top_left_org_value += m.get_ship().get_org();
 					}
 
@@ -1825,7 +1825,7 @@ public:
 							++total_count;
 
 							str += m.get_ship().get_strength();
-							display.top_left_value += m.get_ship().get_strength();
+							display.top_left_value += 1.0f;
 							display.top_left_org_value += m.get_ship().get_org();
 						}
 

--- a/src/gui/gui_modifier_tooltips.cpp
+++ b/src/gui/gui_modifier_tooltips.cpp
@@ -370,4 +370,43 @@ void display_battle_reinforcement_modifiers(sys::state& state, dcon::land_battle
 	text::add_line(state, contents, "alice_reinforce_battle_national_modifier", text::variable_type::x, text::format_float(reinf_mod, 2), indent + 20);
 }
 
+void display_unit_stats(sys::state& state, text::columnar_layout& contents, dcon::nation_id controller, dcon::unit_type_id unit_type) {
+
+	text::add_line(state, contents, state.military_definitions.unit_base_definitions[unit_type].name);
+	const auto& stats = state.world.nation_get_unit_stats(controller, unit_type);
+	if(state.military_definitions.unit_base_definitions[unit_type].is_land) {
+		if(stats.reconnaissance_or_fire_range > 0) {
+			text::add_line(state, contents, "unit_recon", text::variable_type::x, text::format_float(stats.reconnaissance_or_fire_range, 2));
+		}
+		if(stats.siege_or_torpedo_attack > 0) {
+			text::add_line(state, contents, "unit_siege", text::variable_type::x, text::format_float(stats.siege_or_torpedo_attack, 2));
+		}
+		text::add_line(state, contents, "unit_attack", text::variable_type::x, text::format_float(stats.attack_or_gun_power, 2));
+		text::add_line(state, contents, "unit_defence", text::variable_type::x, text::format_float(stats.defence_or_hull, 2));
+		text::add_line(state, contents, "unit_discipline", text::variable_type::x, text::format_percentage(stats.discipline_or_evasion, 0));
+		if(stats.support > 0) {
+			text::add_line(state, contents, "unit_support", text::variable_type::x, text::format_percentage(stats.support, 0));
+		}
+		text::add_line(state, contents, "unit_maneuver", text::variable_type::x, text::format_float(stats.maneuver, 0));
+		text::add_line(state, contents, "unit_max_speed", text::variable_type::x, text::format_float(stats.maximum_speed, 2));
+		text::add_line(state, contents, "unit_supply_consumption", text::variable_type::x, text::format_percentage(stats.supply_consumption, 0));
+	} else {
+		text::add_line(state, contents, "unit_max_speed", text::variable_type::x, text::format_float(stats.maximum_speed, 2));
+		text::add_line(state, contents, "unit_attack", text::variable_type::x, text::format_float(stats.attack_or_gun_power, 2));
+		if(stats.siege_or_torpedo_attack > 0) {
+			text::add_line(state, contents, "unit_torpedo_attack", text::variable_type::x, text::format_float(stats.siege_or_torpedo_attack, 2));
+		}
+		text::add_line(state, contents, "unit_hull", text::variable_type::x, text::format_float(stats.defence_or_hull, 2));
+		text::add_line(state, contents, "unit_fire_range", text::variable_type::x, text::format_float(stats.reconnaissance_or_fire_range, 2));
+		if(stats.discipline_or_evasion > 0) {
+			text::add_line(state, contents, "unit_evasion", text::variable_type::x, text::format_percentage(stats.discipline_or_evasion, 0));
+		}
+		text::add_line(state, contents, "unit_supply_consumption", text::variable_type::x, text::format_percentage(stats.supply_consumption, 0));
+		text::add_line(state, contents, "unit_supply_load", text::variable_type::x, state.military_definitions.unit_base_definitions[unit_type].supply_consumption_score);
+	}
+
+}
+
+
+
 } // namespace ui

--- a/src/gui/gui_modifier_tooltips.hpp
+++ b/src/gui/gui_modifier_tooltips.hpp
@@ -14,5 +14,6 @@ void active_modifiers_description(sys::state& state, text::layout_base& layout, 
 void active_modifiers_description(sys::state& state, text::layout_base& layout, dcon::nation_id n, int32_t identation,
 		dcon::national_modifier_value nmid, bool have_header);
 void display_battle_reinforcement_modifiers(sys::state& state, dcon::land_battle_id b, text::layout_base& contents, int32_t indent, bool attacker);
+void display_unit_stats(sys::state& state, text::columnar_layout& contents, dcon::nation_id controller, dcon::unit_type_id unit_type);
 
 } // namespace ui

--- a/src/gui/gui_naval_combat.hpp
+++ b/src/gui/gui_naval_combat.hpp
@@ -1418,8 +1418,8 @@ public:
 		auto b = retrieve<dcon::naval_battle_id>(state, parent);
 		for(auto n : state.world.naval_battle_get_navy_battle_participation(b)) {
 			auto navy = n.get_navy();
-			if(!command::can_retreat_from_naval_battle(state, state.local_player_nation, navy, true).empty()) {
-				command::retreat_from_naval_battle(state, state.local_player_nation, navy, true);
+			if(!command::can_retreat_from_naval_battle(state, state.local_player_nation, navy, military::retreat_type::manual).empty()) {
+				command::retreat_from_naval_battle(state, state.local_player_nation, navy);
 			}
 			
 			
@@ -1428,7 +1428,7 @@ public:
 	}
 	void on_update(sys::state& state) noexcept override {
 		auto b = retrieve<dcon::naval_battle_id>(state, parent);
-		if(!military::can_retreat_from_battle(state, b) || province::make_naval_retreat_path(state, state.local_player_nation, state.world.naval_battle_get_location_from_naval_battle_location(b)).empty()) {
+		if(!military::is_battle_retreatable(state, b, military::retreat_type::manual) || province::make_naval_retreat_path(state, state.local_player_nation, state.world.naval_battle_get_location_from_naval_battle_location(b)).empty()) {
 			disabled = true;
 			return;
 		}

--- a/src/gui/gui_unit_grid_box.hpp
+++ b/src/gui/gui_unit_grid_box.hpp
@@ -188,12 +188,12 @@ public:
 			}
 			set_text(state, text::prettify(total));
 		} else if(std::holds_alternative<dcon::navy_id>(u)) {
-			float total = 0.0f;
+			int32_t total = 0;
 			auto a = std::get<dcon::navy_id>(u);
 			for(auto m : state.world.navy_get_navy_membership(a)) {
-				total += m.get_ship().get_strength();
+				total += 1;
 			}
-			set_text(state, text::format_float(total, 1));
+			set_text(state, text::format_wholenum(total));
 		}
 
 	}

--- a/src/gui/gui_unit_panel.hpp
+++ b/src/gui/gui_unit_panel.hpp
@@ -2710,19 +2710,20 @@ class u_row_strength : public simple_text_element_base {
 public:
 	void on_update(sys::state& state) noexcept override {
 		auto foru = retrieve<unit_var>(state, parent);
-		float total = 0.0f;
 		if(std::holds_alternative<dcon::army_id>(foru)) {
 			auto a = std::get<dcon::army_id>(foru);
+			float total = 0.0f;
 			for(auto r : state.world.army_get_army_membership(a)) {
 				total += r.get_regiment().get_strength() * state.defines.pop_size_per_regiment;
 			}
 			set_text(state, text::format_wholenum(int32_t(total)));
 		} else if(std::holds_alternative<dcon::navy_id>(foru)) {
 			auto a = std::get<dcon::navy_id>(foru);
+			uint32_t total = 0;
 			for(auto r : state.world.navy_get_navy_membership(a)) {
-				total += r.get_ship().get_strength();
+				total += 1;
 			}
-			set_text(state, text::format_float(total, 1));
+			set_text(state, text::format_wholenum(total));
 		}
 	}
 };

--- a/src/gui/gui_unit_panel.hpp
+++ b/src/gui/gui_unit_panel.hpp
@@ -9,6 +9,7 @@
 #include "gui_leader_tooltip.hpp"
 #include "gui_leader_select.hpp"
 #include "gui_unit_grid_box.hpp"
+#include "gui_modifier_tooltips.hpp"
 
 namespace ui {
 
@@ -2234,39 +2235,7 @@ class unit_type_listbox_entry_label : public button_element_base {
 		auto new_type = retrieve<dcon::unit_type_id>(state, parent);
 		auto const& ut = state.military_definitions.unit_base_definitions[new_type];
 
-		if(ut.is_land) {
-			if(state.world.nation_get_unit_stats(state.local_player_nation, new_type).reconnaissance_or_fire_range > 0) {
-				text::add_line(state, contents, "unit_recon", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, new_type).reconnaissance_or_fire_range, 2));
-			}
-			if(state.world.nation_get_unit_stats(state.local_player_nation, new_type).siege_or_torpedo_attack > 0) {
-				text::add_line(state, contents, "unit_siege", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, new_type).siege_or_torpedo_attack, 2));
-			}
-
-			text::add_line(state, contents, "unit_attack", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, new_type).attack_or_gun_power, 2));
-			text::add_line(state, contents, "unit_defence", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, new_type).defence_or_hull, 2));
-			text::add_line(state, contents, "unit_discipline", text::variable_type::x, text::format_percentage(ut.discipline_or_evasion, 0));
-			if(ut.support > 0) {
-				text::add_line(state, contents, "unit_support", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, new_type).support, 0));
-			}
-			text::add_line(state, contents, "unit_maneuver", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, new_type).maneuver, 0));
-			text::add_line(state, contents, "unit_max_speed", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, new_type).maximum_speed, 2));
-			text::add_line(state, contents, "unit_supply_consumption", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, new_type).supply_consumption * 100, 0));
-			text::add_line(state, contents, "unit_supply_load", text::variable_type::x, ut.supply_consumption_score);
-		}
-		else {
-			text::add_line(state, contents, "unit_max_speed", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, new_type).maximum_speed, 2));
-			text::add_line(state, contents, "unit_attack", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, new_type).attack_or_gun_power, 2));
-			if(state.world.nation_get_unit_stats(state.local_player_nation, new_type).siege_or_torpedo_attack > 0) {
-				text::add_line(state, contents, "unit_torpedo_attack", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, new_type).siege_or_torpedo_attack, 2));
-			}
-			text::add_line(state, contents, "unit_hull", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, new_type).defence_or_hull, 2));
-			text::add_line(state, contents, "unit_fire_range", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, new_type).reconnaissance_or_fire_range, 2));
-			if(ut.discipline_or_evasion > 0) {
-				text::add_line(state, contents, "unit_evasion", text::variable_type::x, text::format_percentage(ut.discipline_or_evasion, 0));
-			}
-			text::add_line(state, contents, "unit_supply_consumption", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, new_type).supply_consumption * 100, 0));
-			text::add_line(state, contents, "unit_supply_load", text::variable_type::x, ut.supply_consumption_score);
-		}
+		ui::display_unit_stats(state, contents, state.local_player_nation, new_type);
 
 		text::add_line_break_to_layout(state, contents);
 

--- a/src/gui/macrobuilder2.cpp
+++ b/src/gui/macrobuilder2.cpp
@@ -1232,44 +1232,17 @@ void macrobuilder2_grid_item_unit_icon_t::update_tooltip(sys::state& state, int3
 	text::add_line(state, contents, state.military_definitions.unit_base_definitions[grid_item.value].name);
 	text::add_line_break_to_layout(state, contents);
 	auto utid = grid_item.value;
-	auto is_land = state.military_definitions.unit_base_definitions[utid].is_land;
-
-	float reconnaissance_or_fire_range = 0.f;
-	float siege_or_torpedo_attack = 0.f;
-	float attack_or_gun_power = 0.f;
-	float defence_or_hull = 0.f;
-	float discipline_or_evasion = std::numeric_limits<float>::max();
-	float support = 0.f;
-	float supply_consumption = 0.f;
-	float maximum_speed = std::numeric_limits<float>::max();
-	float maneuver = std::numeric_limits<float>::max();
-	int32_t supply_consumption_score = 0;
 	bool warn_overseas = false;
 	bool warn_culture = false;
 	bool warn_active = false;
 
-	
+	if(!state.military_definitions.unit_base_definitions[utid].active && !state.world.nation_get_active_unit(state.local_player_nation, utid))
+		warn_active = true;
+	if(state.military_definitions.unit_base_definitions[utid].primary_culture)
+		warn_culture = true;
+	if(!state.military_definitions.unit_base_definitions[utid].can_build_overseas)
+		warn_overseas = true;
 
-		if(!state.military_definitions.unit_base_definitions[utid].active && !state.world.nation_get_active_unit(state.local_player_nation, utid))
-			warn_active = true;
-		if(state.military_definitions.unit_base_definitions[utid].primary_culture)
-			warn_culture = true;
-		if(!state.military_definitions.unit_base_definitions[utid].can_build_overseas)
-			warn_overseas = true;
-
-		reconnaissance_or_fire_range += state.world.nation_get_unit_stats(state.local_player_nation, utid).reconnaissance_or_fire_range;
-		siege_or_torpedo_attack += state.world.nation_get_unit_stats(state.local_player_nation, utid).siege_or_torpedo_attack;
-		attack_or_gun_power += state.world.nation_get_unit_stats(state.local_player_nation, utid).attack_or_gun_power;
-		defence_or_hull += state.world.nation_get_unit_stats(state.local_player_nation, utid).defence_or_hull ;
-		discipline_or_evasion += std::min(discipline_or_evasion, state.world.nation_get_unit_stats(state.local_player_nation, utid).discipline_or_evasion);
-		supply_consumption += state.world.nation_get_unit_stats(state.local_player_nation, utid).supply_consumption;
-		maximum_speed = std::min(maximum_speed, state.world.nation_get_unit_stats(state.local_player_nation, utid).maximum_speed);
-		if(is_land) {
-			support += state.world.nation_get_unit_stats(state.local_player_nation, utid).support ;
-			maneuver += state.world.nation_get_unit_stats(state.local_player_nation, utid).maneuver;
-		} else {
-			supply_consumption_score += state.military_definitions.unit_base_definitions[utid].supply_consumption_score;
-		}
 	
 
 	if(warn_overseas)
@@ -1278,40 +1251,10 @@ void macrobuilder2_grid_item_unit_icon_t::update_tooltip(sys::state& state, int3
 		text::add_line(state, contents, "macro_warn_culture");
 	if(warn_active)
 		text::add_line(state, contents, "macro_warn_unlocked");
+
+
+	ui::display_unit_stats(state, contents, state.local_player_nation, utid);
 	
-	if(maximum_speed == std::numeric_limits<float>::max()) maximum_speed = 0.f;
-	if(discipline_or_evasion == std::numeric_limits<float>::max()) discipline_or_evasion = 0.f;
-	if(maneuver == std::numeric_limits<float>::max()) maneuver = 0.f;
-	if(is_land) {
-		if(reconnaissance_or_fire_range > 0.f) {
-			text::add_line(state, contents, "unit_recon", text::variable_type::x, text::format_float(reconnaissance_or_fire_range, 2));
-		}
-		if(siege_or_torpedo_attack > 0.f) {
-			text::add_line(state, contents, "unit_siege", text::variable_type::x, text::format_float(siege_or_torpedo_attack, 2));
-		}
-		text::add_line(state, contents, "unit_attack", text::variable_type::x, text::format_float(attack_or_gun_power, 2));
-		text::add_line(state, contents, "unit_defence", text::variable_type::x, text::format_float(defence_or_hull, 2));
-		text::add_line(state, contents, "unit_discipline", text::variable_type::x, text::format_percentage(discipline_or_evasion, 0));
-		if(support > 0.f) {
-			text::add_line(state, contents, "unit_support", text::variable_type::x, text::format_float(support, 0));
-		}
-		text::add_line(state, contents, "unit_maneuver", text::variable_type::x, text::format_float(maneuver, 0));
-		text::add_line(state, contents, "unit_max_speed", text::variable_type::x, text::format_float(maximum_speed, 2));
-		text::add_line(state, contents, "unit_supply_consumption", text::variable_type::x, text::format_percentage(supply_consumption, 0));
-	} else {
-		text::add_line(state, contents, "unit_max_speed", text::variable_type::x, text::format_float(maximum_speed, 2));
-		text::add_line(state, contents, "unit_attack", text::variable_type::x, text::format_float(attack_or_gun_power, 2));
-		if(siege_or_torpedo_attack > 0.f) {
-			text::add_line(state, contents, "unit_torpedo_attack", text::variable_type::x, text::format_float(siege_or_torpedo_attack, 2));
-		}
-		text::add_line(state, contents, "unit_hull", text::variable_type::x, text::format_float(defence_or_hull, 2));
-		text::add_line(state, contents, "unit_fire_range", text::variable_type::x, text::format_float(reconnaissance_or_fire_range, 2));
-		if(discipline_or_evasion > 0.f) {
-			text::add_line(state, contents, "unit_evasion", text::variable_type::x, text::format_percentage(discipline_or_evasion, 0));
-		}
-		text::add_line(state, contents, "unit_supply_consumption", text::variable_type::x, text::format_percentage(supply_consumption, 0));
-		text::add_line(state, contents, "unit_supply_load", text::variable_type::x, supply_consumption_score);
-	}
 // END
 }
 void macrobuilder2_grid_item_unit_icon_t::render(sys::state & state, int32_t x, int32_t y) noexcept {

--- a/src/gui/topbar_subwindows/gui_military_window.hpp
+++ b/src/gui/topbar_subwindows/gui_military_window.hpp
@@ -4,7 +4,6 @@
 #include "gui_leaders_window.hpp"
 #include "gui_stats_window.hpp"
 #include "gui_units_window.hpp"
-#include "gui_build_unit_large_window.hpp"
 
 namespace ui {
 

--- a/src/gui/topbar_subwindows/gui_technology_window.cpp
+++ b/src/gui/topbar_subwindows/gui_technology_window.cpp
@@ -268,10 +268,10 @@ void invention_description(sys::state& state, text::layout_base& contents, dcon:
 				text::localised_format_box(state, contents, box, "support");
 				text::add_to_layout_box(state, contents, box, std::string_view{": "});
 				if(mod.support < 0) {
-					text::add_to_layout_box(state, contents, box, text::fp_two_places{mod.support}, text::text_color::red);
+					text::add_to_layout_box(state, contents, box, text::fp_percentage{mod.support }, text::text_color::red);
 				} else {
 					text::add_to_layout_box(state, contents, box, std::string_view{"+"}, text::text_color::green);
-					text::add_to_layout_box(state, contents, box, text::fp_two_places{mod.support}, text::text_color::green);
+					text::add_to_layout_box(state, contents, box, text::fp_percentage{ mod.support }, text::text_color::green);
 				}
 				text::close_layout_box(contents, box);
 			}
@@ -631,10 +631,10 @@ void technology_description(sys::state& state, text::layout_base& contents, dcon
 				text::localised_format_box(state, contents, box, "support");
 				text::add_to_layout_box(state, contents, box, std::string_view{": "});
 				if(mod.support < 0) {
-					text::add_to_layout_box(state, contents, box, text::fp_two_places{mod.support}, text::text_color::red);
+					text::add_to_layout_box(state, contents, box, text::fp_percentage{mod.support}, text::text_color::red);
 				} else {
 					text::add_to_layout_box(state, contents, box, std::string_view{"+"}, text::text_color::green);
-					text::add_to_layout_box(state, contents, box, text::fp_two_places{mod.support}, text::text_color::green);
+					text::add_to_layout_box(state, contents, box, text::fp_percentage{mod.support}, text::text_color::green);
 				}
 				text::close_layout_box(contents, box);
 			}

--- a/src/gui/topbar_subwindows/military_subwindows/gui_build_unit_large_window.hpp
+++ b/src/gui/topbar_subwindows/military_subwindows/gui_build_unit_large_window.hpp
@@ -3,6 +3,7 @@
 #include "gui_common_elements.hpp"
 #include "gui_element_types.hpp"
 #include "triggers.hpp"
+#include "gui_modifier_tooltips.hpp"
 
 namespace ui {
 
@@ -100,45 +101,14 @@ public:
 	void update_tooltip(sys::state& state, int32_t x, int32_t y, text::columnar_layout& contents) noexcept override {
 		dcon::unit_type_id utid = retrieve<dcon::unit_type_id>(state, parent);
 		dcon::province_id p = retrieve<dcon::province_id>(state, parent);
-		if(is_navy) {
-			text::add_line(state, contents, "military_build_unit_tooltip", text::variable_type::name, state.military_definitions.unit_base_definitions[utid].name, text::variable_type::loc, state.world.province_get_name(p));
-			//Any key starting with 'alice' has been added in \assets\alice.csv
-			text::add_line(state, contents, "unit_max_speed", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, utid).maximum_speed, 2));
-			text::add_line(state, contents, "unit_attack", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, utid).attack_or_gun_power, 2));
-			if(state.world.nation_get_unit_stats(state.local_player_nation, utid).siege_or_torpedo_attack > 0) {
-				text::add_line(state, contents, "unit_torpedo_attack", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, utid).siege_or_torpedo_attack, 2));
-			}
-			text::add_line(state, contents, "unit_hull", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, utid).defence_or_hull, 2));
-			text::add_line(state, contents, "unit_fire_range", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, utid).reconnaissance_or_fire_range, 2));
-			if(state.military_definitions.unit_base_definitions[utid].discipline_or_evasion > 0) {
-				text::add_line(state, contents, "unit_evasion", text::variable_type::x, text::format_percentage(state.military_definitions.unit_base_definitions[utid].discipline_or_evasion, 0));
-			}
-			text::add_line(state, contents, "unit_supply_consumption", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, utid).supply_consumption * 100, 0));
-			text::add_line(state, contents, "unit_supply_load", text::variable_type::x, state.military_definitions.unit_base_definitions[utid].supply_consumption_score);
-		} else {
-			text::add_line(state, contents, "military_build_unit_tooltip", text::variable_type::name, state.military_definitions.unit_base_definitions[utid].name, text::variable_type::loc, state.world.province_get_name(p));
-
+		text::add_line(state, contents, "military_build_unit_tooltip", text::variable_type::name, state.military_definitions.unit_base_definitions[utid].name, text::variable_type::loc, state.world.province_get_name(p));
+		if(!is_navy) {
 			buildable_unit_entry_info info = retrieve< buildable_unit_entry_info>(state, parent);
 			if(std::max(state.defines.alice_full_reinforce, state.world.pop_get_size(info.pop_info) / state.defines.pop_size_per_regiment) < 1.f) {
 				text::add_line(state, contents, "understaffed_regiment", text::variable_type::value, text::format_wholenum(int32_t(state.world.pop_get_size(info.pop_info))));
 			}
-
-			if(state.world.nation_get_unit_stats(state.local_player_nation, utid).reconnaissance_or_fire_range > 0) {
-				text::add_line(state, contents, "unit_recon", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, utid).reconnaissance_or_fire_range, 2));
-			}
-			if(state.world.nation_get_unit_stats(state.local_player_nation, utid).siege_or_torpedo_attack > 0) {
-				text::add_line(state, contents, "unit_siege", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, utid).siege_or_torpedo_attack, 2));
-			}
-			text::add_line(state, contents, "unit_attack", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, utid).attack_or_gun_power, 2));
-			text::add_line(state, contents, "unit_defence", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, utid).defence_or_hull, 2));
-			text::add_line(state, contents, "unit_discipline", text::variable_type::x, text::format_percentage(state.military_definitions.unit_base_definitions[utid].discipline_or_evasion, 0));
-			if(state.military_definitions.unit_base_definitions[utid].support > 0) {
-				text::add_line(state, contents, "unit_support", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, utid).support, 0));
-			}
-			text::add_line(state, contents, "unit_maneuver", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, utid).maneuver, 0));
-			text::add_line(state, contents, "unit_max_speed", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, utid).maximum_speed, 2));
-			text::add_line(state, contents, "unit_supply_consumption", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, utid).supply_consumption * 100, 0));
 		}
+		ui::display_unit_stats(state, contents, state.local_player_nation, utid);
 	}
 };
 
@@ -286,6 +256,7 @@ public:
 
 };
 
+
 class unit_folder_button : public button_element_base {
 public:
 	dcon::unit_type_id unit_type{};
@@ -305,42 +276,17 @@ public:
 	}
 
 	void update_tooltip(sys::state& state, int32_t x, int32_t y, text::columnar_layout& contents) noexcept override {
-		text::add_line(state, contents, state.military_definitions.unit_base_definitions[unit_type].name);
-		if(state.military_definitions.unit_base_definitions[unit_type].is_land) {
-			if(state.world.nation_get_unit_stats(state.local_player_nation, unit_type).reconnaissance_or_fire_range > 0) {
-				text::add_line(state, contents, "unit_recon", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, unit_type).reconnaissance_or_fire_range, 2));
-			}
-			if(state.world.nation_get_unit_stats(state.local_player_nation, unit_type).siege_or_torpedo_attack > 0) {
-				text::add_line(state, contents, "unit_siege", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, unit_type).siege_or_torpedo_attack, 2));
-			}
-			text::add_line(state, contents, "unit_attack", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, unit_type).attack_or_gun_power, 2));
-			text::add_line(state, contents, "unit_defence", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, unit_type).defence_or_hull, 2));
-			text::add_line(state, contents, "unit_discipline", text::variable_type::x, text::format_percentage(state.military_definitions.unit_base_definitions[unit_type].discipline_or_evasion, 0));
-			if(state.military_definitions.unit_base_definitions[unit_type].support > 0) {
-				text::add_line(state, contents, "unit_support", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, unit_type).support, 0));
-			}
-			text::add_line(state, contents, "unit_maneuver", text::variable_type::x, text::format_float(state.military_definitions.unit_base_definitions[unit_type].maneuver, 0));
-			text::add_line(state, contents, "unit_max_speed", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, unit_type).maximum_speed, 2));
-			text::add_line(state, contents, "unit_supply_consumption", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, unit_type).supply_consumption * 100, 0));
-		} else {
-			text::add_line(state, contents, "unit_max_speed", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, unit_type).maximum_speed, 2));
-			text::add_line(state, contents, "unit_attack", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, unit_type).attack_or_gun_power, 2));
-			if(state.world.nation_get_unit_stats(state.local_player_nation, unit_type).siege_or_torpedo_attack > 0) {
-				text::add_line(state, contents, "unit_torpedo_attack", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, unit_type).siege_or_torpedo_attack, 2));
-			}
-			text::add_line(state, contents, "unit_hull", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, unit_type).defence_or_hull, 2));
-			text::add_line(state, contents, "unit_fire_range", text::variable_type::x, text::format_float(state.world.nation_get_unit_stats(state.local_player_nation, unit_type).reconnaissance_or_fire_range, 2));
-			if(state.military_definitions.unit_base_definitions[unit_type].discipline_or_evasion > 0) {
-				text::add_line(state, contents, "unit_evasion", text::variable_type::x, text::format_percentage(state.military_definitions.unit_base_definitions[unit_type].discipline_or_evasion, 0));
-			}
-			text::add_line(state, contents, "unit_supply_consumption", text::variable_type::x, text::format_percentage(state.world.nation_get_unit_stats(state.local_player_nation, unit_type).supply_consumption, 0));
-			text::add_line(state, contents, "unit_supply_load", text::variable_type::x, state.military_definitions.unit_base_definitions[unit_type].supply_consumption_score);
-		}
+		ui::display_unit_stats(state, contents, state.local_player_nation, unit_type);
 		if(!(state.world.nation_get_active_unit(state.local_player_nation, unit_type) && state.military_definitions.unit_base_definitions[unit_type].active)) {
 			for(const auto inv : state.world.in_invention) {
 				if(inv.get_activate_unit(unit_type)) {
 					text::add_line(state, contents, "activated_by_with_a_chance_of", text::variable_type::x, inv.get_name());
-					additive_value_modifier_description(state, contents, inv.get_chance(), trigger::to_generic(state.local_player_nation), trigger::to_generic(state.local_player_nation), 0);
+					ui::additive_value_modifier_description(state, contents, inv.get_chance(), trigger::to_generic(state.local_player_nation), trigger::to_generic(state.local_player_nation), 0);
+				}
+			}
+			for(const auto tech : state.world.in_technology) {
+				if(tech.get_activate_unit(unit_type)) {
+					text::add_line(state, contents, "activated_by_tech", text::variable_type::x, tech.get_name());
 				}
 			}
 		}

--- a/src/military/military.hpp
+++ b/src/military/military.hpp
@@ -636,8 +636,11 @@ uint8_t get_effective_battle_dig_in(sys::state& state, dcon::land_battle_id batt
 float get_army_recon_eff(sys::state& state, dcon::army_id army);
 float get_army_siege_eff(sys::state& state, dcon::army_id army);
 dcon::nation_id tech_nation_for_army(sys::state& state, dcon::army_id army);
-// Deletes the ship and deletes&damages any regiments on transport if it resulted in negative transport capacity. This does NOT remove the ship from a battle if it it is in one!
-void delete_ship_w_army_transport_loss(sys::state& state, dcon::ship_id ship);
+
+// Deletes the ship and removes it from any battle it may be in
+void delete_ship_safe(sys::state& state, dcon::ship_id ship);
+// Deletes the ship and deletes&damages any regiments on transport if it resulted in negative transport capacity. This will remove the ship from battle if it is in one
+void delete_ship_safe_w_army_transport_loss(sys::state& state, dcon::ship_id ship);
 dcon::regiment_id get_land_combat_target(sys::state& state, dcon::regiment_id damage_dealer, int32_t position, const std::array<dcon::regiment_id, 30>& opposing_line);
 void apply_attrition_to_army(sys::state& state, dcon::army_id army);
 void apply_attrition(sys::state& state);

--- a/src/military/military.hpp
+++ b/src/military/military.hpp
@@ -607,6 +607,9 @@ void update_movement(sys::state& state);
 bool siege_potential(sys::state& state, dcon::nation_id army_controller, dcon::nation_id province_controller);
 void update_siege_progress(sys::state& state);
 void single_ship_start_retreat(sys::state& state, ship_in_battle& ship, dcon::naval_battle_id battle);
+
+// stackwipes the given navy, sinks all of the ships currently in a battle, and removes all ships from the navy. The empty navy will still exist in a retreating state, but will be cleaned up by GC later
+void stackwipe_navy(sys::state& state, dcon::navy_id navy);
 float required_avg_dist_to_center_for_retreat(sys::state& state);
 void update_naval_battles(sys::state& state);
 void update_land_battles(sys::state& state);
@@ -623,6 +626,8 @@ uint8_t get_effective_battle_dig_in(sys::state& state, dcon::land_battle_id batt
 float get_army_recon_eff(sys::state& state, dcon::army_id army);
 float get_army_siege_eff(sys::state& state, dcon::army_id army);
 dcon::nation_id tech_nation_for_army(sys::state& state, dcon::army_id army);
+// Deletes the ship and deletes&damages any regiments on transport if it resulted in negative transport capacity. This does NOT remove the ship from a battle if it it is in one!
+void delete_ship_w_army_transport_loss(sys::state& state, dcon::ship_id ship);
 dcon::regiment_id get_land_combat_target(sys::state& state, dcon::regiment_id damage_dealer, int32_t position, const std::array<dcon::regiment_id, 30>& opposing_line);
 void apply_attrition_to_army(sys::state& state, dcon::army_id army);
 void apply_attrition(sys::state& state);

--- a/src/military/military.hpp
+++ b/src/military/military.hpp
@@ -588,6 +588,16 @@ enum class battle_is_ending {
 	no, yes
 };
 
+enum class retreat_type : bool {
+	automatic = 0,
+	manual = 1,
+};
+
+struct naval_battle_last_retreat {
+	dcon::nation_id last_retreat_attacker;
+	dcon::nation_id last_retreat_defender;
+};
+
 template <apply_attrition_on_arrival attrition_tick = apply_attrition_on_arrival::no>
 void army_arrives_in_province(sys::state& state, dcon::army_id a, dcon::province_id p, crossing_type crossing, dcon::land_battle_id from = dcon::land_battle_id{}); // only for land provinces
 void navy_arrives_in_province(sys::state& state, dcon::navy_id n, dcon::province_id p, dcon::naval_battle_id from = dcon::naval_battle_id{}); // only for sea provinces
@@ -595,9 +605,9 @@ void navy_arrives_in_province(sys::state& state, dcon::navy_id n, dcon::province
 std::vector<dcon::nation_id> get_one_side_war_participants(sys::state& state, dcon::war_id war, bool attackers);
 
 template<battle_is_ending battle_state>
-bool retreat(sys::state& state, dcon::navy_id n);
+bool retreat(sys::state& state, dcon::navy_id n, retreat_type retreat_type);
 
-void end_battle(sys::state& state, dcon::naval_battle_id b, battle_result result);
+void end_battle(sys::state& state, dcon::naval_battle_id b, battle_result result, dcon::nation_id lead_attacker = dcon::nation_id{ }, dcon::nation_id lead_defender = dcon::nation_id{ });
 void end_battle(sys::state& state, dcon::land_battle_id b, battle_result result);
 
 void invalidate_unowned_wargoals(sys::state& state);
@@ -660,7 +670,7 @@ void run_gc(sys::state& state);
 void update_blackflag_status(sys::state& state);
 void send_rebel_hunter_to_next_province(sys::state& state, dcon::army_id ar, dcon::province_id prov);
 
-bool can_retreat_from_battle(sys::state& state, dcon::naval_battle_id battle);
+bool is_battle_retreatable(sys::state& state, dcon::naval_battle_id battle, retreat_type retreat_type);
 bool can_retreat_from_battle(sys::state& state, dcon::land_battle_id battle);
 
 dcon::nation_id get_land_battle_lead_attacker(sys::state& state, dcon::land_battle_id b);


### PR DESCRIPTION
- Improve performance of estimating immigration via the migration mapmode. Previously it was stuttering quite abit more when hovering over each country whilst the mapmode was on. Performance was about 3 times better on my machine with the new parallel loop. About 2 times faster if the game was running at the same time.

- Improve caching in the migration mapmode to reduce the needed recalculations.

- Change display of ships in UI to be actual number of ships instead of the sum of all strength, to make it consistent with the rest of the UI using ship count.

- Change some military unit stat display to display support as percentage instead of float. This was duplicated in quite a few places so i combined it into a common function

- Fix "ghost" battle being spawned for one day if a navy was insta-wiped due to having too little hull

- Fix bug with naval battles in which the end-of-battle report would not pop up for participants if the ships already had a manual retreat initiated. This was because no one was technically in the battle on the losing side when it ended.

- Fix bug with naval battles in which the battle would continue for one day after ending with 0 units on the losing side.

- Fixed navies being able to be stackwiped in a naval battle if ships werent close enough to the center line when it ended

- Check each time a transport dies if a regiment should be killed also if lacking transport capacity, instead of only doing it after a battle has ended.

- Renamed a function and refactored some naval related code in the process of doing the above changes