### PR TITLE
Add gamerule for command units, expand lua API to interact wth gamerules

### DIFF
--- a/assets/localisation/en-US/alice.csv
+++ b/assets/localisation/en-US/alice.csv
@@ -1803,7 +1803,7 @@ alice_declarewar_truce_with_explain;?Y$NATION$?W: Have truce with ?Y$TARGET$?W. 
 alice_command_units_condition_1;?Y$NATION$?W is our subject
 alice_command_units_condition_2;Both you and the target is at war
 alice_command_units_condition_3;Target is not a player
-alice_command_units_condition_4;Playing singleplayer
+alice_command_units_condition_4;Is enabled in game rules
 free_trade_di;Free trade agreement
 free_trade_offer;$actor$ is offering a free trade agreement, allowing us to trade tariff-free for $years$ years
 alice_original_war_participant_not_in_war;?Y$NATION$?W is no longer in the war
@@ -1834,10 +1834,15 @@ alice_gamerule_fog_of_war;Fog of war
 alice_gamerule_fog_of_war_desc;Specifies whether to enable fog of war (FoW) to obscure vision of neutral/enemy provinces&units
 alice_gamerule_fog_of_war_opt_disabled;Fog of war is OFF
 alice_gamerule_fog_of_war_opt_enabled;Fog of war is ON
+alice_gamerule_fog_of_war_opt_disabled_for_observer; Fog of war is OFF for observer
 alice_gamerule_auto_concession_peace;Auto-peace when conceding wargoals
 alice_gamerule_auto_concession_peace_desc;Specifies whether a conceding peacedeal (ie one side surrenders to ALL added wargoals, or 100 warscore) will always be accepted no matter what
 alice_gamerule_auto_concession_peace_opt_cannot_reject;Conceding peace offers cannot be rejected
 alice_gamerule_auto_concession_peace_opt_can_reject;Conceding peace offers can be rejected
+alice_gamerule_command_units;Command AI puppet units while at war
+alice_gamerule_command_units_opt_disabled;Disabled
+alice_gamerule_command_units_opt_enabled;Enabled
+alice_gamerule_command_units_desc;Specifies whether AI puppet units may be commanded by the player at war
 alice_savegame_incompatible_warning;?RThis savegame is from a diffrent scenario than the currently loaded one. The save may be buggy, fail to load or crash the game.?W
 alice_show_all_saves_text;Show all saves
 alice_show_all_saves_tooltip;Toggle showing all saves (even potentially incompatible ones) in the save list

--- a/assets/lua/custom_ffi.lua
+++ b/assets/lua/custom_ffi.lua
@@ -51,6 +51,13 @@ ffi.cdef[[
     int32_t local_player_nation();
 
     void console_log(const char text[]);
+	
+	int32_t get_gamerule_id_by_name(const char gamerule_name[]);
+	bool check_gamerule_option_by_name(const char gamerule_name[], const char gamerule_option_name[]);
+	bool check_gamerule_option_by_id(const char gamerule_name[], uint8_t opt_id);
+	
+	
+	
 ]]
 
 
@@ -83,6 +90,34 @@ end
 function MILITARY.get_stats(a)
 	return ffi.C.alice_get_unit_stats(a)
 end
+
+
+GAMERULE = {}
+
+---returns the gamerule ID for the gamerule with the supplied name
+---@param the text name of a gamerule
+---@return a gamerule ID, or -1 if there is no gamerule with that name
+function GAMERULE.get_gamerule_id_by_name(gamerule_name)
+	return ffi.C.get_gamerule_id_by_name(gamerule_name);
+end
+
+
+---returns true if the given gamerule has the specified option selected, false otherwise
+---@param the text name of a gamerule
+---@param the text name of a gamerule option to check
+---@return a boolean representing if the specified gamerule option is selected
+function GAMERULE.check_gamerule_option_by_name(gamerule_name, gamerule_option_name)
+	return ffi.C.check_gamerule_option_by_name(gamerule_name, gamerule_option_name);
+end
+
+---returns true if the given gamerule has the specified option selected, false otherwise
+---@param the text name of a gamerule
+---@param the numeric ID of the gamerule option to check.
+---@return a boolean representing if the specified gamerule option is selected
+function GAMERULE.check_gamerule_option_by_id(gamerule_name, opt_id)
+	return ffi.C.check_gamerule_option_by_id(gamerule_name, opt_id);
+end
+
 
 ON_ACTION = {}
 

--- a/assets/lua/custom_ffi.lua
+++ b/assets/lua/custom_ffi.lua
@@ -51,10 +51,12 @@ ffi.cdef[[
     int32_t local_player_nation();
 
     void console_log(const char text[]);
-	
-	int32_t get_gamerule_id_by_name(const char gamerule_name[]);
-	bool check_gamerule_option_by_name(const char gamerule_name[], const char gamerule_option_name[]);
-	bool check_gamerule_option_by_id(const char gamerule_name[], uint8_t opt_id);
+
+    int32_t lua_get_gamerule_id_by_name(const char gamerule_name[]);
+	int32_t lua_get_gamerule_option_id_by_name(const char gamerule_option_name[]);
+	bool lua_check_gamerule(int32_t gamerule_id, uint8_t opt_id);
+	int32_t lua_get_active_gamerule_option(int32_t gamerule_id);
+
 	
 	
 	
@@ -98,24 +100,32 @@ GAMERULE = {}
 ---@param the text name of a gamerule
 ---@return a gamerule ID, or -1 if there is no gamerule with that name
 function GAMERULE.get_gamerule_id_by_name(gamerule_name)
-	return ffi.C.get_gamerule_id_by_name(gamerule_name);
+	return ffi.C.lua_get_gamerule_id_by_name(gamerule_name)
 end
 
 
----returns true if the given gamerule has the specified option selected, false otherwise
----@param the text name of a gamerule
----@param the text name of a gamerule option to check
----@return a boolean representing if the specified gamerule option is selected
-function GAMERULE.check_gamerule_option_by_name(gamerule_name, gamerule_option_name)
-	return ffi.C.check_gamerule_option_by_name(gamerule_name, gamerule_option_name);
+---returns a numeric ID for the gamerule option with the supplied name
+---@param the text name of a gamerule option
+---@return a numeric ID for the a matching gamerule option
+function GAMERULE.get_gamerule_option_id_by_name(gamerule_option_name)
+	return ffi.C.check_gamerule_option_by_name(gamerule_option_name)
 end
 
----returns true if the given gamerule has the specified option selected, false otherwise
----@param the text name of a gamerule
+---returns true if the given gamerule has the specified option ID selected, false otherwise
+---@param the numeric ID of the gamerule
 ---@param the numeric ID of the gamerule option to check.
 ---@return a boolean representing if the specified gamerule option is selected
-function GAMERULE.check_gamerule_option_by_id(gamerule_name, opt_id)
-	return ffi.C.check_gamerule_option_by_id(gamerule_name, opt_id);
+function GAMERULE.check_gamerule(gamerule_id, opt_id)
+	return ffi.C.lua_check_gamerule(gamerule_id, opt_id)
+end
+
+
+
+---returns the currently active gamerule option ID for a gamerule ID
+---@param the numeric ID of the gamerule
+---@return a numeric ID representing the active gamerule option
+function GAMERULE.get_active_gamerule_option(gamerule_id)
+	return ffi.C.lua_get_active_gamerule_option(gamerule_id)
 end
 
 

--- a/assets/lua/game_scripts/gamerule.lua
+++ b/assets/lua/game_scripts/gamerule.lua
@@ -1,0 +1,97 @@
+--- This file contains all lua functions used by hardcoded gamerules
+
+
+---@param gamerule_id gamerule id
+function alice.alice_gamerule_allow_sphereling_declare_war_on_spherelord_opt_no_on_select(gamerule_id)
+end
+
+
+---@param gamerule_id gamerule id
+function alice.alice_gamerule_allow_sphereling_declare_war_on_spherelord_opt_no_on_deselect(gamerule_id)
+end
+
+---@param gamerule_id gamerule id
+function alice.alice_gamerule_allow_sphereling_declare_war_on_spherelord_opt_yes_on_select(gamerule_id)
+end
+
+---@param gamerule_id gamerule id
+function alice.alice_gamerule_allow_sphereling_declare_war_on_spherelord_opt_yes_on_deselect(gamerule_id)
+end
+
+---@param gamerule_id gamerule id
+function alice.alice_gamerule_allow_partial_retreat_opt_disabled_on_select(gamerule_id)
+end
+
+---@param gamerule_id gamerule id
+function alice.alice_gamerule_allow_partial_retreat_opt_disabled_on_deselect(gamerule_id)
+end
+
+---@param gamerule_id gamerule id
+function alice.alice_gamerule_allow_partial_retreat_opt_enabled_on_select(gamerule_id)
+end
+
+---@param gamerule_id gamerule id
+function alice.alice_gamerule_allow_partial_retreat_opt_enabled_on_deselect(gamerule_id)
+end
+
+---@param gamerule_id gamerule id
+function alice.alice_gamerule_fog_of_war_opt_disabled_on_select(gamerule_id)
+end
+
+---@param gamerule_id gamerule id
+function alice.alice_gamerule_fog_of_war_opt_disabled_on_deselect(gamerule_id)
+end
+
+---@param gamerule_id gamerule id
+function alice.alice_gamerule_fog_of_war_opt_enabled_on_select(gamerule_id)
+end
+
+---@param gamerule_id gamerule id
+function alice.alice_gamerule_fog_of_war_opt_enabled_on_deselect(gamerule_id)
+end
+
+---@param gamerule_id gamerule id
+function alice.alice_gamerule_fog_of_war_opt_disabled_for_observer_on_select(gamerule_id)
+end
+
+---@param gamerule_id gamerule id
+function alice.alice_gamerule_fog_of_war_opt_disabled_for_observer_on_deselect(gamerule_id)
+end
+
+---@param gamerule_id gamerule id
+function alice.alice_gamerule_auto_concession_peace_opt_cannot_reject_on_select(gamerule_id)
+end
+
+---@param gamerule_id gamerule id
+function alice.alice_gamerule_auto_concession_peace_opt_cannot_reject_on_deselect(gamerule_id)
+end
+
+---@param gamerule_id gamerule id
+function alice.alice_gamerule_auto_concession_peace_opt_can_reject_on_select(gamerule_id)
+end
+
+---@param gamerule_id gamerule id
+function alice.alice_gamerule_auto_concession_peace_opt_can_reject_on_deselect(gamerule_id)
+end
+
+---@param gamerule_id gamerule id
+function alice.alice_gamerule_command_units_opt_disabled_on_select(gamerule_id)
+	-- get all commanded units back to their original owners when the gamerule is disabled
+	for nation_id = 0, NATION.size() - 1 do
+		if(NATION.get_overlord_commanding_units(nation_id)) then
+			NATION.set_overlord_commanding_units(nation_id, false)
+		end
+	end
+end
+
+---@param gamerule_id gamerule id
+function alice.alice_gamerule_command_units_opt_disabled_on_deselect(gamerule_id)
+end
+
+---@param gamerule_id gamerule id
+function alice.alice_gamerule_command_units_opt_enabled_on_select(gamerule_id)
+end
+
+---@param gamerule_id gamerule id
+function alice.alice_gamerule_command_units_opt_enabled_on_deselect(gamerule_id)
+end

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -574,9 +574,10 @@ These relate to occupations
 These relate to gamerules
 
 - `alice_can_goto_war_against_spherelord_default_setting = 1.0f` - Sets the default setting for the hardcoded gamerule deciding whether a sphereling can goto war against its spherelord. Can be either 1 (which means they can declare war against spherelord), or 0 (which means they cannot). Default is 1
-- `alice_allow_partial_retreat_default_setting = 0.0f` - Sets the default setting for the hardcoded gamerule deciding whether armies can partial-retreat from battles. 1.0 means it is enabled, while 0 means it is disabled.
+- `alice_allow_partial_retreat_default_setting = 0.0f` - Sets the default setting for the hardcoded gamerule deciding whether armies can partial-retreat from battles. 1.0 means it is enabled, 0 means it is disabled, and 2.0 it is disabled only for the observer tag
 - `alice_fog_of_war_default_setting = 1.0f` - Sets the default setting for the hardcoded gamerule deciding whether fog og war is on or off. 1.0 means fog of war is on, where 0.0 means it is off.
 - `alice_auto_concession_peace_default_setting = 1.0f` - Sets the default setting for the hardcoded gamerule deciding whether a peacedeal will be force-accepted if it is conceding all wargoals (or if the peacedeal concedes 100 warscore or higher). 1.0 means forced-peaces are disabled, where 0.0 means they are enabled.
+- `alice_command_units_default_setting = 0.0f` - Decides whether AI puppets' units can be commanded by players while at war. A value of 0.0f means it is disabled, while a value of 1.0f means it is enabled
 
 ### Support for reforms based on party issues
 
@@ -841,23 +842,14 @@ scripted_gamerule = {
 	name = "test_gamerule"
 	option = {
 		name = "test__gameruleopt_1"
-		on_select = {
-			set_global_flag = rule_1
-		}
-		on_deselect = {
-			clr_global_flag = rule_1
-		}
+		on_select = "opt1_on_select"
+		on_deselect = "opt1_on_deselect"
 	}
 	option = {
 		name = "test__gameruleopt_2"
 		default_option = yes
-		on_select = {
-			set_global_flag = rule_2
-		}
-		on_deselect = {
-			clr_global_flag = rule_2
-		}
-	}
+		on_select = "opt2_on_select"
+		on_deselect = "opt2_on_deselect"
 	
 }
 ```
@@ -869,7 +861,8 @@ Each gamerule may have one or more options. Each option also has a mandatory `na
 
 Next there is the `default_option` member. This simply signals which of the options is selected by default on a new save.
 
-Lastly, there is the `on_select` and `on_deselect` members. These describe a scripted effect to run when said option is either selected or deselected respectively. In the example above it will set a global flag when enabled, and clear that same flag when disabled.
+Lastly, there is the `on_select` and `on_deselect` members. These describe the name of a lua function which should be run when the corrosponding option is selected/deselected. The function should start with the "alice" prefix take a single parameter, which is the numeric ID of the gamerule which was changed.
+Eg. in the previous example, if `"test_gameruleopt_2"` was selected, the function named `alice.opt2_on_select` would be run.
 
 You can also check the state of a gamerule directly in a trigger, with the following trigger:
 
@@ -880,6 +873,7 @@ check_gamerule = {
 }_
 ```
 Here, it evaluates if the gamerule with name `test_gamerule` is set to the option with the name `test_gameruleopt_1`.
+The gamerule can also be checked in lua code, by calling `GAMERULE.check_gamerule_option_by_name` or `GAMERULE.check_gamerule_option_by_id`. 
 
 There are also some hardcoded gamerules which interact with base gameplay directly which is not present in the gamerules.txt file. These can also have their selected option checked with `check_gamerule` trigger. Below is a list of names of the hardcoded gamerules and their options:
 
@@ -898,3 +892,7 @@ There are also some hardcoded gamerules which interact with base gameplay direct
 - `alice_gamerule_auto_concession_peace`: Name of gamerule for enabling/disabling auto peacing in cases of the enemy conceding all wargoals
 	- `alice_gamerule_auto_concession_peace_opt_cannot_reject`: Option for the auto-peace being enabled
 	- `alice_gamerule_auto_concession_peace_opt_can_reject`: Option for the auto-peace being disabled
+
+- `alice_gamerule_command_units`: Name of gamerule for enabling/disabling commanding AI puppets' troops in wars
+    - `alice_gamerule_command_units_opt_disabled`: Option for it being disabled
+    - `alice_gamerule_command_units_opt_disabled`: Option for it being enabled

--- a/src/common_types/container_types_dcon.hpp
+++ b/src/common_types/container_types_dcon.hpp
@@ -23,8 +23,10 @@ namespace sys {
 
 struct gamerule_option {
 	dcon::text_key name;
-	dcon::effect_key on_select;
-	dcon::effect_key on_deselect;
+
+	dcon::text_key on_select_lua_function;
+	dcon::text_key on_deselect_lua_function;
+
 
 	bool operator==(const gamerule_option& other) const = default;
 	bool operator!=(const gamerule_option& other) const = default;

--- a/src/common_types/debug_string_convertions.cpp
+++ b/src/common_types/debug_string_convertions.cpp
@@ -9,7 +9,7 @@ std::string to_debug_string(const event_option& obj) {
 }
 
 std::string to_debug_string(const gamerule_option& obj)  {
-	return "(name;on_select;on_deselect) => " + std::to_string(obj.name.value) + ";" + std::to_string(obj.on_select.value) + ";" + std::to_string(obj.on_deselect.value);
+	return "(name;on_select_lua_function;on_deselect_lua_function) => " + std::to_string(obj.name.value) + ";" + std::to_string(obj.on_select_lua_function.value) + ";" + std::to_string(obj.on_deselect_lua_function.value);
 }
 
 

--- a/src/gamerule/gamerule.cpp
+++ b/src/gamerule/gamerule.cpp
@@ -33,12 +33,16 @@ void load_hardcoded_gamerules(parsers::scenario_building_context& context) {
 		context.state.hardcoded_gamerules.allow_partial_retreat = create_hardcoded_gamerule(context, "alice_gamerule_allow_partial_retreat", options, uint8_t(context.state.defines.alice_allow_partial_retreat_default_setting));
 	}
 	{
-		std::vector<std::string> options = { "alice_gamerule_fog_of_war_opt_disabled", "alice_gamerule_fog_of_war_opt_enabled" };
+		std::vector<std::string> options = { "alice_gamerule_fog_of_war_opt_disabled", "alice_gamerule_fog_of_war_opt_enabled", "alice_gamerule_fog_of_war_opt_disabled_for_observer" };
 		context.state.hardcoded_gamerules.fog_of_war = create_hardcoded_gamerule(context, "alice_gamerule_fog_of_war", options, uint8_t(context.state.defines.alice_fog_of_war_default_setting));
 	}
 	{
 		std::vector<std::string> options = { "alice_gamerule_auto_concession_peace_opt_cannot_reject", "alice_gamerule_auto_concession_peace_opt_can_reject" };
 		context.state.hardcoded_gamerules.auto_concession_peace = create_hardcoded_gamerule(context, "alice_gamerule_auto_concession_peace", options, uint8_t(context.state.defines.alice_auto_concession_peace_default_setting));
+	}
+	{
+		std::vector<std::string> options = { "alice_gamerule_command_units_opt_disabled", "alice_gamerule_command_units_opt_enabled" };
+		context.state.hardcoded_gamerules.command_units = create_hardcoded_gamerule(context, "alice_gamerule_command_units", options, uint8_t(context.state.defines.alice_command_units_default_setting));
 	}
 }
 

--- a/src/gamerule/gamerule.cpp
+++ b/src/gamerule/gamerule.cpp
@@ -1,19 +1,32 @@
 #include "system_state.hpp"
 #include "gamerule.hpp"
 #include "parsers_declarations.hpp"
+#include "lua_alice_api.hpp"
 
 
 
 namespace gamerule {
 
-dcon::gamerule_id create_hardcoded_gamerule(parsers::scenario_building_context& context, std::string_view name, const std::vector<std::string>& settings, uint8_t default_setting ) {
+dcon::gamerule_id create_hardcoded_gamerule(parsers::scenario_building_context& context, std::string_view name, const std::vector<sys::gamerule_option>& settings, uint8_t default_setting, parsers::error_handler& err) {
 	auto game_rule = context.state.world.create_gamerule();
 	context.state.world.gamerule_set_name(game_rule, text::find_or_add_key(context.state, name, false));
 	context.state.world.gamerule_set_tooltip_explain(game_rule, text::find_or_add_key(context.state, std::string(name) + "_desc", false));
 	for(size_t i = 0; i < settings.size(); i++) {
-		context.map_of_gamerule_options.insert_or_assign(settings[i], parsers::scanned_gamerule_option{ game_rule, uint8_t(i) });
+		std::string option_name = text::produce_simple_string(context.state, settings[i].name);
+		context.map_of_gamerule_options.insert_or_assign(option_name, parsers::scanned_gamerule_option{ game_rule, uint8_t(i) });
 		auto& options = context.state.world.gamerule_get_options(game_rule);
-		options[uint8_t(i)].name = text::find_or_add_key(context.state, settings[i], false);
+		std::string select_lua_fun_name = text::produce_simple_string(context.state, settings[i].on_select_lua_function);
+		std::string deselect_lua_fun_name = text::produce_simple_string(context.state, settings[i].on_deselect_lua_function);
+		options[uint8_t(i)] = settings[i];
+		// Check that the lua functions exist, otherwise remove them
+		if(!lua_alice_api::has_named_function(context.state, select_lua_fun_name.c_str())){
+			options[i].on_select_lua_function = dcon::text_key{ };
+			err.accumulated_errors += "Lua function " + select_lua_fun_name + " for hardecoded gamerule " + std::string(name) + " is missing\n";
+		}
+		if(!lua_alice_api::has_named_function(context.state, deselect_lua_fun_name.c_str())) {
+			options[i].on_deselect_lua_function = dcon::text_key{ };
+			err.accumulated_errors += "Lua function " + deselect_lua_fun_name + " for hardecoded gamerule " + std::string(name) + " is missing\n";
+		}
 	}
 	context.state.world.gamerule_set_default_setting(game_rule, default_setting);
 	context.state.world.gamerule_set_current_setting(game_rule, default_setting);
@@ -22,27 +35,48 @@ dcon::gamerule_id create_hardcoded_gamerule(parsers::scenario_building_context& 
 	return game_rule;
 }
 
-void load_hardcoded_gamerules(parsers::scenario_building_context& context) {
+void load_hardcoded_gamerules(parsers::scenario_building_context& context, parsers::error_handler& err) {
 	// create gamerule for spherelings declaring war on spherelord
 	{
-		std::vector<std::string> options = { "alice_gamerule_allow_sphereling_declare_war_on_spherelord_opt_no", "alice_gamerule_allow_sphereling_declare_war_on_spherelord_opt_yes" };
-		context.state.hardcoded_gamerules.sphereling_can_declare_spherelord = create_hardcoded_gamerule(context, "alice_gamerule_allow_sphereling_declare_war_on_spherelord", options, uint8_t(context.state.defines.alice_can_goto_war_against_spherelord_default_setting));
+		std::string base_name = "alice_gamerule_allow_sphereling_declare_war_on_spherelord";
+		std::vector<sys::gamerule_option> options  =
+			{ {text::find_or_add_key(context.state, base_name + "_opt_no", false), text::find_or_add_key(context.state, base_name + "_opt_no_on_select", false), text::find_or_add_key(context.state, base_name + "_opt_no_on_deselect", false) },
+			{ text::find_or_add_key(context.state, base_name + "_opt_yes", false), text::find_or_add_key(context.state, base_name + "_opt_yes_on_select", false), text::find_or_add_key(context.state, base_name + "_opt_yes_on_deselect", false) },
+		};
+		context.state.hardcoded_gamerules.sphereling_can_declare_spherelord = create_hardcoded_gamerule(context, base_name, options, uint8_t(context.state.defines.alice_can_goto_war_against_spherelord_default_setting), err);
 	}
 	{
-		std::vector<std::string> options = { "alice_gamerule_allow_partial_retreat_opt_disabled", "alice_gamerule_allow_partial_retreat_opt_enabled" };
-		context.state.hardcoded_gamerules.allow_partial_retreat = create_hardcoded_gamerule(context, "alice_gamerule_allow_partial_retreat", options, uint8_t(context.state.defines.alice_allow_partial_retreat_default_setting));
+		std::string base_name = "alice_gamerule_allow_partial_retreat";
+		std::vector<sys::gamerule_option> options =
+			{ {text::find_or_add_key(context.state, base_name + "_opt_disabled", false), text::find_or_add_key(context.state, base_name + "_opt_disabled_on_select", false), text::find_or_add_key(context.state, base_name + "_opt_disabled_on_deselect", false) },
+			{ text::find_or_add_key(context.state, base_name + "_opt_enabled", false), text::find_or_add_key(context.state, base_name + "_opt_enabled_on_select", false), text::find_or_add_key(context.state, base_name + "_opt_enabled_on_deselect", false) },
+		};
+		context.state.hardcoded_gamerules.allow_partial_retreat = create_hardcoded_gamerule(context, base_name, options, uint8_t(context.state.defines.alice_allow_partial_retreat_default_setting), err);
 	}
 	{
-		std::vector<std::string> options = { "alice_gamerule_fog_of_war_opt_disabled", "alice_gamerule_fog_of_war_opt_enabled", "alice_gamerule_fog_of_war_opt_disabled_for_observer" };
-		context.state.hardcoded_gamerules.fog_of_war = create_hardcoded_gamerule(context, "alice_gamerule_fog_of_war", options, uint8_t(context.state.defines.alice_fog_of_war_default_setting));
+		std::string base_name = "alice_gamerule_fog_of_war";
+		std::vector<sys::gamerule_option> options =
+			{ {text::find_or_add_key(context.state, base_name + "_opt_disabled", false), text::find_or_add_key(context.state, base_name + "_opt_disabled_on_select", false), text::find_or_add_key(context.state, base_name + "_opt_disabled_on_deselect", false) },
+			{ text::find_or_add_key(context.state, base_name + "_opt_enabled", false), text::find_or_add_key(context.state, base_name + "_opt_enabled_on_select", false), text::find_or_add_key(context.state, base_name + "_opt_enabled_on_deselect", false) },
+			{ text::find_or_add_key(context.state, base_name + "_opt_disabled_for_observer", false), text::find_or_add_key(context.state, base_name + "_opt_disabled_for_observer_on_select", false), text::find_or_add_key(context.state, base_name + "_opt_disabled_for_observer_on_deselect", false) },
+		};
+		context.state.hardcoded_gamerules.fog_of_war = create_hardcoded_gamerule(context, base_name, options, uint8_t(context.state.defines.alice_fog_of_war_default_setting), err);
 	}
 	{
-		std::vector<std::string> options = { "alice_gamerule_auto_concession_peace_opt_cannot_reject", "alice_gamerule_auto_concession_peace_opt_can_reject" };
-		context.state.hardcoded_gamerules.auto_concession_peace = create_hardcoded_gamerule(context, "alice_gamerule_auto_concession_peace", options, uint8_t(context.state.defines.alice_auto_concession_peace_default_setting));
+		std::string base_name = "alice_gamerule_auto_concession_peace";
+		std::vector<sys::gamerule_option> options =
+			{ {text::find_or_add_key(context.state, base_name + "_opt_cannot_reject", false), text::find_or_add_key(context.state, base_name + "_opt_cannot_reject_on_select", false), text::find_or_add_key(context.state, base_name + "_opt_cannot_reject_on_deselect", false) },
+			{ text::find_or_add_key(context.state, base_name + "_opt_can_reject", false), text::find_or_add_key(context.state, base_name + "_opt_can_reject_on_select", false), text::find_or_add_key(context.state, base_name + "_opt_can_reject_on_deselect", false) },
+		};
+		context.state.hardcoded_gamerules.auto_concession_peace = create_hardcoded_gamerule(context, base_name, options, uint8_t(context.state.defines.alice_auto_concession_peace_default_setting), err);
 	}
 	{
-		std::vector<std::string> options = { "alice_gamerule_command_units_opt_disabled", "alice_gamerule_command_units_opt_enabled" };
-		context.state.hardcoded_gamerules.command_units = create_hardcoded_gamerule(context, "alice_gamerule_command_units", options, uint8_t(context.state.defines.alice_command_units_default_setting));
+		std::string base_name = "alice_gamerule_command_units";
+		std::vector<sys::gamerule_option> options =
+			{ {text::find_or_add_key(context.state,  base_name + "_opt_disabled", false), text::find_or_add_key(context.state, base_name + "_opt_disabled_on_select", false), text::find_or_add_key(context.state, base_name + "_opt_disabled_on_deselect", false) },
+			{ text::find_or_add_key(context.state, base_name + "_opt_enabled", false), text::find_or_add_key(context.state, base_name + "_opt_enabled_on_select", false), text::find_or_add_key(context.state, base_name + "_opt_enabled_on_deselect", false) },
+		};
+		context.state.hardcoded_gamerules.command_units = create_hardcoded_gamerule(context, base_name, options, uint8_t(context.state.defines.alice_command_units_default_setting), err);
 	}
 }
 
@@ -52,24 +86,31 @@ void restore_gamerule_ui_settings(sys::state& state) {
 		state.ui_state.gamerule_ui_settings.insert_or_assign(gamerule.id, gamerule.get_current_setting());
 	}
 }
+
+void set_gamerule_no_lua_exec(sys::state& state, dcon::gamerule_id gamerule, uint8_t new_setting) {
+	state.world.gamerule_set_current_setting(gamerule, new_setting);
+	state.ui_state.gamerule_ui_settings.insert_or_assign(gamerule, new_setting);
+	// if its being called from somewhere not in a command, set new_game to false
+	state.network_state.is_new_game = false;
+}
+
 void set_gamerule(sys::state& state, dcon::gamerule_id gamerule, uint8_t new_setting) {
 	if(check_gamerule(state, gamerule, new_setting)) {
 		return;
 	}
 	auto old_setting = state.world.gamerule_get_current_setting(gamerule);
+	set_gamerule_no_lua_exec(state, gamerule, new_setting);
+
 	auto& options = state.world.gamerule_get_options(gamerule);
-	auto on_deselect_effect = options[old_setting].on_deselect;
-	if(on_deselect_effect) {
-		effect::execute(state, on_deselect_effect, 0, 0, 0, uint32_t(state.current_date.value), uint32_t(gamerule.index() << 4 ^ new_setting));
+	auto on_deselect_lua_fun = options[old_setting].on_deselect_lua_function;
+	if(on_deselect_lua_fun) {
+		lua_alice_api::call_named_function(state, text::produce_simple_string(state, on_deselect_lua_fun).c_str(), gamerule);
 	}
-	auto on_select_effect = options[new_setting].on_select;
-	if(on_select_effect) {
-		effect::execute(state, on_select_effect, 0, 0, 0, uint32_t(state.current_date.value), uint32_t(gamerule.index() << 4 ^ new_setting));
+	auto on_select_lua_fun = options[new_setting].on_select_lua_function;
+	if(on_select_lua_fun) {
+		lua_alice_api::call_named_function(state, text::produce_simple_string(state, on_select_lua_fun).c_str(), gamerule);
 	}
-	state.world.gamerule_set_current_setting(gamerule, new_setting);
-	state.ui_state.gamerule_ui_settings.insert_or_assign(gamerule, new_setting);
-	// if its being called from somewhere not in a command, set new_game to false
-	state.network_state.is_new_game = false;
+
 }
 
 

--- a/src/gamerule/gamerule.cpp
+++ b/src/gamerule/gamerule.cpp
@@ -2,6 +2,7 @@
 #include "gamerule.hpp"
 #include "parsers_declarations.hpp"
 #include "lua_alice_api.hpp"
+#include "lua_alice_api_templates.hpp"
 
 
 
@@ -108,9 +109,34 @@ void set_gamerule(sys::state& state, dcon::gamerule_id gamerule, uint8_t new_set
 	}
 	auto on_select_lua_fun = options[new_setting].on_select_lua_function;
 	if(on_select_lua_fun) {
-		lua_alice_api::call_named_function(state, text::produce_simple_string(state, on_select_lua_fun).c_str(), gamerule);
+		auto func_name = text::produce_simple_string(state, on_select_lua_fun);
+		lua_alice_api::call_named_function(state, func_name.c_str(), gamerule);
 	}
 
+}
+
+
+dcon::gamerule_id get_gamerule_id_by_name(const sys::state& state, std::string_view gamerule_name) {
+	auto iterator = state.gamerules_map.find(std::string(gamerule_name));
+	if(iterator == state.gamerules_map.end()) {
+		return dcon::gamerule_id{ };
+	} else {
+		return iterator->second;
+	}
+}
+
+uint8_t get_gamerule_option_id_by_name(const sys::state& state, std::string_view gamerule_option_name) {
+	auto iterator = state.gamerule_options_map.find(std::string(gamerule_option_name));
+	if(iterator == state.gamerule_options_map.end()) {
+		return 0;
+	} else {
+		return int32_t(iterator->second);
+	}
+}
+
+uint8_t get_active_gamerule_option(const sys::state& state, dcon::gamerule_id gamerule) {
+	assert(gamerule);
+	return state.world.gamerule_get_current_setting(gamerule);
 }
 
 

--- a/src/gamerule/gamerule.hpp
+++ b/src/gamerule/gamerule.hpp
@@ -63,6 +63,13 @@ void set_gamerule_no_lua_exec(sys::state& state, dcon::gamerule_id gamerule, uin
 
 bool check_gamerule(sys::state& state, dcon::gamerule_id gamerule, uint8_t setting);
 
+dcon::gamerule_id get_gamerule_id_by_name(const sys::state& state, std::string_view gamerule_name);
+
+// Returns the gamerule option id with the given name
+uint8_t get_gamerule_option_id_by_name(const sys::state& state, std::string_view gamerule_option_name);
+
+uint8_t get_active_gamerule_option(const sys::state& state, dcon::gamerule_id gamerule);
+
 
 }
 

--- a/src/gamerule/gamerule.hpp
+++ b/src/gamerule/gamerule.hpp
@@ -54,11 +54,12 @@ struct hardcoded_gamerules {
 
 };
 
-void load_hardcoded_gamerules(parsers::scenario_building_context& context);
+void load_hardcoded_gamerules(parsers::scenario_building_context& context, parsers::error_handler& err);
 
 void restore_gamerule_ui_settings(sys::state& state);
 
 void set_gamerule(sys::state& state, dcon::gamerule_id gamerule, uint8_t new_setting);
+void set_gamerule_no_lua_exec(sys::state& state, dcon::gamerule_id gamerule, uint8_t new_setting);
 
 bool check_gamerule(sys::state& state, dcon::gamerule_id gamerule, uint8_t setting);
 

--- a/src/gamerule/gamerule.hpp
+++ b/src/gamerule/gamerule.hpp
@@ -31,13 +31,18 @@ enum class partial_retreat_settings : uint8_t {
 };
 enum class fog_of_war_settings : uint8_t {
 	disable = 0,
-	enable = 1
+	enable = 1,
+	disable_for_observer = 2,
 };
 enum class auto_concession_peace_settings : uint8_t {
 	cannot_reject = 0,
 	can_reject = 1
 };
 
+enum class command_units_settings : uint8_t {
+	disabled = 0,
+	enabled = 1
+};
 
 
 struct hardcoded_gamerules {
@@ -45,6 +50,7 @@ struct hardcoded_gamerules {
 	dcon::gamerule_id allow_partial_retreat;
 	dcon::gamerule_id fog_of_war;
 	dcon::gamerule_id auto_concession_peace;
+	dcon::gamerule_id command_units;
 
 };
 

--- a/src/gamerule/gamerule_templates.hpp
+++ b/src/gamerule/gamerule_templates.hpp
@@ -1,0 +1,17 @@
+#include "dcon_generated_ids.hpp"
+#include "system_state.hpp"
+#pragma once
+
+namespace gamerule {
+
+
+template<typename enum_type> requires std::is_enum<enum_type>::value
+enum_type get_gamerule_setting(sys::state& state, dcon::gamerule_id gamerule) {
+	assert(gamerule);
+	return static_cast<enum_type>(state.world.gamerule_get_current_setting(gamerule));
+}
+
+
+
+}
+

--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -3002,11 +3002,11 @@ void execute_state_transfer(sys::state& state, dcon::nation_id asker, dcon::nati
 }
 
 bool can_command_units(sys::state& state, dcon::nation_id asker, dcon::nation_id target) {
-	// disable in SP for now. Maybe could be a game rule later?
 	if(!state.current_scene.game_in_progress) {
 		return false;
 	}
-	if(state.network_mode == sys::network_mode_type::single_player) {
+	// If disabled in gamerules, you cant
+	if(gamerule::check_gamerule(state, state.hardcoded_gamerules.command_units, uint8_t(gamerule::command_units_settings::disabled))) {
 		return false;
 	}
 	if(asker == target)

--- a/src/gamestate/commands.cpp
+++ b/src/gamestate/commands.cpp
@@ -6343,6 +6343,13 @@ void execute_notify_start_game(sys::state& state, dcon::nation_id source) {
 				military::give_back_units(state, n);
 			}
 		}
+		else {
+			// If the nation's overlord is NOT a player and their armies are commanded by the overlord, return them since the overlord arent a player anymore
+			auto overlord = state.world.overlord_get_ruler(state.world.nation_get_overlord_as_subject(n));
+			if(state.world.nation_is_valid(overlord) && !state.world.nation_get_is_player_controlled(overlord)) {
+				military::give_back_units(state, n);
+			}
+		}
 	}
 	{
 		state.yield_game_state_resetting_lock = true;
@@ -6587,7 +6594,9 @@ void execute_load_save_game(sys::state& state, std::string_view filename, bool i
 				return true;
 			}
 		} else {
-			if(!sys::try_read_save_file(state, native_filename)) {
+			// If the user has the show all saves setting on, try to load it no matter the consequence. The user has already been warned
+			bool ignore_checksum = state.user_settings.show_all_saves;
+			if(!sys::try_read_save_file(state, native_filename, ignore_checksum)) {
 				auto msg = std::string("Save file ") + std::string(filename) + " could not be loaded.";
 				auto discard = state.error_windows.try_push(ui::error_window{ "Save Error", msg });
 				state.save_list_updated.store(true, std::memory_order::release); //update savefile list

--- a/src/gamestate/dcon_generated.txt
+++ b/src/gamestate/dcon_generated.txt
@@ -4366,6 +4366,7 @@ object {
 	property {
 		name{ overlord_commanding_units }
 		type{ bitfield }
+		tag{ save }
 	}
 	property {
 		name{ averge_land_unit_score }

--- a/src/gamestate/lua_alice_api.cpp
+++ b/src/gamestate/lua_alice_api.cpp
@@ -32,9 +32,11 @@ extern "C" {
 	DCON_LUADLL_API void command_move_army(int32_t unit, int32_t target, bool reset);
 	DCON_LUADLL_API void command_move_navy(int32_t unit, int32_t target, bool reset);
 	DCON_LUADLL_API void console_log(const char message[]);
-	DCON_LUADLL_API int32_t get_gamerule_id_by_name(const char gamerule_name[]);
-	DCON_LUADLL_API bool check_gamerule_option_by_name(const char gamerule_name[], const char gamerule_option_name[]);
-	DCON_LUADLL_API bool check_gamerule_option_by_id(const char gamerule_name[], uint8_t opt_id);
+	DCON_LUADLL_API int32_t lua_get_gamerule_id_by_name(const char gamerule_name[]);
+	DCON_LUADLL_API uint8_t lua_get_gamerule_option_id_by_name(const char gamerule_option_name[]);
+	DCON_LUADLL_API bool lua_check_gamerule(int32_t gamerule_id, uint8_t opt_id);
+	DCON_LUADLL_API int32_t lua_get_active_gamerule_option(int32_t gamerule_id);
+
 }
 
 void console_log(const char message[]) {
@@ -53,35 +55,20 @@ void command_move_navy(int32_t unit, int32_t target, bool reset) {
 }
 
 
-int32_t get_gamerule_id_by_name(const char gamerule_name[]) {
-	auto iterator = alice_state_ptr->gamerules_map.find(gamerule_name);
-	if(iterator == alice_state_ptr->gamerules_map.end()) {
-		return -1;
-	}
-	else {
-		return iterator->second.index();
-	}
+int32_t lua_get_gamerule_id_by_name(const char gamerule_name[]) {
+	return gamerule::get_gamerule_id_by_name(*alice_state_ptr, std::string_view(gamerule_name)).index();
 }
 
-bool check_gamerule_option_by_name(const char gamerule_name[], const char gamerule_option_name[]) {
-	auto id_index = get_gamerule_id_by_name(gamerule_name);
-	auto id = dcon::gamerule_id{ dcon::gamerule_id::value_base_t(id_index) };
-	auto& options = alice_state_ptr->world.gamerule_get_options(id);
-	auto current_selected = alice_state_ptr->world.gamerule_get_current_setting(id);
-	auto current_selected_name = text::produce_simple_string(*alice_state_ptr, options[current_selected].name);
-	if(std::strcmp(gamerule_option_name, current_selected_name.c_str()) == 0) {
-		return true;
-	}
-	else {
-		return false;
-	}
+uint8_t lua_get_gamerule_option_id_by_name(const char gamerule_option_name[]) {
+	return gamerule::get_gamerule_option_id_by_name(*alice_state_ptr, std::string_view(gamerule_option_name));
 }
 
+bool lua_check_gamerule(int32_t gamerule_id, uint8_t opt_id) {
+	return gamerule::check_gamerule(*alice_state_ptr, dcon::gamerule_id{ dcon::gamerule_id::value_base_t(gamerule_id) }, opt_id);
+}
 
-bool check_gamerule_option_by_id(const char gamerule_name[], uint8_t opt_id) {
-	auto id_index = get_gamerule_id_by_name(gamerule_name);
-	auto id = dcon::gamerule_id{ dcon::gamerule_id::value_base_t(id_index) };
-	return gamerule::check_gamerule(*alice_state_ptr, id, opt_id);
+int32_t lua_get_active_gamerule_option(int32_t gamerule_id) {
+	return static_cast<int32_t>(gamerule::get_active_gamerule_option(*alice_state_ptr, dcon::gamerule_id{ dcon::gamerule_id::value_base_t(gamerule_id) }));
 }
 
 namespace ui {

--- a/src/gamestate/lua_alice_api.cpp
+++ b/src/gamestate/lua_alice_api.cpp
@@ -32,6 +32,9 @@ extern "C" {
 	DCON_LUADLL_API void command_move_army(int32_t unit, int32_t target, bool reset);
 	DCON_LUADLL_API void command_move_navy(int32_t unit, int32_t target, bool reset);
 	DCON_LUADLL_API void console_log(const char message[]);
+	DCON_LUADLL_API int32_t get_gamerule_id_by_name(const char gamerule_name[]);
+	DCON_LUADLL_API bool check_gamerule_option_by_name(const char gamerule_name[], const char gamerule_option_name[]);
+	DCON_LUADLL_API bool check_gamerule_option_by_id(const char gamerule_name[], uint8_t opt_id);
 }
 
 void console_log(const char message[]) {
@@ -47,6 +50,38 @@ void command_move_army(int32_t unit, int32_t target, bool reset) {
 }
 void command_move_navy(int32_t unit, int32_t target, bool reset) {
 	command::move_navy(*alice_state_ptr, alice_state_ptr->local_player_nation, dcon::navy_id{ uint16_t(unit) }, dcon::province_id{ uint16_t(target) }, reset);
+}
+
+
+int32_t get_gamerule_id_by_name(const char gamerule_name[]) {
+	auto iterator = alice_state_ptr->gamerules_map.find(gamerule_name);
+	if(iterator == alice_state_ptr->gamerules_map.end()) {
+		return -1;
+	}
+	else {
+		return iterator->second.index();
+	}
+}
+
+bool check_gamerule_option_by_name(const char gamerule_name[], const char gamerule_option_name[]) {
+	auto id_index = get_gamerule_id_by_name(gamerule_name);
+	auto id = dcon::gamerule_id{ dcon::gamerule_id::value_base_t(id_index) };
+	auto& options = alice_state_ptr->world.gamerule_get_options(id);
+	auto current_selected = alice_state_ptr->world.gamerule_get_current_setting(id);
+	auto current_selected_name = text::produce_simple_string(*alice_state_ptr, options[current_selected].name);
+	if(std::strcmp(gamerule_option_name, current_selected_name.c_str()) == 0) {
+		return true;
+	}
+	else {
+		return false;
+	}
+}
+
+
+bool check_gamerule_option_by_id(const char gamerule_name[], uint8_t opt_id) {
+	auto id_index = get_gamerule_id_by_name(gamerule_name);
+	auto id = dcon::gamerule_id{ dcon::gamerule_id::value_base_t(id_index) };
+	return gamerule::check_gamerule(*alice_state_ptr, id, opt_id);
 }
 
 namespace ui {

--- a/src/gamestate/lua_alice_api.hpp
+++ b/src/gamestate/lua_alice_api.hpp
@@ -16,6 +16,48 @@ bool has_named_function(sys::state& state, const char function_name[]);
 void call_named_function(sys::state& state, const char function_name[]);
 void call_named_function(sys::state& state, const char function_name[], dcon::province_id prov);
 void call_named_function_safe(sys::state& state, const char function_name[], dcon::province_id prov);
+
+template<typename ... dcon_args>
+void call_named_function(sys::state& state, const char function_name[], dcon_args ... id_params) {
+	std::string name = function_name;
+	auto found = state.lua_registered_functions.find(name);
+	int index;
+
+	if(found != state.lua_registered_functions.end()) {
+		index = found->second;
+	} else {
+		auto stack_size_at_start = lua_gettop(state.lua_game_loop_environment);
+
+		lua_getfield(state.lua_game_loop_environment, LUA_GLOBALSINDEX, "alice"); // [alice
+		lua_getfield(state.lua_game_loop_environment, -1, function_name); // [alice, function
+		lua_remove(state.lua_game_loop_environment, -2); // [function
+		index = luaL_ref(state.lua_game_loop_environment, LUA_REGISTRYINDEX); // [
+
+		assert(lua_gettop(state.lua_game_loop_environment) == stack_size_at_start);
+
+		state.lua_registered_functions[name] = index;
+	}
+
+	lua_rawgeti(state.lua_game_loop_environment, LUA_REGISTRYINDEX, index);
+
+	// "loop" over the varadic template arguments in loop. Taken from https://stackoverflow.com/questions/7230621/how-can-i-iterate-over-a-packed-variadic-template-argument-list
+	([&] {
+
+	
+		lua_pushnumber(state.lua_game_loop_environment, id_params.index());
+
+	} (), ...);
+	auto pcall_result = lua_pcall(state.lua_game_loop_environment, 1, 0, 0);
+	if(pcall_result) {
+		state.lua_notification(lua_tostring(state.lua_game_loop_environment, -1));
+		lua_settop(state.lua_game_loop_environment, 0);
+	}
+	assert(lua_gettop(state.lua_game_loop_environment) == 0);
+}
+
+
+
+
 }
 
 namespace ui {

--- a/src/gamestate/lua_alice_api.hpp
+++ b/src/gamestate/lua_alice_api.hpp
@@ -17,46 +17,6 @@ void call_named_function(sys::state& state, const char function_name[]);
 void call_named_function(sys::state& state, const char function_name[], dcon::province_id prov);
 void call_named_function_safe(sys::state& state, const char function_name[], dcon::province_id prov);
 
-template<typename ... dcon_args>
-void call_named_function(sys::state& state, const char function_name[], dcon_args ... id_params) {
-	std::string name = function_name;
-	auto found = state.lua_registered_functions.find(name);
-	int index;
-
-	if(found != state.lua_registered_functions.end()) {
-		index = found->second;
-	} else {
-		auto stack_size_at_start = lua_gettop(state.lua_game_loop_environment);
-
-		lua_getfield(state.lua_game_loop_environment, LUA_GLOBALSINDEX, "alice"); // [alice
-		lua_getfield(state.lua_game_loop_environment, -1, function_name); // [alice, function
-		lua_remove(state.lua_game_loop_environment, -2); // [function
-		index = luaL_ref(state.lua_game_loop_environment, LUA_REGISTRYINDEX); // [
-
-		assert(lua_gettop(state.lua_game_loop_environment) == stack_size_at_start);
-
-		state.lua_registered_functions[name] = index;
-	}
-
-	lua_rawgeti(state.lua_game_loop_environment, LUA_REGISTRYINDEX, index);
-
-	// "loop" over the varadic template arguments in loop. Taken from https://stackoverflow.com/questions/7230621/how-can-i-iterate-over-a-packed-variadic-template-argument-list
-	([&] {
-
-	
-		lua_pushnumber(state.lua_game_loop_environment, id_params.index());
-
-	} (), ...);
-	auto pcall_result = lua_pcall(state.lua_game_loop_environment, 1, 0, 0);
-	if(pcall_result) {
-		state.lua_notification(lua_tostring(state.lua_game_loop_environment, -1));
-		lua_settop(state.lua_game_loop_environment, 0);
-	}
-	assert(lua_gettop(state.lua_game_loop_environment) == 0);
-}
-
-
-
 
 }
 

--- a/src/gamestate/lua_alice_api_templates.hpp
+++ b/src/gamestate/lua_alice_api_templates.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "system_state.hpp"
+
+namespace lua_alice_api {
+template<typename ... dcon_args>
+void call_named_function(sys::state& state, const char function_name[], dcon_args ... id_params) {
+	std::string name = function_name;
+	auto found = state.lua_registered_functions.find(name);
+	int index;
+
+	if(found != state.lua_registered_functions.end()) {
+		index = found->second;
+	} else {
+		auto stack_size_at_start = lua_gettop(state.lua_game_loop_environment);
+
+		lua_getfield(state.lua_game_loop_environment, LUA_GLOBALSINDEX, "alice"); // [alice
+		lua_getfield(state.lua_game_loop_environment, -1, function_name); // [alice, function
+		lua_remove(state.lua_game_loop_environment, -2); // [function
+		index = luaL_ref(state.lua_game_loop_environment, LUA_REGISTRYINDEX); // [
+
+		assert(lua_gettop(state.lua_game_loop_environment) == stack_size_at_start);
+
+		state.lua_registered_functions[name] = index;
+	}
+
+	lua_rawgeti(state.lua_game_loop_environment, LUA_REGISTRYINDEX, index);
+
+	// "loop" over the varadic template arguments in loop. Taken from https://stackoverflow.com/questions/7230621/how-can-i-iterate-over-a-packed-variadic-template-argument-list
+	([&] {
+
+
+		lua_pushnumber(state.lua_game_loop_environment, id_params.index());
+
+	} (), ...);
+	auto pcall_result = lua_pcall(state.lua_game_loop_environment, 1, 0, 0);
+	if(pcall_result) {
+		state.lua_notification(lua_tostring(state.lua_game_loop_environment, -1));
+		lua_settop(state.lua_game_loop_environment, 0);
+	}
+	assert(lua_gettop(state.lua_game_loop_environment) == 0);
+}
+}

--- a/src/gamestate/serialization.cpp
+++ b/src/gamestate/serialization.cpp
@@ -1097,6 +1097,8 @@ bool try_read_scenario_file(sys::state& state, native_string_view name) {
 		buffer_pos = with_decompressed_section(buffer_pos,
 				[&](uint8_t const* ptr_in, uint32_t length) { read_scenario_section(ptr_in, ptr_in + length, state); });
 
+		state.on_scenario_load();
+
 		return true;
 	} else {
 		return false;

--- a/src/gamestate/serialization.cpp
+++ b/src/gamestate/serialization.cpp
@@ -1351,7 +1351,7 @@ void write_save_file(sys::state& state, save_type type, std::string const& name,
 		state.cheat_data.supply_dump_buffer.clear();
 	}
 }
-bool try_read_save_file(sys::state& state, native_string_view name) {
+bool try_read_save_file(sys::state& state, native_string_view name, bool ignore_checksum) {
 	auto dir = simple_fs::get_or_create_save_game_directory(state.mod_save_dir);
 	auto save_file = open_file(dir, name);
 	if(save_file) {
@@ -1374,8 +1374,13 @@ bool try_read_save_file(sys::state& state, native_string_view name) {
 		//	return false;
 		//if(state.scenario_time_stamp != header.timestamp)
 		//	return false;
-		if(!state.scenario_checksum.is_equal(header.checksum))
-			return false;
+		// 
+		// check the checksum if we dont want to ignore it, and refuse to load if it mismatches
+		if(!ignore_checksum) {
+			if(!state.scenario_checksum.is_equal(header.checksum))
+				return false;
+		}
+		
 
 		state.loaded_save_file = name;
 

--- a/src/gamestate/serialization.hpp
+++ b/src/gamestate/serialization.hpp
@@ -266,6 +266,6 @@ bool try_read_scenario_as_save_file(sys::state& state, native_string_view name);
 std::string get_default_save_name(sys::state& state, save_type type);
 
 void write_save_file(sys::state& state, sys::save_type type = sys::save_type::normal, std::string const& name = std::string(""), const std::string& file_name = std::string(""));
-bool try_read_save_file(sys::state& state, native_string_view name);
+bool try_read_save_file(sys::state& state, native_string_view name, bool ignore_checksum = false);
 
 } // namespace sys

--- a/src/gamestate/system_state.cpp
+++ b/src/gamestate/system_state.cpp
@@ -1587,7 +1587,7 @@ void state::load_gamerule_settings() {
 			uint8_t setting = data_ptr[i];
 			dcon::gamerule_id gamerule{ dcon::gamerule_id::value_base_t{ uint8_t(i) } };
 			if(world.gamerule_is_valid(gamerule) && world.gamerule_get_settings_count(gamerule) > setting) {
-				gamerule::set_gamerule(*this, gamerule, setting);
+				gamerule::set_gamerule_no_lua_exec(*this, gamerule, setting);
 			}
 		}
 	}
@@ -1673,6 +1673,106 @@ void state::load_scenario_data(parsers::error_handler& err, sys::year_month_day 
 	auto common = open_directory(root, NATIVE("common"));
 
 	parsers::scenario_building_context context(*this);
+
+	lua_alice_api::set_state(this);
+	lua_alice_api::setup_gameloop_environment(*this);
+
+	// read lua scripts
+	lua_combined_script.clear();
+	auto assets = simple_fs::open_directory(root, NATIVE("assets"));
+	auto assets_lua = simple_fs::open_directory(assets, NATIVE("lua"));
+	{
+		// read dcon wrappers
+		auto engine_lua = open_directory(assets_lua, NATIVE("engine"));
+		for(auto province_file : list_files(engine_lua, NATIVE(".lua"))) {
+			auto opened_file = open_file(province_file);
+			if(opened_file) {
+				auto content = view_contents(*opened_file);
+				lua_combined_script += content.data;
+				simple_fs::standardize_newlines(lua_combined_script);
+				lua_combined_script += "\n";
+			}
+		}
+
+		auto hand_written_wrappers = open_file(assets_lua, NATIVE("custom_ffi.lua"));
+		if(hand_written_wrappers) {
+			auto content = view_contents(*hand_written_wrappers);
+			lua_combined_script += content.data;
+			simple_fs::standardize_newlines(lua_combined_script);
+			lua_combined_script += "\n";
+		}
+
+		// read loader for game thread
+		lua_game_loop_script.clear();
+		auto game_loop = open_file(assets_lua, NATIVE("loader_game_loop.lua"));
+		if(game_loop) {
+			auto content = view_contents(*game_loop);
+			lua_game_loop_script += content.data;
+			simple_fs::standardize_newlines(lua_game_loop_script);
+			lua_game_loop_script += "\n";
+		}
+
+		// read loader for ui thread
+		lua_ui_script.clear();
+		auto ui_script = open_file(assets_lua, NATIVE("loader_ui.lua"));
+		if(ui_script) {
+			auto content = view_contents(*ui_script);
+			lua_ui_script += content.data;
+			simple_fs::standardize_newlines(lua_ui_script);
+			lua_ui_script += "\n";
+		}
+
+		// game scripts
+		auto game_scripts_dir = open_directory(assets_lua, NATIVE("game_scripts"));
+		for(auto lua_file : list_files(game_scripts_dir, NATIVE(".lua"))) {
+			auto opened_file = open_file(lua_file);
+			if(opened_file) {
+				auto content = view_contents(*opened_file);
+				lua_combined_script += content.data;
+				simple_fs::standardize_newlines(lua_combined_script);
+				lua_combined_script += "\n";
+			}
+		}
+
+		// custom scripts
+		auto custom_scripts_dir = open_directory(assets_lua, NATIVE("custom_scripts"));
+		for(auto lua_file : list_files(custom_scripts_dir, NATIVE(".lua"))) {
+			auto opened_file = open_file(lua_file);
+			if(opened_file) {
+				auto content = view_contents(*opened_file);
+				lua_combined_script += content.data;
+				simple_fs::standardize_newlines(lua_combined_script);
+				lua_combined_script += "\n";
+			}
+		}
+	}
+
+	{
+		int status;
+		status = luaL_dostring(lua_game_loop_environment, lua_combined_script.c_str());
+		if(status) {
+#ifdef _WIN32
+			OutputDebugStringA(lua_tostring(lua_game_loop_environment, -1));
+#endif
+			lua_settop(lua_game_loop_environment, 0);
+			std::abort();
+		}
+		status = luaL_dostring(lua_game_loop_environment, lua_game_loop_script.c_str());
+		if(status) {
+#ifdef _WIN32
+			OutputDebugStringA(lua_tostring(lua_game_loop_environment, -1));
+#endif
+			lua_settop(lua_game_loop_environment, 0);
+			std::abort();
+		}
+	}
+
+	if(lua_alice_api::has_named_function(*this, "update_administrative_efficiency")) {
+		err.accumulated_warnings += "update_administrative_efficiency function was overidden from LUA\n";
+	}
+
+
+
 
 	//text::name_into_font_id(*this, "garamond_14");
 	ui::load_text_gui_definitions(*this, context.gfx_context, err);
@@ -2001,7 +2101,7 @@ void state::load_scenario_data(parsers::error_handler& err, sys::year_month_day 
 	}
 
 	// create the hardcoded gamerules
-	gamerule::load_hardcoded_gamerules(context);
+	gamerule::load_hardcoded_gamerules(context, err);
 	// pre parse scripted gamerules
 	{
 
@@ -3265,13 +3365,6 @@ void state::load_scenario_data(parsers::error_handler& err, sys::year_month_day 
 			err.accumulated_warnings += "Province" + std::to_string(context.prov_id_to_original_id_map[p].id) + " has state_building of size exceeding its factory_max_size\n";
 		}
 	}
-	// apply effects from gamerule options which are on by default
-	for(auto gamerule : context.state.world.in_gamerule) {
-		if(gamerule.get_settings_count() > 0) {
-			auto default_selection_effect = gamerule.get_options()[gamerule.get_default_setting()].on_select;
-			effect::execute(*this, default_selection_effect, 0, 0, 0, uint32_t(current_date.value), uint32_t(gamerule.id.index() << 4 ^ gamerule.get_default_setting()));
-		}
-	}
 
 	// run pending triggers and effects
 	for(auto pending_decision : pending_decisions) {
@@ -3281,79 +3374,6 @@ void state::load_scenario_data(parsers::error_handler& err, sys::year_month_day 
 			effect::execute(*this, e, trigger::to_generic(n), trigger::to_generic(n), 0, uint32_t(current_date.value), uint32_t(n.index() << 4 ^ d.index()));
 	}
 
-
-	lua_alice_api::set_state(this);
-	lua_alice_api::setup_gameloop_environment(*this);
-
-	// read lua scripts
-	lua_combined_script.clear();
-	auto assets = simple_fs::open_directory(root, NATIVE("assets"));
-	auto assets_lua = simple_fs::open_directory(assets, NATIVE("lua"));
-	{
-		// read dcon wrappers
-		auto engine_lua = open_directory(assets_lua, NATIVE("engine"));
-		for(auto province_file : list_files(engine_lua, NATIVE(".lua"))) {
-			auto opened_file = open_file(province_file);
-			if(opened_file) {
-				auto content = view_contents(*opened_file);
-				lua_combined_script += content.data;
-				simple_fs::standardize_newlines(lua_combined_script);
-				lua_combined_script += "\n";
-			}
-		}
-
-		auto hand_written_wrappers = open_file(assets_lua, NATIVE("custom_ffi.lua"));
-		if(hand_written_wrappers) {
-			auto content = view_contents(*hand_written_wrappers);
-			lua_combined_script += content.data;
-			simple_fs::standardize_newlines(lua_combined_script);
-			lua_combined_script += "\n";
-		}
-
-		// read loader for game thread
-		lua_game_loop_script.clear();
-		auto game_loop = open_file(assets_lua, NATIVE("loader_game_loop.lua"));
-		if(game_loop) {
-			auto content = view_contents(*game_loop);
-			lua_game_loop_script += content.data;
-			simple_fs::standardize_newlines(lua_game_loop_script);
-			lua_game_loop_script += "\n";
-		}
-
-		// read loader for ui thread
-		lua_ui_script.clear();
-		auto ui_script = open_file(assets_lua, NATIVE("loader_ui.lua"));
-		if(ui_script) {
-			auto content = view_contents(*ui_script);
-			lua_ui_script += content.data;
-			simple_fs::standardize_newlines(lua_ui_script);
-			lua_ui_script += "\n";
-		}
-	}
-
-	{
-		int status;
-		status = luaL_dostring(lua_game_loop_environment, lua_combined_script.c_str());
-		if(status) {
-#ifdef _WIN32
-			OutputDebugStringA(lua_tostring(lua_game_loop_environment, -1));
-#endif
-			lua_settop(lua_game_loop_environment, 0);
-			std::abort();
-		}
-		status = luaL_dostring(lua_game_loop_environment, lua_game_loop_script.c_str());
-		if(status) {
-#ifdef _WIN32
-			OutputDebugStringA(lua_tostring(lua_game_loop_environment, -1));
-#endif
-			lua_settop(lua_game_loop_environment, 0);
-			std::abort();
-		}
-	}
-
-	if(lua_alice_api::has_named_function(*this, "update_administrative_efficiency")) {
-		err.accumulated_warnings += "update_administrative_efficiency function was overidden from LUA\n";
-	}
 
 	demographics::regenerate_from_pop_data_full(*this);
 	economy::initialize(*this);

--- a/src/gamestate/system_state.cpp
+++ b/src/gamestate/system_state.cpp
@@ -3586,10 +3586,16 @@ void state::preload() {
 
 void state::on_scenario_load() {
 
-	// update map of gamerules
+	// update map of gamerules. No gamerules or gamerule options should be added after scenario load, as they themselves are scenario data. The only thing that may change is the active gamerule option
 	for(auto gamerule : world.in_gamerule) {
 		if(gamerule.is_valid()) {
 			gamerules_map.insert_or_assign(text::produce_simple_string(*this, gamerule.get_name()), gamerule.id);
+			const auto& gamerule_options = world.gamerule_get_options(gamerule);
+			auto gamerule_option_count = world.gamerule_get_settings_count(gamerule);
+			for(uint8_t option_id = 0; option_id < gamerule_option_count; option_id++) {
+				gamerule_options_map.insert_or_assign(text::produce_simple_string(*this, gamerule_options[option_id].name), option_id);
+
+			}
 		}
 	}
 

--- a/src/gamestate/system_state.cpp
+++ b/src/gamestate/system_state.cpp
@@ -3585,6 +3585,14 @@ void state::preload() {
 }
 
 void state::on_scenario_load() {
+
+	// update map of gamerules
+	for(auto gamerule : world.in_gamerule) {
+		if(gamerule.is_valid()) {
+			gamerules_map.insert_or_assign(text::produce_simple_string(*this, gamerule.get_name()), gamerule.id);
+		}
+	}
+
 	world.pop_type_resize_issues_fns(world.issue_option_size());
 	world.pop_type_resize_ideology_fns(world.ideology_size());
 	world.pop_type_resize_promotion_fns(world.pop_type_size());

--- a/src/gamestate/system_state.cpp
+++ b/src/gamestate/system_state.cpp
@@ -199,7 +199,7 @@ void state::on_resize(int32_t x, int32_t y, window::window_state win_state) {
 	ogl::deinitialize_framebuffer_for_province_indices(*this);
 	ogl::initialize_framebuffer_for_province_indices(*this, x, y);
 
-	
+
 
 	if(win_state != window::window_state::minimized) {
 		ui_state.for_each_root([&](ui::element_base& elm) {
@@ -209,13 +209,12 @@ void state::on_resize(int32_t x, int32_t y, window::window_state win_state) {
 		if(ui_state.outliner_window) {
 			ui_state.outliner_window->impl_on_update(*this);
 		}
-		if(current_scene.game_in_progress) {
+		if(current_scene.id == game_scene::scene_id::in_game_production_view) {
 			alice_ui::display_at_front<alice_ui::make_production_main>(*this, alice_ui::display_closure_command::return_pointer)->base_data.size.y = int16_t(y / user_settings.ui_scale);
 			alice_ui::display_at_front<alice_ui::make_production_rh_view>(*this, alice_ui::display_closure_command::return_pointer)->base_data.size.y = int16_t(y / user_settings.ui_scale);
 		}
 	}
 }
-
 
 void state::on_key_down(virtual_key keycode, key_modifiers mod) {
 	if(keycode == virtual_key::CONTROL)

--- a/src/gamestate/system_state.hpp
+++ b/src/gamestate/system_state.hpp
@@ -737,6 +737,7 @@ struct alignas(64) state {
 	province::global_provincial_state province_definitions;
 	gamerule::hardcoded_gamerules hardcoded_gamerules;
 	ankerl::unordered_dense::map<std::string, dcon::gamerule_id> gamerules_map; // map of gamerule name -> gamerule ID. Values are initialized at runtime and used by lua functions to locate gamerules by their script names
+	ankerl::unordered_dense::map<std::string, uint8_t> gamerule_options_map; // map of gamerule option name -> gamerule option ID. Values are initialized at runtime and used by lua functions to locate gamerule options by their script names
 
 	absolute_time_point start_date;
 	absolute_time_point end_date;

--- a/src/gamestate/system_state.hpp
+++ b/src/gamestate/system_state.hpp
@@ -736,6 +736,7 @@ struct alignas(64) state {
 	nations::global_national_state national_definitions;
 	province::global_provincial_state province_definitions;
 	gamerule::hardcoded_gamerules hardcoded_gamerules;
+	ankerl::unordered_dense::map<std::string, dcon::gamerule_id> gamerules_map; // map of gamerule name -> gamerule ID. Values are initialized at runtime and used by lua functions to locate gamerules by their script names
 
 	absolute_time_point start_date;
 	absolute_time_point end_date;

--- a/src/gui/topbar_subwindows/diplomacy_subwindows/gui_diplomacy_actions_window.hpp
+++ b/src/gui/topbar_subwindows/diplomacy_subwindows/gui_diplomacy_actions_window.hpp
@@ -330,7 +330,7 @@ public:
 			text::add_line_with_condition(state, contents, "alice_command_units_condition_2", asker_wars.begin() != asker_wars.end() && target_wars.begin() != target_wars.end());
 		}
 
-		if(state.network_mode == sys::network_mode_type::single_player) {
+		if(gamerule::check_gamerule(state, state.hardcoded_gamerules.command_units, uint8_t(gamerule::command_units_settings::disabled))) {
 			text::add_line_with_condition(state, contents, "alice_command_units_condition_4", false);
 		}
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -16,6 +16,7 @@
 #include "prng.hpp"
 #include "demographics.hpp"
 #include "projections.hpp"
+#include "gamerule_templates.hpp"
 
 #include "xac.hpp"
 namespace duplicates {
@@ -221,7 +222,9 @@ void display_data::update_fog_of_war(sys::state& state) {
 
 	// update fog of war too
 	std::vector<uint32_t> province_fows(state.world.province_size() + 1, 0xFFFFFFFF);
-	if(gamerule::check_gamerule(state, state.hardcoded_gamerules.fog_of_war, uint8_t(gamerule::fog_of_war_settings::enable))) {
+	gamerule::fog_of_war_settings cur_gamerule_setting = gamerule::get_gamerule_setting<gamerule::fog_of_war_settings>(state, state.hardcoded_gamerules.fog_of_war);
+	if(cur_gamerule_setting == gamerule::fog_of_war_settings::enable ||
+	(state.world.nation_get_identity_from_identity_holder(state.local_player_nation) != state.national_definitions.rebel_id && cur_gamerule_setting == gamerule::fog_of_war_settings::disable_for_observer)) {
 		state.map_state.visible_provinces.clear();
 		state.map_state.visible_provinces.resize(state.world.province_size() + 1, false);
 		for(auto p : direct_provinces) {

--- a/src/map/map_state.cpp
+++ b/src/map/map_state.cpp
@@ -15,6 +15,7 @@
 #include "province.hpp"
 
 #include "projections.hpp"
+#include "gamerule_templates.hpp"
 
 //#include <filesystem>
 
@@ -1139,7 +1140,9 @@ void update_unit_arrows(sys::state& state, display_data& map_data) {
 			return;
 		}
 		// Exclude if out of FOW
-		if(gamerule::check_gamerule(state, state.hardcoded_gamerules.fog_of_war, uint8_t(gamerule::fog_of_war_settings::enable))) {
+		gamerule::fog_of_war_settings cur_gamerule_setting = gamerule::get_gamerule_setting<gamerule::fog_of_war_settings>(state, state.hardcoded_gamerules.fog_of_war);
+		if(cur_gamerule_setting == gamerule::fog_of_war_settings::enable ||
+		(state.world.nation_get_identity_from_identity_holder(state.local_player_nation) != state.national_definitions.rebel_id && cur_gamerule_setting == gamerule::fog_of_war_settings::disable_for_observer)) {
 			auto pc = map_army.get_army_location().get_location().id;
 			if(!state.map_state.visible_provinces[province::to_map_id(pc)]) {
 				continue;
@@ -1182,7 +1185,9 @@ void update_unit_arrows(sys::state& state, display_data& map_data) {
 			return;
 		}
 		// Exclude if out of FOW
-		if(gamerule::check_gamerule(state, state.hardcoded_gamerules.fog_of_war, uint8_t(gamerule::fog_of_war_settings::enable))) {
+		gamerule::fog_of_war_settings cur_gamerule_setting = gamerule::get_gamerule_setting<gamerule::fog_of_war_settings>(state, state.hardcoded_gamerules.fog_of_war);
+		if(cur_gamerule_setting == gamerule::fog_of_war_settings::enable ||
+		(state.world.nation_get_identity_from_identity_holder(state.local_player_nation) != state.national_definitions.rebel_id && cur_gamerule_setting == gamerule::fog_of_war_settings::disable_for_observer)) {
 			auto pc = map_navy.get_navy_location().get_location().id;
 			if(!state.map_state.visible_provinces[province::to_map_id(pc)]) {
 				continue;

--- a/src/nations/nations.cpp
+++ b/src/nations/nations.cpp
@@ -2065,7 +2065,7 @@ void switch_all_players(sys::state& state, dcon::nation_id new_n, dcon::nation_i
 			msg.source = new_n;
 	
 	if(state.current_scene.game_in_progress) {
-		// give back units if puppet becomes player controlled. This is also done when the game starts and goes from lobby to game in progress
+		// give back units if puppet becomes player controlled while the game is running. This is also done when the game starts and goes from lobby to game in progress
 		if(bool(state.world.nation_get_overlord_as_subject(new_n)) && state.world.nation_get_overlord_commanding_units(new_n)) {
 			military::give_back_units(state, new_n);
 		}

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -2417,7 +2417,7 @@ void switch_one_player(sys::state& state, dcon::nation_id new_n, dcon::nation_id
 			msg.source = new_n;
 
 	if(state.current_scene.game_in_progress) {
-		// give back units if puppet becomes player controlled. This is also done when the game starts and goes from lobby to game in progress
+		// give back units if puppet becomes player controlled while the game is running. This is also done when the game starts and goes from lobby to game in progress
 		if(bool(state.world.nation_get_overlord_as_subject(new_n)) && state.world.nation_get_overlord_commanding_units(new_n)) {
 			military::give_back_units(state, new_n);
 		}

--- a/src/parsing/defines.hpp
+++ b/src/parsing/defines.hpp
@@ -768,6 +768,7 @@
 	LUA_DEFINES_LIST_ELEMENT(alice_allow_partial_retreat_default_setting, 0.0) \
 	LUA_DEFINES_LIST_ELEMENT(alice_fog_of_war_default_setting, 1.0) \
 	LUA_DEFINES_LIST_ELEMENT(alice_auto_concession_peace_default_setting, 1.0) \
+	LUA_DEFINES_LIST_ELEMENT(alice_command_units_default_setting, 1.0) \
 	LUA_DEFINES_LIST_ELEMENT(alice_render_on_map_generals, 0.0) \
 	LUA_DEFINES_LIST_ELEMENT(alice_economy_presim_days, 730.0) \
 

--- a/src/parsing/defines.hpp
+++ b/src/parsing/defines.hpp
@@ -768,7 +768,7 @@
 	LUA_DEFINES_LIST_ELEMENT(alice_allow_partial_retreat_default_setting, 0.0) \
 	LUA_DEFINES_LIST_ELEMENT(alice_fog_of_war_default_setting, 1.0) \
 	LUA_DEFINES_LIST_ELEMENT(alice_auto_concession_peace_default_setting, 1.0) \
-	LUA_DEFINES_LIST_ELEMENT(alice_command_units_default_setting, 1.0) \
+	LUA_DEFINES_LIST_ELEMENT(alice_command_units_default_setting, 0.0) \
 	LUA_DEFINES_LIST_ELEMENT(alice_render_on_map_generals, 0.0) \
 	LUA_DEFINES_LIST_ELEMENT(alice_economy_presim_days, 730.0) \
 

--- a/src/parsing/effect_parser_defs.txt
+++ b/src/parsing/effect_parser_defs.txt
@@ -366,5 +366,5 @@ event_option
 gamerule_option
 	name                  value      text								 member_fn
 	default_option                  value      bool								 member
-	on_select						extern	   make_gamerule_effect					 member
-	on_deselect						extern	   make_gamerule_effect					 member
+	on_select			  value	    text  											 member_fn
+	on_deselect			  value	    text  											 member_fn

--- a/src/parsing/gamerule_parsing.cpp
+++ b/src/parsing/gamerule_parsing.cpp
@@ -20,38 +20,6 @@ void make_scan_gamerule(token_generator& gen, error_handler& err, scenario_build
 }
 
 
-dcon::effect_key make_gamerule_effect(token_generator& gen, error_handler& err, scenario_building_context& context) {
-	effect_building_context e_context{ context, trigger::slot_contents::empty, trigger::slot_contents::empty, trigger::slot_contents::empty };
-	e_context.effect_is_for_event = false;
-
-	e_context.compiled_effect.push_back(uint16_t(effect::generic_scope | effect::scope_has_limit));
-	e_context.compiled_effect.push_back(uint16_t(0));
-	auto payload_size_offset = e_context.compiled_effect.size() - 1;
-	e_context.limit_position = e_context.compiled_effect.size();
-	e_context.compiled_effect.push_back(trigger::payload(dcon::trigger_key()).value);
-	auto old_err_size = err.accumulated_errors.size();
-	parsers::parse_effect_body<effect_building_context&>(gen, err, e_context);
-
-	e_context.compiled_effect[payload_size_offset] = uint16_t(e_context.compiled_effect.size() - payload_size_offset);
-
-	if(e_context.compiled_effect.size() >= std::numeric_limits<uint16_t>::max()) {
-		err.accumulated_errors += "effect in gamerule is " +
-			std::to_string(e_context.compiled_effect.size()) +
-			" cells big, which exceeds 64 KB bytecode limit (" + err.file_name + ")\n";
-		return dcon::effect_key{ 0 };
-	}
-
-	if(err.accumulated_errors.size() == old_err_size) {
-		auto const new_size = simplify_effect(e_context.compiled_effect.data());
-		e_context.compiled_effect.resize(static_cast<size_t>(new_size));
-	} else {
-		e_context.compiled_effect.clear();
-	}
-
-	auto effect_id = context.state.commit_effect_data(e_context.compiled_effect);
-	return effect_id;
-}
-
 }
 
 

--- a/src/parsing/gamerule_parsing.hpp
+++ b/src/parsing/gamerule_parsing.hpp
@@ -5,8 +5,6 @@ namespace parsers {
 
 void make_gamerule(token_generator& gen, error_handler& err, scenario_building_context& context);
 
-dcon::effect_key make_gamerule_effect(token_generator& gen, error_handler& err, scenario_building_context& context);
-
 void make_scan_gamerule(token_generator& gen, error_handler& err, scenario_building_context& context);
 
 

--- a/src/parsing/parsers_declarations.cpp
+++ b/src/parsing/parsers_declarations.cpp
@@ -101,7 +101,7 @@ void gamerule_option::on_select(association_type, std::string_view text, error_h
 		on_select_lua_function = text::find_or_add_key(context.state, function_name, false);
 
 	} else {
-		err.accumulated_errors += "Lua function " + function_name + " dosen't exist. Line " + std::to_string(line) + " in gamerules.txt\n";
+		err.accumulated_errors += "Lua function " + function_name + " dosen't exist. (Line " + std::to_string(line) + " in gamerules.txt)\n";
 	}
 }
 
@@ -112,7 +112,7 @@ void gamerule_option::on_deselect(association_type, std::string_view text, error
 
 	}
 	else {
-		err.accumulated_errors += "Lua function " + function_name + " dosen't exist. Line " + std::to_string(line) + " in gamerules.txt\n";
+		err.accumulated_errors += "Lua function " + function_name + " dosen't exist. (Line " + std::to_string(line) + " in gamerules.txt)\n";
 	}
 }
 

--- a/src/parsing/parsers_declarations.cpp
+++ b/src/parsing/parsers_declarations.cpp
@@ -82,7 +82,7 @@ void gamerule_option::name(association_type, std::string_view text, error_handle
 	defined_name = text;
 	auto gamerule_opt_it = context.map_of_gamerule_options.find(std::string(text));
 	if(gamerule_opt_it == context.map_of_gamerule_options.end()) {
-		err.accumulated_errors += "Could not find previously declared gamerule option " + std::string(text) + " in map (" + err.file_name + ")" + " line" + std::to_string(line) + ". This shouldn't happen, report this as a bug!\n";
+		err.accumulated_errors += "Could not find previously declared gamerule option " + std::string(text) + " in file (" + err.file_name + ")" + " line" + std::to_string(line) + ". This shouldn't happen, report this as a bug!\n";
 		return;
 	}
 	else {

--- a/src/parsing/parsers_declarations.hpp
+++ b/src/parsing/parsers_declarations.hpp
@@ -513,13 +513,15 @@ struct gamerule_option {
 	uint8_t option_id = 0;
 	dcon::gamerule_id gamerule_id;
 	bool default_option = false;
-	dcon::effect_key on_select;
-	dcon::effect_key on_deselect;
+
+	dcon::text_key on_select_lua_function;
+	dcon::text_key on_deselect_lua_function;
 	std::string_view defined_name;
 
 	void name(association_type, std::string_view text, error_handler& err, int32_t line, scenario_building_context& context);
 	void finish(scenario_building_context& context);
-
+	void on_deselect(association_type, std::string_view text, error_handler& err, int32_t line, scenario_building_context& context);
+	void on_select(association_type, std::string_view text, error_handler& err, int32_t line, scenario_building_context& context);
 
 };
 

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -32,7 +32,6 @@ std::unique_ptr<sys::state> load_testing_scenario_file(sys::network_mode_type mo
 	if(!sys::try_read_scenario_file(*game_state, NATIVE("tests_scenario.bin"))) {
 		std::abort();
 	} else {
-		game_state->on_scenario_load();
 		INFO("Scenario loaded");
 	}
 


### PR DESCRIPTION
 - Adds gamerule for whether commanding puppet units is allowed, also adds another gamerule option for FoW, allowing only the observer tag to not have FoW.
 - Add support for lua scripting for gamerules
 - Fix the bug where it would always play the "ship select" sound when selecting units. Also change the shift-select behavoir slightly when selecting units to work like you would expect in Vic2 (Land units prioitized over naval units when nothing is selected, when land units are selected it will only select other land units and same for naval units).
 - Apply Schombert's fix for the production directive popping up when resizing window.
 - Move lua parsing to the very start of scenario creation, so that script triggers like gamerules can refer to them
 - Create a new folder structure with a "Custom scipts" and "Game scripts" folder, in which it will parse every .lua file in each.
 - When a user has the "Show all saves" option selected, try to load the save even if the checksum mismatches. The user will already have been warned of the possibility of a crash.