### PR TITLE
Technology Headers FIx

### DIFF
--- a/src/gui/gui_element_types.cpp
+++ b/src/gui/gui_element_types.cpp
@@ -2529,6 +2529,7 @@ void line_graph::render(sys::state& state, int32_t x, int32_t y) noexcept {
 }
 
 void simple_text_element_base::set_text(sys::state& state, std::string const& new_text) {
+	text_override = true;  
 	if(base_data.get_element_type() == element_type::button) {
 		if(new_text != cached_text) {
 			cached_text = new_text;
@@ -2587,7 +2588,9 @@ void simple_text_element_base::format_text(sys::state& state) {
 void simple_text_element_base::on_reset_text(sys::state& state) noexcept {
 	if(base_data.get_element_type() == element_type::button) {
 		black_text = text::is_black_from_font_id(base_data.data.button.font_handle);
-		cached_text = text::produce_simple_string(state, base_data.data.button.txt);
+		if(!text_override) { 
+			cached_text = text::produce_simple_string(state, base_data.data.button.txt);
+		}
 		{
 			internal_layout.contents.clear();
 			internal_layout.number_of_lines = 0;
@@ -2601,7 +2604,9 @@ void simple_text_element_base::on_reset_text(sys::state& state) noexcept {
 		format_text(state);
 	} else if(base_data.get_element_type() == element_type::text) {
 		black_text = text::is_black_from_font_id(base_data.data.text.font_handle);
-		cached_text = text::produce_simple_string(state, base_data.data.text.txt);
+		if(!text_override) { 
+			cached_text = text::produce_simple_string(state, base_data.data.text.txt);
+		}
 		{
 			internal_layout.contents.clear();
 			internal_layout.number_of_lines = 0;

--- a/src/gui/gui_element_types.hpp
+++ b/src/gui/gui_element_types.hpp
@@ -248,6 +248,7 @@ class simple_text_element_base : public element_base {
 protected:
 	std::string cached_text;
 	text::layout internal_layout;
+	bool text_override = false;  
 public:
 	bool black_text = true;
 


### PR DESCRIPTION
When switching to and from classic fonts, some text breaks which is usually fixed by just switching back to the original font you started with, but the headers in the technology tab get stuck as folder category. 

<img width="995" height="153" alt="Screenshot 2026-05-03 143052" src="https://github.com/user-attachments/assets/8b7f0831-0441-4a00-a265-4d1b0f1d4ed9" />

This PR just makes it so that the headers keep the proper name when switching to and from classic fonts.
